### PR TITLE
feat(bivariate-color-manager) 11506 - fix maps count calculation

### DIFF
--- a/src/features/bivariate_color_manager/atoms/bivariateColorManagerResource.ts
+++ b/src/features/bivariate_color_manager/atoms/bivariateColorManagerResource.ts
@@ -40,8 +40,12 @@ export type BivariateColorManagerData = {
 type IndicatorsMap = { [key: string]: Indicator };
 export type NumeratorCorellationMap = { [key: string]: number | undefined };
 
-type AxisNominatorQualityMap = {
-  [numerator: string]: [denominator: string, quality: number];
+type AxisNominatorInfo = {
+  [numerator: string]: {
+    mostQualityDenominator: string;
+    quality: number;
+    layersCount: number;
+  };
 };
 
 const abortControllers: AbortController[] = [];
@@ -112,39 +116,47 @@ export const bivariateColorManagerResourceAtom = createResourceAtom(
         return acc;
       }, {});
 
-      const axisNominatorQualityMap = axis.reduce<AxisNominatorQualityMap>(
-        (acc, axis) => {
-          if (!axis.quality) return acc;
+      const axisNominatorInfo = axis.reduce<AxisNominatorInfo>((acc, axis) => {
+        if (!axis.quality || axis.quality < 0.5) return acc; // we don't need low quality axises
 
-          const [numerator, denominator] = axis.quotient;
-          if (!acc[numerator]) {
-            acc[numerator] = [denominator, axis.quality];
-          } else {
-            const prevAxisQualityByNumerator = acc[numerator][1];
-            if (prevAxisQualityByNumerator < axis.quality) {
-              acc[numerator] = [denominator, axis.quality];
-            }
+        const [numerator, denominator] = axis.quotient;
+        if (!acc[numerator]) {
+          acc[numerator] = {
+            mostQualityDenominator: denominator,
+            quality: axis.quality,
+            layersCount: 1,
+          };
+        } else {
+          acc[numerator].layersCount++;
+
+          const prevAxisQualityByNumerator = acc[numerator].quality;
+          if (prevAxisQualityByNumerator < axis.quality) {
+            acc[numerator] = {
+              ...acc[numerator],
+              mostQualityDenominator: denominator,
+              quality: axis.quality,
+            };
           }
-          return acc;
-        },
-        {},
-      );
+        }
+        return acc;
+      }, {});
 
       const getMostQualityDenominatorForNumenator = (
         numenator: string,
-      ): string | undefined => axisNominatorQualityMap?.[numenator]?.[0];
+      ): string | undefined =>
+        axisNominatorInfo?.[numenator]?.mostQualityDenominator;
 
       const numeratorCorellationMap: NumeratorCorellationMap = {};
 
       const bivariateColorManagerData =
         correlationRates.reduce<BivariateColorManagerData>(
           (acc, correlationRate) => {
-            const xQuotientNumerator = correlationRate.x.quotient[0];
-            const yQuotientNumerator = correlationRate.y.quotient[0];
+            const [xNumerator, xDenominator] = correlationRate.x.quotient;
+            const [yNumerator, yDenominator] = correlationRate.y.quotient;
 
             // x - for vertical, y - for horizontal
-            const xQuotientIndicator = indicatorsMap[xQuotientNumerator];
-            const yQuotientIndicator = indicatorsMap[yQuotientNumerator];
+            const xQuotientIndicator = indicatorsMap[xNumerator];
+            const yQuotientIndicator = indicatorsMap[yNumerator];
 
             // fill numeratorCorellationMap with correllation by layer for sorting sublists
             // avgCorrelationY is by Y, so we associate it with yQuotientIndicator
@@ -155,11 +167,6 @@ export const bivariateColorManagerResourceAtom = createResourceAtom(
               vertical: xQuotientIndicator.direction,
               horizontal: yQuotientIndicator.direction,
             });
-
-            const xNumerator = correlationRate.x.quotient[0];
-            const xDenominator = correlationRate.x.quotient[1];
-            const yNumerator = correlationRate.y.quotient[0];
-            const yDenominator = correlationRate.y.quotient[1];
 
             if (!acc[key]) {
               const colorThemeAndBivariateStyle =
@@ -196,8 +203,6 @@ export const bivariateColorManagerResourceAtom = createResourceAtom(
               }
             }
 
-            acc[key].maps++;
-
             if (!acc[key].vertical[xQuotientIndicator.name]) {
               const mostQualityDenominator =
                 getMostQualityDenominatorForNumenator(xQuotientIndicator.name);
@@ -223,9 +228,10 @@ export const bivariateColorManagerResourceAtom = createResourceAtom(
           {},
         );
 
-      fillLayersWithCorrelationLevel(
+      fillLayersWithCorrelationLevelAndMaps(
         bivariateColorManagerData,
         numeratorCorellationMap,
+        axisNominatorInfo,
       );
 
       const sortedIndicators = indicators
@@ -254,15 +260,24 @@ export const bivariateColorManagerResourceAtom = createResourceAtom(
   true,
 );
 
-const fillLayersWithCorrelationLevel = (
+const fillLayersWithCorrelationLevelAndMaps = (
   bivariateColorManagerData: BivariateColorManagerData,
   numeratorCorellationMap: NumeratorCorellationMap,
+  axisNominatorInfo: AxisNominatorInfo,
 ): void => {
   Object.values(bivariateColorManagerData).forEach((row) => {
-    [...Object.values(row.horizontal), ...Object.values(row.vertical)].forEach(
-      (layer) => {
-        layer.correlationLevel = numeratorCorellationMap[layer.name] || 0;
-      },
-    );
+    let horizontalLayersSum = 0;
+    let verticalLayersSum = 0;
+
+    Object.values(row.horizontal).forEach((layer) => {
+      layer.correlationLevel = numeratorCorellationMap[layer.name] || 0;
+      horizontalLayersSum += axisNominatorInfo[layer.name].layersCount;
+    });
+    Object.values(row.vertical).forEach((layer) => {
+      layer.correlationLevel = numeratorCorellationMap[layer.name] || 0;
+      verticalLayersSum += axisNominatorInfo[layer.name].layersCount;
+    });
+
+    row.maps = horizontalLayersSum * verticalLayersSum;
   });
 };

--- a/src/features/bivariate_color_manager/atoms/bivariateColorManagerResource.ts
+++ b/src/features/bivariate_color_manager/atoms/bivariateColorManagerResource.ts
@@ -253,3 +253,16 @@ export const bivariateColorManagerResourceAtom = createResourceAtom(
   null,
   true,
 );
+
+const fillLayersWithCorrelationLevel = (
+  bivariateColorManagerData: BivariateColorManagerData,
+  numeratorCorellationMap: NumeratorCorellationMap,
+): void => {
+  Object.values(bivariateColorManagerData).forEach((row) => {
+    [...Object.values(row.horizontal), ...Object.values(row.vertical)].forEach(
+      (layer) => {
+        layer.correlationLevel = numeratorCorellationMap[layer.name] || 0;
+      },
+    );
+  });
+};


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/The-number-of-Maps-should-be-considered-as-a-multiplication-of-maps-on-the-two-axes-11506
before
<img width="817" alt="Screenshot 2022-08-11 at 16 40 46" src="https://user-images.githubusercontent.com/20676525/184147038-0a6713a5-96b9-43a5-a2dc-52f643ca8caf.png">
after
<img width="858" alt="Screenshot 2022-08-11 at 16 41 31" src="https://user-images.githubusercontent.com/20676525/184147281-4838fa91-6aa5-40c6-af69-70a2efc73c3b.png">

