### PR TITLE
fix(core - logical_layers): 11657 - wait for map readiness in more reliable manner

### DIFF
--- a/src/core/logical_layers/renderers/BivariateRenderer.ts
+++ b/src/core/logical_layers/renderers/BivariateRenderer.ts
@@ -6,7 +6,7 @@ import {
 } from '~core/logical_layers/constants';
 import { layerByOrder } from '~utils/map/layersOrder';
 import { adaptTileUrl } from '~utils/bivariate/tile/adaptTileUrl';
-import { waitMapEvent } from '~utils/map/waitMapEvent';
+import { mapLoaded } from '~utils/map/waitMapEvent';
 import type { ApplicationMap } from '~components/ConnectedMap/ConnectedMap';
 import type { AnyLayer, RasterSource, VectorSource } from 'maplibre-gl';
 import type { BivariateLegend } from '~core/logical_layers/types/legends';
@@ -45,7 +45,7 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     }
   }
 
-  mountBivariateLayer(
+  async mountBivariateLayer(
     map: ApplicationMap,
     layer: LayerTileSource,
     legend: BivariateLegend | null,
@@ -59,6 +59,8 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     };
     // I expect that all servers provide url with same scheme
     this._setTileScheme(layer.source.urls[0], mapSource);
+
+    await mapLoaded(map);
     if (map.getSource(this._sourceId) === undefined) {
       map.addSource(this._sourceId, mapSource);
     }
@@ -106,16 +108,8 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     }
   }
 
-  async willMount({
-    map,
-    state,
-  }: {
-    map: ApplicationMap;
-    state: LogicalLayerState;
-  }) {
+  willMount({ map, state }: { map: ApplicationMap; state: LogicalLayerState }) {
     if (state.source) {
-      // this case happens after userprofile change resets most of the app
-      !map.loaded() && (await waitMapEvent(map, 'load'));
       this._updateMap(
         map,
         state.source as LayerTileSource,

--- a/src/core/logical_layers/renderers/GenericRenderer.ts
+++ b/src/core/logical_layers/renderers/GenericRenderer.ts
@@ -12,7 +12,7 @@ import { registerMapListener } from '~core/shared_state/mapListeners';
 import { LogicalLayerDefaultRenderer } from '~core/logical_layers/renderers/DefaultRenderer';
 import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
 import { layerByOrder } from '~utils/map/layersOrder';
-import { waitMapEvent } from '~utils/map/waitMapEvent';
+import { mapLoaded } from '~utils/map/waitMapEvent';
 import { replaceUrlWithProxy } from '~utils/axios/replaceUrlWithProxy';
 import {
   addZoomFilter,
@@ -258,13 +258,15 @@ export class GenericRenderer extends LogicalLayerDefaultRenderer {
   isGeoJSONLayer = (layer: LayerSource): layer is LayerGeoJSONSource =>
     layer.source.type === 'geojson';
 
-  private _updateMap(
+  private async _updateMap(
     map: ApplicationMap,
     layerData: LayerSource,
     legend: LayerLegend | null,
     isVisible: boolean,
   ) {
     if (layerData == null) return;
+    await mapLoaded(map);
+
     if (this.isGeoJSONLayer(layerData)) {
       this.mountGeoJSONLayer(map, layerData, legend);
     } else {
@@ -386,16 +388,8 @@ export class GenericRenderer extends LogicalLayerDefaultRenderer {
     }
   }
 
-  async willMount({
-    map,
-    state,
-  }: {
-    map: ApplicationMap;
-    state: LogicalLayerState;
-  }) {
+  willMount({ map, state }: { map: ApplicationMap; state: LogicalLayerState }) {
     if (state.source) {
-      // this case happens after userprofile change resets most of the app
-      !map.loaded() && (await waitMapEvent(map, 'load'));
       this._updateMap(map, state.source, state.legend, state.isVisible);
     }
   }

--- a/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
+++ b/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
@@ -1,5 +1,5 @@
 import { LogicalLayerDefaultRenderer } from '~core/logical_layers/renderers/DefaultRenderer';
-import { waitMapEvent } from '~utils/map/waitMapEvent';
+import { mapLoaded, waitMapEvent } from '~utils/map/waitMapEvent';
 import { loadImageOnMap } from '~utils/map/loadImageOnMap';
 import { layerByOrder } from '~utils/map/layersOrder';
 import Icon from '../icons/marker_black.png';
@@ -90,11 +90,7 @@ export class FocusedGeometryRenderer extends LogicalLayerDefaultRenderer {
   }
 
   async setupIcon(map: ApplicationMap, id: string, url: string) {
-    // @ts-expect-error
-    // it seems to me that map._loaded represents current map state which is needed,
-    // whereas map.loaded() or map.isStyleLoaded() check allows
-    // to set a callback on map.on('load') method, that will never run
-    !map._loaded && (await waitMapEvent(map, 'load'));
+    await mapLoaded(map);
     const image = await loadImageOnMap(map, url);
     map.addImage(id, image);
     this.availableIcons.add(id);
@@ -118,9 +114,7 @@ export class FocusedGeometryRenderer extends LogicalLayerDefaultRenderer {
   }) {
     // TODO address this logic in task 9295
 
-    // @ts-expect-error
-    // see comment on top
-    !map._loaded && (await waitMapEvent(map, 'load'));
+    await mapLoaded(map);
 
     const stateSource = state.source?.source ?? null;
 

--- a/src/utils/map/waitMapEvent.ts
+++ b/src/utils/map/waitMapEvent.ts
@@ -13,7 +13,7 @@ export const waitMapEvent = <T extends keyof MapEventType>(
     }
   });
 
-export async function mapLoaded(map: ApplicationMap) {
+export function mapLoaded(map: ApplicationMap) {
   // Use hidden maplibre method for reliability. Explanation - https://github.com/konturio/disaster-ninja-fe/issues/101
   // @ts-expect-error
   if (!map._loaded) {

--- a/src/utils/map/waitMapEvent.ts
+++ b/src/utils/map/waitMapEvent.ts
@@ -5,10 +5,19 @@ export const waitMapEvent = <T extends keyof MapEventType>(
   map: ApplicationMap,
   event: T,
 ) =>
-  new Promise<MapEventType[T] & EventData>((res, rej) => {
+  new Promise<(MapEventType[T] & EventData) | void>((res, rej) => {
     try {
       map.on(event, res);
     } catch (error) {
       rej(error);
     }
   });
+
+export async function mapLoaded(map: ApplicationMap) {
+  // Use hidden maplibre method for reliability. Explanation - https://github.com/konturio/disaster-ninja-fe/issues/101
+  // @ts-expect-error
+  if (!map._loaded) {
+    return waitMapEvent(map, 'load');
+  }
+  return;
+}


### PR DESCRIPTION
Explanation of why i'm using such approach: https://github.com/konturio/disaster-ninja-fe/issues/101

Problem we had:
![image](https://user-images.githubusercontent.com/50058726/184357749-14cf6304-d1eb-4b9c-a159-b74cd764db73.png)
Now works as expected