### PR TITLE
11528 cancel request to to events list when prev request not needed anymore

### DIFF
--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
@@ -97,13 +97,6 @@ export function EventsListPanel({
     };
   }, []);
 
-  useEffect(() => {
-    if (!eventsList?.length && !loading) disable(EVENT_LIST_CONTROL_ID);
-    else if (!wasClosed && !isMobile) {
-      enable(EVENT_LIST_CONTROL_ID);
-    }
-  }, [eventsList, loading]);
-
   return (
     <Panel
       header={<Text type="heading-l">{i18n.t('Disasters')}</Text>}

--- a/src/utils/atoms/createResourceAtom.ts
+++ b/src/utils/atoms/createResourceAtom.ts
@@ -1,4 +1,5 @@
 import { isObject } from '@reatom/core';
+import { memo } from '@reatom/core/experiments/memo';
 import { createAtom } from '~utils/atoms/createPrimitives';
 import { isApiError } from '~core/api_client/apiClientError';
 import type { Atom, AtomSelfBinded, Action } from '@reatom/core';
@@ -173,11 +174,12 @@ function createResourceFetcherAtom<P, T>(
 
       // Significant reduce renders count
       // Replace it with memo decorator if it cause of bugs
-      return state.loading === true && newState.loading === true
-        ? state
-        : newState;
+      return newState;
     },
-    name,
+    {
+      id: name,
+      decorators: [memo()],
+    },
   );
 }
 


### PR DESCRIPTION
feat(eventList): 11528 cancel event list request, in not needed anymore
also fixes for loading state of event pannel
BREAKING CHANGE: in createResourceAtom fabric - canceled state now not remove loading state from component.
Heuristic about "with not need updates while resource loading" replaced with memo decorator,
because we need to know when request canceled for process inherit loading state for layers (enabled layers feature)
