### PR TITLE
add(layers_panel): 11563 - control exceptions for layers panel

### DIFF
--- a/src/features/layers_panel/components/Layer/Layer.tsx
+++ b/src/features/layers_panel/components/Layer/Layer.tsx
@@ -36,7 +36,9 @@ export function Layer({
     [layerState.isMounted],
   );
 
-  const controlElements = useControlElements(layerState, layerActions);
+  const controlElements = useControlElements(layerState, layerActions, {
+    skipVisibilityControl: true,
+  });
   useEffect(() => {
     if (!delegateLegendRender) return;
     if (layerState.isEnabled && layerState.legend?.type === 'bivariate') {

--- a/src/features/layers_panel/components/Layer/useControlElements.tsx
+++ b/src/features/layers_panel/components/Layer/useControlElements.tsx
@@ -13,12 +13,18 @@ export function useControlElements(
     show: () => void;
     download: () => void;
   },
+  skipControls?: {
+    skipVisibilityControl?: true;
+    skipDownloadControl?: true;
+    skipContextMenu?: true;
+    skipLayerInfo?: true;
+  },
 ) {
   const [controlElements, setControlElements] = useState<JSX.Element[]>([]);
 
   useEffect(() => {
     const elements: JSX.Element[] = [];
-    if (layerState.isMounted)
+    if (layerState.isMounted && !skipControls?.skipVisibilityControl)
       elements.push(
         <LayerHideControl
           key={layerState.id + 'hide'}
@@ -27,7 +33,11 @@ export function useControlElements(
           unhideLayer={layerActions.show}
         />,
       );
-    if (layerState.isMounted && layerState.isDownloadable)
+    if (
+      layerState.isMounted &&
+      layerState.isDownloadable &&
+      !skipControls?.skipDownloadControl
+    )
       elements.push(
         <DownloadControl
           key={layerState.id + 'download'}
@@ -35,7 +45,7 @@ export function useControlElements(
         />,
       );
 
-    if (layerState?.contextMenu)
+    if (layerState?.contextMenu && !skipControls?.skipContextMenu)
       elements.push(
         <LayerContextMenu
           contextMenu={layerState.contextMenu}
@@ -43,7 +53,7 @@ export function useControlElements(
         />,
       );
 
-    if (layerState.meta) {
+    if (layerState.meta && !skipControls?.skipLayerInfo) {
       elements.push(
         <LayerInfo
           key={layerState.id}
@@ -54,7 +64,7 @@ export function useControlElements(
     }
 
     setControlElements(elements);
-  }, [layerState, layerActions]);
+  }, [layerState, layerActions, skipControls]);
 
   return controlElements;
 }


### PR DESCRIPTION
Visibility controls are now exist within Legend Panel only and removed from Layers Panel accorging to task 11563
![image](https://user-images.githubusercontent.com/50058726/184116516-22aee61c-0247-4c18-9a8c-90d8dca9e13e.png)
