### PR TITLE
fix(tooltip): 11502 - close tooltip on route change

### DIFF
--- a/src/features/tooltip/Tooltip/Tooltip.tsx
+++ b/src/features/tooltip/Tooltip/Tooltip.tsx
@@ -1,7 +1,8 @@
 import ReactMarkdown from 'react-markdown';
 import clsx from 'clsx';
 import { Close16 } from '@konturio/default-icons';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router';
 import { LinkRenderer } from '~components/LinkRenderer/LinkRenderer';
 import { parseLinksAsTags } from '~utils/markdown/parser';
 import s from './Tooltip.module.css';
@@ -33,6 +34,16 @@ export function Tooltip({
 }) {
   const [position, setPosition] = useState<Position | null>(null);
   const [prevCoords, setPrevCoords] = useState<Coords | null | undefined>(null);
+  const { pathname } = useLocation();
+  const prevPathname = useRef<string>();
+
+  useEffect(() => {
+    if (pathname !== prevPathname.current && properties?.position) {
+      closeTooltip();
+    }
+    prevPathname.current = pathname;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
 
   if (!properties) return null;
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Tooltip-of-the-Color-manager-button-remains-after-panel-opened-11502
![image](https://user-images.githubusercontent.com/20676525/184379443-2181f970-d40b-4d20-8674-92777474f6df.png)
