### PR TITLE
feat(toolbar & sidebar): 11734 - create tooltips for toolbar and change them for sidebar

### DIFF
--- a/src/core/modes/MapMode.tsx
+++ b/src/core/modes/MapMode.tsx
@@ -1,10 +1,12 @@
 import { Map24 } from '@konturio/default-icons';
+import { i18n } from '~core/localization';
 import { currentModeAtom } from './currentMode';
 import type { ModesControlsAtom } from './modesControls';
 
 export function registerMapMode(modesControlAtom: ModesControlsAtom) {
   modesControlAtom.addControl.dispatch({
     id: 'map',
+    title: i18n.t('modes.map'),
     active: false,
     icon: <Map24 />,
     onClick() {

--- a/src/core/modes/ReportsMode.tsx
+++ b/src/core/modes/ReportsMode.tsx
@@ -1,10 +1,12 @@
 import { BookOpen24 } from '@konturio/default-icons';
+import { i18n } from '~core/localization';
 import { currentModeAtom } from './currentMode';
 import type { ModesControlsAtom } from './modesControls';
 
 export function registerReportsMode(modesControlAtom: ModesControlsAtom) {
   modesControlAtom.addControl.dispatch({
     id: 'reports',
+    title: i18n.t('modes.reports'),
     active: false,
     icon: <BookOpen24 />,
     onClick() {

--- a/src/core/modes/modesControls.tsx
+++ b/src/core/modes/modesControls.tsx
@@ -4,6 +4,7 @@ import type { ApplicationMode } from './currentMode';
 
 export interface ModeControl {
   id: ApplicationMode;
+  title: string;
   icon: JSX.Element;
   active: boolean;
   onClick: () => void;

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
@@ -58,7 +58,7 @@ export function EventsListPanel({
       id: EVENT_LIST_CONTROL_ID,
       name: EVENT_LIST_CONTROL_NAME,
       title: i18n.t('event_list.title'),
-      active: false,
+      active: true,
       visualGroup: controlVisualGroup.withAnalytics,
       icon: <Disasters24 />,
       onClick: (becomesActive) => {

--- a/src/features/legend_panel/components/LegendPanel/LegendPanel.tsx
+++ b/src/features/legend_panel/components/LegendPanel/LegendPanel.tsx
@@ -20,7 +20,7 @@ interface LegendPanelProps {
 export function LegendPanel({ layers, iconsContainerRef }: LegendPanelProps) {
   // isOpen - is an overall state of panel. Was closed stores wether the panel was closed by user -> preferred to be closed
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [wasClosed, setWasClosed] = useState<boolean>(false);
+  const [wasClosed, setWasClosed] = useState<boolean>(true);
 
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
   const turnOffTooltip = useAction(currentTooltipAtom.turnOffById);

--- a/src/features/reports/components/ReportsList/ReportsList.tsx
+++ b/src/features/reports/components/ReportsList/ReportsList.tsx
@@ -20,22 +20,13 @@ export function ReportsList() {
     (async function () {
       if (!reports.length) getReports();
     })();
-  }, []);
+  }, [reports.length, getReports]);
 
   return (
     <div className={styles.mainWrap}>
       <div className={styles.titleRow}>
         <Text type="heading-l">
           <span className={styles.pageTitle}>{i18n.t('reports.title')}</span>
-        </Text>
-        <Text type="heading-l">
-          <Link
-            to={config.baseUrl}
-            className={clsx(styles.linkToMain, styles.link)}
-          >
-            disaster.ninja
-            <img src={arrowIcon} />
-          </Link>
         </Text>
       </div>
 
@@ -48,10 +39,9 @@ export function ReportsList() {
             >
               Kontur{' '}
             </a>{' '}
-            generates several reports that help validate OpenStreetMap quality.
-            They have links to OpenStreetMap objects on osm.org as well as links
-            to OpenStreetMap remote control so that you can use them within the
-            JOSM editor.
+            generates several reports that help validate OpenStreetMap quality. They have
+            links to OpenStreetMap objects on osm.org as well as links to OpenStreetMap
+            remote control so that you can use them within the JOSM editor.
           </Trans>
         </div>
       </Text>
@@ -64,11 +54,7 @@ export function ReportsList() {
               history.push(config.baseUrl + 'reports/' + report.id);
             };
             return (
-              <div
-                className={styles.reportWrap}
-                key={report.id}
-                onClick={goToReport}
-              >
+              <div className={styles.reportWrap} key={report.id} onClick={goToReport}>
                 <Text type="heading-m">
                   <div className={clsx(styles.link, styles.reportTitle)}>
                     {report.name}

--- a/src/features/side_bar/components/SideBar/SideBar.tsx
+++ b/src/features/side_bar/components/SideBar/SideBar.tsx
@@ -19,11 +19,12 @@ export function SideBar() {
   const setTooltip = useAction(currentTooltipAtom.setCurrentTooltip);
   const resetTooltip = useAction(currentTooltipAtom.resetCurrentTooltip);
 
-  function onMouseEnter(e: React.MouseEvent<HTMLDivElement, MouseEvent>, title: string) {
+  function onMouseEnter(target: HTMLDivElement, title: string) {
+    // place tooltip right and vertically aligned to the element
     !isOpen &&
       setTooltip({
         popup: title,
-        position: { x: e.clientX + 5, y: e.clientY },
+        position: { x: target.offsetLeft + 40, y: target.offsetTop },
         hoverBehavior: true,
       });
   }
@@ -55,8 +56,10 @@ export function SideBar() {
             <div
               className={s.buttonWrap}
               onClick={() => control.onClick()}
-              onPointerEnter={(e) => onMouseEnter(e, control.title)}
               onPointerLeave={onMouseLeave}
+              onPointerEnter={(e) =>
+                onMouseEnter(e.target as HTMLDivElement, control.title)
+              }
             >
               <ActionsBarBTN
                 active={control.active}

--- a/src/features/side_bar/components/SideBar/SideBar.tsx
+++ b/src/features/side_bar/components/SideBar/SideBar.tsx
@@ -55,7 +55,7 @@ export function SideBar() {
           >
             <div
               className={s.buttonWrap}
-              onClick={() => control.onClick()}
+              onClick={control.onClick}
               onPointerLeave={onMouseLeave}
               onPointerEnter={(e) =>
                 onMouseEnter(e.target as HTMLDivElement, control.title)

--- a/src/features/side_bar/components/SideBar/SideBar.tsx
+++ b/src/features/side_bar/components/SideBar/SideBar.tsx
@@ -24,7 +24,7 @@ export function SideBar() {
     !isOpen &&
       setTooltip({
         popup: title,
-        position: { x: target.offsetLeft + 40, y: target.offsetTop },
+        position: { x: target.offsetLeft + 50, y: target.offsetTop },
         hoverBehavior: true,
       });
   }

--- a/src/features/side_bar/components/SideBar/SideBar.tsx
+++ b/src/features/side_bar/components/SideBar/SideBar.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from '@reatom/react';
+import { useAction, useAtom } from '@reatom/react';
 import { ActionsBar, ActionsBarBTN } from '@konturio/ui-kit';
 import { nanoid } from 'nanoid';
 import { Link } from 'react-router-dom';
@@ -9,12 +9,28 @@ import { APP_ROUTES } from '~core/app_config/appRoutes';
 import { MODES_LABELS } from '~core/modes/constants';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import { i18n } from '~core/localization';
+import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
 import s from './SideBar.module.css';
 
 export function SideBar() {
   const [controls] = useAtom(modesControlsAtom);
   const [isOpen, setIsOpen] = useState(true);
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
+  const setTooltip = useAction(currentTooltipAtom.setCurrentTooltip);
+  const resetTooltip = useAction(currentTooltipAtom.resetCurrentTooltip);
+
+  function onMouseEnter(e: React.MouseEvent<HTMLDivElement, MouseEvent>, title: string) {
+    !isOpen &&
+      setTooltip({
+        popup: title,
+        position: { x: e.clientX + 5, y: e.clientY },
+        hoverBehavior: true,
+      });
+  }
+
+  function onMouseLeave() {
+    resetTooltip();
+  }
 
   useEffect(() => {
     if (isMobile) {
@@ -36,7 +52,12 @@ export function SideBar() {
             to={APP_ROUTES[control.id]}
             tabIndex={-1}
           >
-            <div className={s.buttonWrap} onClick={() => control.onClick()}>
+            <div
+              className={s.buttonWrap}
+              onClick={() => control.onClick()}
+              onPointerEnter={(e) => onMouseEnter(e, control.title)}
+              onPointerLeave={onMouseLeave}
+            >
               <ActionsBarBTN
                 active={control.active}
                 iconBefore={control.icon}

--- a/src/features/toolbar/components/Toolbar.module.css
+++ b/src/features/toolbar/components/Toolbar.module.css
@@ -36,9 +36,36 @@
   box-shadow: none;
   outline: 0;
 }
+
 .toolbarItem {
   box-shadow: var(--elevation-1);
   border-radius: var(--border-radius);
+  position: relative;
+  align-items: center;
+}
+
+.hoverHint {
+  z-index: -1;
+  opacity: 0;
+  pointer-events: none;
+  transition: 0.3s;
+
+  position: absolute;
+  top: calc(0px - var(--unit));
+  left: 50%;
+  transform: translate(-50%, -100%);
+  background-color: var(--base-strong);
+  border-radius: var(--border-radius);
+  color: var(--neutral-neutral-10);
+  padding: var(--unit);
+  width: max-content;
+}
+
+.toolbarItem:hover .hoverHint {
+  height: unset;
+  z-index: 1;
+  opacity: 1;
+  pointer-events: all;
 }
 
 /* stylelint-enable */

--- a/src/features/toolbar/components/Toolbar.module.css
+++ b/src/features/toolbar/components/Toolbar.module.css
@@ -73,4 +73,8 @@
   .toolbar {
     flex-direction: column;
   }
+
+  .hoverHint {
+    display: none;
+  }
 }

--- a/src/features/toolbar/components/Toolbar.tsx
+++ b/src/features/toolbar/components/Toolbar.tsx
@@ -17,7 +17,7 @@ export function Toolbar() {
           <div key={control.id} className={s.toolbarItem}>
             <div
               className={clsx([s.buttonWrap, control.active && s.active])}
-              onClick={() => control.onClick && control.onClick(!control.active)}
+              onClick={() => control.onClick?.(!control.active)}
             >
               <Button
                 active={control.active}

--- a/src/features/toolbar/components/Toolbar.tsx
+++ b/src/features/toolbar/components/Toolbar.tsx
@@ -1,9 +1,7 @@
-import { useAction, useAtom } from '@reatom/react';
+import { useAtom } from '@reatom/react';
 import { Button } from '@konturio/ui-kit';
-import { nanoid } from 'nanoid';
 import clsx from 'clsx';
 import { toolbarControlsAtom } from '~core/shared_state';
-import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
 import { controlsOrder } from '../constants';
 import { sortByPredefinedOrder } from '../sortByPredefinedOrder';
 import s from './Toolbar.module.css';
@@ -11,23 +9,6 @@ import s from './Toolbar.module.css';
 // To be developed in next commit
 export function Toolbar() {
   const [controls] = useAtom(toolbarControlsAtom);
-  // To do soon in #11734
-
-  // const setTooltip = useAction(currentTooltipAtom.setCurrentTooltip);
-  // const resetTooltip = useAction(currentTooltipAtom.resetCurrentTooltip);
-
-  function onMouseEnter(e: React.MouseEvent<HTMLDivElement, MouseEvent>, title: string) {
-    // To do soon in #11734
-    // setTooltip({
-    //   popup: title,
-    //   position: { x: e.clientX + 5, y: e.clientY },
-    //   hoverBehavior: true,
-    // });
-  }
-
-  function onMouseLeave() {
-    // resetTooltip();
-  }
 
   return (
     <div className={s.toolbar}>
@@ -37,8 +18,6 @@ export function Toolbar() {
             <div
               className={clsx([s.buttonWrap, control.active && s.active])}
               onClick={() => control.onClick && control.onClick(!control.active)}
-              onPointerEnter={(e) => onMouseEnter(e, control.title)}
-              onPointerLeave={onMouseLeave}
             >
               <Button
                 active={control.active}

--- a/src/features/toolbar/components/Toolbar.tsx
+++ b/src/features/toolbar/components/Toolbar.tsx
@@ -31,24 +31,27 @@ export function Toolbar() {
 
   return (
     <div className={s.toolbar}>
-      {sortByPredefinedOrder(Object.values(controls), controlsOrder).map((control) => (
-        <div key={control.id} className={s.toolbarItem}>
-          <div
-            className={clsx([s.buttonWrap, control.active && s.active])}
-            onClick={() => control.onClick && control.onClick(!control.active)}
-            onPointerEnter={(e) => onMouseEnter(e, control.title)}
-            onPointerLeave={onMouseLeave}
-          >
-            <Button
-              active={control.active}
-              iconBefore={control.icon}
-              size="small"
-              className={s.toolButton}
-              variant="invert"
-            />
+      {sortByPredefinedOrder(Object.values(controls), controlsOrder).map(
+        (control, index) => (
+          <div key={control.id} className={s.toolbarItem}>
+            <div
+              className={clsx([s.buttonWrap, control.active && s.active])}
+              onClick={() => control.onClick && control.onClick(!control.active)}
+              onPointerEnter={(e) => onMouseEnter(e, control.title)}
+              onPointerLeave={onMouseLeave}
+            >
+              <Button
+                active={control.active}
+                iconBefore={control.icon}
+                size="small"
+                className={s.toolButton}
+                variant="invert"
+              />
+            </div>
+            <div className={s.hoverHint}>{control.title}</div>
           </div>
-        </div>
-      ))}
+        ),
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Toolbar tooltip on hover (desktop only)
![image](https://user-images.githubusercontent.com/50058726/188106255-b10bce9c-a3ac-4bf0-b573-a249e37fcc76.png)
Collapsed sidebar tooltip on hover (desktop obly, as usual for all hover tooltips)
![image](https://user-images.githubusercontent.com/50058726/188106351-361be378-d037-45a5-9e4b-b075c414dab2.png)
