### PR TITLE
fix(layers_in_area): 11069 - remove global layers /search because we don't have a separate endpoint yet

### DIFF
--- a/src/core/shared_state/currentEvent.ts
+++ b/src/core/shared_state/currentEvent.ts
@@ -32,3 +32,4 @@ export const currentEventAtom = createAtom(
 
 export const scheduledAutoSelect = createBooleanAtom(false);
 export const scheduledAutoFocus = createBooleanAtom(false);
+export const eventWasDeselected = createBooleanAtom(false);

--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -11,6 +11,7 @@ import {
 import {
   scheduledAutoSelect,
   scheduledAutoFocus,
+  eventWasDeselected,
 } from '~core/shared_state/currentEvent';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { URLStore } from '../URLStore';
@@ -113,6 +114,8 @@ export const urlStoreAtom = createAtom(
         // Apply event
         if (state.event) {
           actions.push(currentEventAtom.setCurrentEventId(state.event));
+        } else if (state.map) {
+          actions.push(eventWasDeselected.setTrue());
         }
 
         // Apply feed


### PR DESCRIPTION
While removing the search for global layers i've found out there's no way for us to know if user wants to see map only using link. So i stored this and when the link has map but no events - request for current "global layers" with empty geometry still sent (to at least be able to see bivariate layers)