### PR TITLE
fix(url_store): 11636 - link with map coordinates doesn't initiate autoselect

### DIFF
--- a/src/core/shared_state/currentEvent.ts
+++ b/src/core/shared_state/currentEvent.ts
@@ -10,8 +10,8 @@ export type CurrentEventAtomState = {
 
 export const currentEventAtom = createAtom(
   {
-    setCurrentEventId: (eventId: string | null) => eventId,
-    resetCurrentEvent: () => null,
+    setCurrentEventId: (eventId: string) => eventId,
+    deselectCurrentEvent: () => null,
     focusedGeometryAtom,
   },
   ({ onAction, onChange }, state: CurrentEventAtomState = null) => {
@@ -25,7 +25,8 @@ export const currentEventAtom = createAtom(
     });
 
     onAction('setCurrentEventId', (eventId) => (state = { id: eventId }));
-    onAction('resetCurrentEvent', () => (state = null));
+    onAction('deselectCurrentEvent', () => (state = { id: null }));
+
     return state;
   },
   '[Shared state] currentEventAtom',

--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -83,8 +83,11 @@ export const urlStoreAtom = createAtom(
 
       const initActions: Action[] = [];
       if (state.event === undefined) {
-        // Auto select event from event list when url not contain that
-        initActions.push(scheduledAutoSelect.setTrue());
+        // if link was shared with map coords without event - mark event was deselected intentionally
+        if (state.map)
+          initActions.push(currentEventAtom.deselectCurrentEvent());
+        // Or auto select event from event list when url is empty
+        else initActions.push(scheduledAutoSelect.setTrue());
       }
 
       if (state.map === undefined) {

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -11,7 +11,7 @@ export const autoSelectEvent = createAtom(
     eventListResourceAtom,
   },
   ({ getUnlistedState, schedule, onChange }, state = {}) => {
-    onChange('eventListResourceAtom', (eventListResource) => {
+    onChange('eventListResourceAtom', (eventListResource, prevRes) => {
       const autoSelectWasScheduled = getUnlistedState(scheduledAutoSelect);
       if (
         autoSelectWasScheduled &&
@@ -22,11 +22,12 @@ export const autoSelectEvent = createAtom(
         eventListResource.data.length
       ) {
         const currentEvent = getUnlistedState(currentEventAtom);
+        const eventWasDeselected = currentEvent?.id === null;
         const currentEventNotInNewList =
           eventListResource.data.findIndex(
             (e) => e.eventId === currentEvent?.id,
           ) === -1;
-        if (currentEventNotInNewList) {
+        if (currentEventNotInNewList && !eventWasDeselected) {
           const firstEventInList = eventListResource.data[0];
           schedule((dispatch) => {
             dispatch([

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -11,7 +11,7 @@ export const autoSelectEvent = createAtom(
     eventListResourceAtom,
   },
   ({ getUnlistedState, schedule, onChange }, state = {}) => {
-    onChange('eventListResourceAtom', (eventListResource, prevRes) => {
+    onChange('eventListResourceAtom', (eventListResource) => {
       const autoSelectWasScheduled = getUnlistedState(scheduledAutoSelect);
       if (
         autoSelectWasScheduled &&


### PR DESCRIPTION
No events popping on when link with map coordinates without event id was applied
![image](https://user-images.githubusercontent.com/50058726/184312772-7af7bbad-9127-4614-83a7-0685d0181ec5.png)
