### PR TITLE
feat(graphql-api): 10835 - switch DN2-FE from insights-api graphql

### DIFF
--- a/configs/config.default.json
+++ b/configs/config.default.json
@@ -1,6 +1,5 @@
 {
   "API_GATEWAY": "https://disaster.ninja/active/api",
-  "GRAPHQL_API": "https://apps.kontur.io/insights-api/graphql",
   "BOUNDARIES_API": "https://api.kontur.io",
   "REPORTS_API": "https://disaster.ninja/active/reports",
   "BIVARIATE_TILES_RELATIVE_URL": "api/tiles/bivariate/v1/",

--- a/src/core/apiClientInstance.ts
+++ b/src/core/apiClientInstance.ts
@@ -29,15 +29,6 @@ ApiClient.init({
   translationService: i18n,
 });
 export const boundariesClient = ApiClient.getInstance('boundaries');
-// initialize graphQl client
-ApiClient.init({
-  instanceId: 'graphql',
-  notificationService: notificationServiceInstance,
-  baseURL: config.graphqlApi,
-  disableAuth: true,
-  translationService: i18n,
-});
-export const graphQlClient = ApiClient.getInstance('graphql');
 // initialize reports client
 ApiClient.init({
   instanceId: 'reports',

--- a/src/core/app_config/index.ts
+++ b/src/core/app_config/index.ts
@@ -1,6 +1,5 @@
 export interface AppConfig {
   API_GATEWAY: string;
-  GRAPHQL_API: string;
   BOUNDARIES_API: string;
   REPORTS_API: string;
   BIVARIATE_TILES_RELATIVE_URL: string;
@@ -32,7 +31,6 @@ declare global {
 
 export default {
   apiGateway: window.konturAppConfig.API_GATEWAY,
-  graphqlApi: window.konturAppConfig.GRAPHQL_API,
   boundariesApi: window.konturAppConfig.BOUNDARIES_API,
   reportsApi: window.konturAppConfig.REPORTS_API,
   bivariateTilesRelativeUrl:

--- a/src/features/bivariate_color_manager/atoms/bivariateColorManagerResource.ts
+++ b/src/features/bivariate_color_manager/atoms/bivariateColorManagerResource.ts
@@ -1,5 +1,5 @@
 import { createResourceAtom } from '~utils/atoms';
-import { graphQlClient } from '~core/apiClientInstance';
+import { apiClient } from '~core/apiClientInstance';
 import { generateColorTheme } from '~utils/bivariate/bivariateColorThemeUtils';
 import { isApiError } from '~core/api_client/apiClientError';
 import { fillBivariateLegend } from '~utils/bivariate/bivariateLegendUtils';
@@ -66,10 +66,10 @@ export const bivariateColorManagerResourceAtom = createResourceAtom(
       abortControllers.push(abortController);
 
       try {
-        responseData = await graphQlClient.post<{
+        responseData = await apiClient.post<{
           data: BivariateStatisticsResponse;
         }>(
-          `/`,
+          '/bivariate_matrix',
           {
             query: createBivariateColorsGraphQLQuery(),
           },

--- a/src/features/bivariate_manager/atoms/bivariateStatisticsResource.ts
+++ b/src/features/bivariate_manager/atoms/bivariateStatisticsResource.ts
@@ -1,5 +1,5 @@
 import { createResourceAtom } from '~utils/atoms';
-import { graphQlClient } from '~core/apiClientInstance';
+import { apiClient } from '~core/apiClientInstance';
 import { focusedGeometryAtom } from '~core/shared_state';
 import {
   createBivariateGraphQLQuery,
@@ -26,11 +26,11 @@ export const bivariateStatisticsResourceAtom = createResourceAtom(
       const abortController = new AbortController();
       abortControllers.push(abortController);
       try {
-        responseData = await graphQlClient.post<{
+        responseData = await apiClient.post<{
           data: BivariateStatisticsResponse;
           errors?: unknown;
         }>(
-          `/`,
+          '/bivariate_matrix',
           {
             query: createBivariateGraphQLQuery(geom),
           },


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Add-DN2-BE-endpoint-to-get-data-for-bivariate-matrix-(instead-of-graphql)-dn-be-10833