### PR TITLE
feat(bivariate-color-manager): 11535 - fix sorting of sublist items.

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "sinon": "^12.0.1",
     "stylelint": "^14.1.0",
     "stylelint-config-recommended": "^6.0.0",
-    "stylelint-config-standard": "^24.0.0",
     "ts-json-schema-generator": "^1.0.0",
     "typescript": "4.3.5",
     "vite": "^2.6.14",

--- a/src/features/bivariate_color_manager/components/SentimentsCombinationsList/CombinationsSublist.tsx
+++ b/src/features/bivariate_color_manager/components/SentimentsCombinationsList/CombinationsSublist.tsx
@@ -21,7 +21,10 @@ type SentimentsCombinationsListProps = {
   layersSelection: BivariateColorManagerAtomState['layersSelection'];
 };
 
-const sortDescendingByQuality = sortByKey<TableDataValue>('quality', 'desc');
+const sortDescendingByQuality = sortByKey<TableDataValue>(
+  'correlationLevel',
+  'desc',
+);
 
 type SublistProps = {
   open: boolean;


### PR DESCRIPTION
Now we collect avgCorrelationY by yQuotientIndicator.name and use it for sorting sublist items. Before we just used avgCorrelationY for both X and Y sublist items.

before
![image](https://user-images.githubusercontent.com/20676525/183926959-4339c77c-d3c2-4fa9-8a1f-87087dcd34de.png)

now after fix
![image](https://user-images.githubusercontent.com/20676525/183927068-8e0668f5-e01a-4903-8d39-7eff4fbf39c2.png)
