### PR TITLE
feat(toolbar): 11731 - style toolbar and fix it's buttons

### DIFF
--- a/src/features/toolbar/components/Toolbar.module.css
+++ b/src/features/toolbar/components/Toolbar.module.css
@@ -1,1 +1,25 @@
-/* styles to be developed */
+/* stylelint-disable */
+.toolbar {
+  display: flex;
+  flex-direction: row;
+  gap: var(--unit);
+
+  & .toolButton {
+    background-color: var(--base-weak);
+    box-shadow: 2px 2px 4px var(--neutral-neutral-50);
+  }
+
+  & .toolButton:hover {
+    color: var(--base-strong);
+    background-color: var(--base-weak);
+  }
+}
+
+.toolButton {
+  color: var(--base-strong-down);
+}
+
+.toolButton:focus {
+  border: 1px solid var(--complimentary-strong);
+}
+/* stylelint-enable */

--- a/src/features/toolbar/components/Toolbar.module.css
+++ b/src/features/toolbar/components/Toolbar.module.css
@@ -6,7 +6,7 @@
 
   & .toolButton {
     background-color: var(--base-weak);
-    box-shadow: 2px 2px 4px var(--neutral-neutral-50);
+    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   }
 
   & .toolButton:hover {

--- a/src/features/toolbar/components/Toolbar.tsx
+++ b/src/features/toolbar/components/Toolbar.tsx
@@ -31,7 +31,7 @@ export function Toolbar() {
   return (
     <div className={s.toolbar}>
       {sortByPredefinedOrder(Object.values(controls), controlsOrder).map((control) => (
-        <div key={nanoid(4)} className={s.sideBarContainer}>
+        <div key={control.id} className={s.sideBarContainer}>
           <div
             className={s.buttonWrap}
             onClick={() => control.onClick && control.onClick(!control.active)}

--- a/src/features/toolbar/components/Toolbar.tsx
+++ b/src/features/toolbar/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import { useAction, useAtom } from '@reatom/react';
-import { ActionsBar, ActionsBarBTN } from '@konturio/ui-kit';
+import { Button } from '@konturio/ui-kit';
 import { nanoid } from 'nanoid';
 import { toolbarControlsAtom } from '~core/shared_state';
 import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
@@ -10,23 +10,26 @@ import s from './Toolbar.module.css';
 // To be developed in next commit
 export function Toolbar() {
   const [controls] = useAtom(toolbarControlsAtom);
-  const setTooltip = useAction(currentTooltipAtom.setCurrentTooltip);
-  const resetTooltip = useAction(currentTooltipAtom.resetCurrentTooltip);
+  // To do soon in #11734
+
+  // const setTooltip = useAction(currentTooltipAtom.setCurrentTooltip);
+  // const resetTooltip = useAction(currentTooltipAtom.resetCurrentTooltip);
 
   function onMouseEnter(e: React.MouseEvent<HTMLDivElement, MouseEvent>, title: string) {
-    setTooltip({
-      popup: title,
-      position: { x: e.clientX + 5, y: e.clientY },
-      hoverBehavior: true,
-    });
+    // To do soon in #11734
+    // setTooltip({
+    //   popup: title,
+    //   position: { x: e.clientX + 5, y: e.clientY },
+    //   hoverBehavior: true,
+    // });
   }
 
   function onMouseLeave() {
-    resetTooltip();
+    // resetTooltip();
   }
 
   return (
-    <ActionsBar>
+    <div className={s.toolbar}>
       {sortByPredefinedOrder(Object.values(controls), controlsOrder).map((control) => (
         <div key={nanoid(4)} className={s.sideBarContainer}>
           <div
@@ -35,10 +38,16 @@ export function Toolbar() {
             onPointerEnter={(e) => onMouseEnter(e, control.title)}
             onPointerLeave={onMouseLeave}
           >
-            <ActionsBarBTN active={control.active} iconBefore={control.icon} />
+            <Button
+              active={control.active}
+              iconBefore={control.icon}
+              size="small"
+              className={s.toolButton}
+              variant="invert"
+            />
           </div>
         </div>
       ))}
-    </ActionsBar>
+    </div>
   );
 }

--- a/src/features/toolbar/constants.ts
+++ b/src/features/toolbar/constants.ts
@@ -1,25 +1,13 @@
 import { BOUNDARY_SELECTOR_CONTROL_ID } from '~features/boundary_selector/constants';
-import { EVENT_LIST_CONTROL_ID } from '~features/events_list/constants';
 import { MAP_RULER_CONTROL_ID } from '~features/map_ruler/constants';
-import { REPORTS_CONTROL_ID } from '~features/reports/constants';
-import {
-  DOWNLOAD_GEOMETRY_CONTROL_ID,
-  FOCUSED_GEOMETRY_EDITOR_CONTROL_ID,
-} from '~core/draw_tools/constants';
+import { FOCUSED_GEOMETRY_EDITOR_CONTROL_ID } from '~core/draw_tools/constants';
 import { GEOMETRY_UPLOADER_CONTROL_ID } from '~features/geometry_uploader/constants';
 import { EDIT_IN_OSM_CONTROL_ID } from '~features/osm_edit_link/constants';
-import { CREATE_LAYER_CONTROL_ID } from '~features/create_layer/constants';
-import { BIVARIATE_COLOR_MANAGER_CONTROL_ID } from '~features/bivariate_color_manager/constants';
 
 export const controlsOrder = [
-  EVENT_LIST_CONTROL_ID,
-  FOCUSED_GEOMETRY_EDITOR_CONTROL_ID,
-  GEOMETRY_UPLOADER_CONTROL_ID,
-  BOUNDARY_SELECTOR_CONTROL_ID,
-  DOWNLOAD_GEOMETRY_CONTROL_ID,
-  MAP_RULER_CONTROL_ID,
   EDIT_IN_OSM_CONTROL_ID,
-  REPORTS_CONTROL_ID,
-  CREATE_LAYER_CONTROL_ID,
-  BIVARIATE_COLOR_MANAGER_CONTROL_ID,
+  MAP_RULER_CONTROL_ID,
+  BOUNDARY_SELECTOR_CONTROL_ID,
+  GEOMETRY_UPLOADER_CONTROL_ID,
+  FOCUSED_GEOMETRY_EDITOR_CONTROL_ID,
 ];

--- a/src/features/toolbar/index.ts
+++ b/src/features/toolbar/index.ts
@@ -1,0 +1,1 @@
+export { Toolbar } from './components/Toolbar';

--- a/src/features/toolbar/readme.md
+++ b/src/features/toolbar/readme.md
@@ -1,3 +1,3 @@
 <h2>Toolbar</h2>
 
-This feature combines registered controls of other features and puts them in predefined order as buttons inside some panel
+This feature combines registered controls of other features and puts them in predefined order as buttons inside panel component

--- a/src/features/toolbar/readme.md
+++ b/src/features/toolbar/readme.md
@@ -1,0 +1,3 @@
+<h2>Toolbar</h2>
+
+This feature combines registered controls of other features and puts them in predefined order as buttons inside some panel

--- a/src/global.css
+++ b/src/global.css
@@ -22,8 +22,7 @@ body,
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 /* ScrollBar */
@@ -61,6 +60,9 @@ code {
 .intercom-lightweight-app-launcher {
   transform: scale(0.8) !important;
 }
+.intercom-lightweight-app-launcher.intercom-launcher {
+  bottom: 28px;
+}
 
 /* handling app header here bacause 
   a) it's global component 
@@ -74,7 +76,7 @@ code {
   }
   .intercom-lightweight-app-launcher.intercom-launcher {
     right: 6px;
-    bottom: 24px;
+    bottom: 36px;
   }
 }
 

--- a/src/views/Main/Main.module.css
+++ b/src/views/Main/Main.module.css
@@ -46,6 +46,13 @@
   bottom: 8px;
 }
 
+.toolbarContainer {
+  position: absolute;
+  bottom: 5%;
+  left: 50%;
+  transform: translate(-50%, 0);
+}
+
 .rightButtonsContainer {
   display: flex;
   flex-direction: column-reverse;

--- a/src/views/Main/Main.tsx
+++ b/src/views/Main/Main.tsx
@@ -5,7 +5,6 @@ import { Row } from '~components/Layout/Layout';
 import { DrawToolsToolbox } from '~core/draw_tools/components/DrawToolsToolbox/DrawToolsToolbox';
 import { AppFeature } from '~core/auth/types';
 import { initBivariateColorManagerIcon } from '~features/bivariate_color_manager';
-import { initReportsIcon } from '~features/reports';
 import s from './Main.module.css';
 import type { UserDataModel } from '~core/auth';
 
@@ -18,9 +17,7 @@ const { EditFeaturesOrLayerPanel } = lazily(
 
 const { Logo } = lazily(() => import('@konturio/ui-kit'));
 
-const { ConnectedMap } = lazily(
-  () => import('~components/ConnectedMap/ConnectedMap'),
-);
+const { ConnectedMap } = lazily(() => import('~components/ConnectedMap/ConnectedMap'));
 
 const { SideBar } = lazily(() => import('~features/side_bar'));
 
@@ -36,9 +33,9 @@ const { Legend } = lazily(() => import('~features/legend_panel'));
 
 const { MapLayersList } = lazily(() => import('~features/layers_panel'));
 
-const { BivariatePanel } = lazily(
-  () => import('~features/bivariate_manager/components'),
-);
+const { Toolbar } = lazily(() => import('~features/toolbar'));
+
+const { BivariatePanel } = lazily(() => import('~features/bivariate_manager/components'));
 
 type MainViewProps = {
   userModel?: UserDataModel | null;
@@ -75,29 +72,24 @@ export function MainView({ userModel }: MainViewProps) {
       );
     }
     if (userModel?.hasFeature(AppFeature.FOCUSED_GEOMETRY_LAYER)) {
-      import('~features/focused_geometry_layer').then(
-        ({ initFocusedGeometryLayer }) => initFocusedGeometryLayer(),
+      import('~features/focused_geometry_layer').then(({ initFocusedGeometryLayer }) =>
+        initFocusedGeometryLayer(),
       );
-    }
-    if (userModel?.hasFeature(AppFeature.REPORTS)) {
-      initReportsIcon(history);
     }
 
     if (userModel?.hasFeature(AppFeature.BIVARIATE_COLOR_MANAGER)) {
       initBivariateColorManagerIcon(history);
     }
     if (userModel?.hasFeature(AppFeature.OSM_EDIT_LINK)) {
-      import('~features/osm_edit_link/').then(({ initOsmEditLink }) =>
-        initOsmEditLink(),
-      );
+      import('~features/osm_edit_link/').then(({ initOsmEditLink }) => initOsmEditLink());
     }
     // TODO add feature flag to replace 'draw_tools' to 'focused_geometry_editor'
     if (
       userModel?.hasFeature(AppFeature.DRAW_TOOLS) ||
       userModel?.hasFeature(AppFeature.FOCUSED_GEOMETRY_EDITOR)
     ) {
-      import('~features/focused_geometry_editor/').then(
-        ({ initFocusedGeometry }) => initFocusedGeometry(),
+      import('~features/focused_geometry_editor/').then(({ initFocusedGeometry }) =>
+        initFocusedGeometry(),
       );
     }
     if (userModel?.hasFeature(AppFeature.CREATE_LAYER)) {
@@ -117,11 +109,10 @@ export function MainView({ userModel }: MainViewProps) {
     <>
       <Row>
         <Suspense fallback={null}>
-          {userModel?.hasFeature(AppFeature.EVENTS_LIST) &&
-            userModel?.feeds && <EventList />}
-          {userModel?.hasFeature(AppFeature.ANALYTICS_PANEL) && (
-            <AnalyticsPanel />
+          {userModel?.hasFeature(AppFeature.EVENTS_LIST) && userModel?.feeds && (
+            <EventList />
           )}
+          {userModel?.hasFeature(AppFeature.ANALYTICS_PANEL) && <AnalyticsPanel />}
           {userModel?.hasFeature(AppFeature.ADVANCED_ANALYTICS_PANEL) && (
             <AdvancedAnalyticsPanel />
           )}
@@ -133,12 +124,12 @@ export function MainView({ userModel }: MainViewProps) {
           <div className={s.logo}>
             <Logo height={24} palette={'contrast'} />
           </div>
+          <div className={s.toolbarContainer}>
+            <Toolbar />
+          </div>
           <Suspense fallback={null}>
             <div className={s.floating}>
-              <div
-                className={s.rightButtonsContainer}
-                ref={iconsContainerRef}
-              ></div>
+              <div className={s.rightButtonsContainer} ref={iconsContainerRef}></div>
               {userModel?.hasFeature(AppFeature.LEGEND_PANEL) && (
                 <Legend iconsContainerRef={iconsContainerRef} />
               )}


### PR DESCRIPTION
Buttons moved from sidebar are now in a new location
![image](https://user-images.githubusercontent.com/50058726/186910242-c690a2f4-ae1f-46d2-931b-a561dbcb4421.png)
Later events panel icon will be moved from this new set of buttons. Also new tooltip selection will be dev'ed later

Also i didn't like stylelint suggestions for my .css. May be we should skip `no-descending-specificity` rule?