### PR TITLE
fix(panels): 12116 - add modal view for panels in mobile mode and differ it from collapse state

### DIFF
--- a/src/components/Panel/Wrap/PanelWrap.module.css
+++ b/src/components/Panel/Wrap/PanelWrap.module.css
@@ -1,0 +1,10 @@
+@media screen and (max-width: 960px) {
+  .modalCover,
+  .modalCover * {
+    z-index: var(--modal);
+  }
+  .modalCover > section {
+    top: 44px; /* header offset */
+    left: 0;
+  }
+}

--- a/src/components/Panel/Wrap/PanelWrap.tsx
+++ b/src/components/Panel/Wrap/PanelWrap.tsx
@@ -1,0 +1,41 @@
+import { Modal } from '@konturio/ui-kit';
+import { useEffect } from 'react';
+import {
+  COLLAPSE_PANEL_QUERY,
+  IS_MOBILE_QUERY,
+  useMediaQuery,
+} from '~utils/hooks/useMediaQuery';
+import style from './PanelWrap.module.css';
+
+type PanelWrap = {
+  isPanelOpen: boolean;
+  onPanelClose: () => void;
+  onAutoCollapse?: () => void;
+  restrictAutoCollapsing?: boolean;
+};
+
+export function PanelWrap({
+  isPanelOpen,
+  children,
+  onPanelClose,
+  onAutoCollapse,
+  restrictAutoCollapsing,
+}: React.PropsWithChildren<PanelWrap>): JSX.Element {
+  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
+  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
+
+  useEffect(() => {
+    if (shouldCollapse && !restrictAutoCollapsing) {
+      onPanelClose();
+      onAutoCollapse?.();
+    }
+  }, [shouldCollapse, restrictAutoCollapsing, onPanelClose, onAutoCollapse]);
+
+  if (isPanelOpen && isMobile)
+    return (
+      <Modal onModalCloseCallback={onPanelClose} className={style.modalCover}>
+        {children}
+      </Modal>
+    );
+  return <>{children}</>;
+}

--- a/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.module.css
+++ b/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.module.css
@@ -27,7 +27,7 @@
   }
 }
 
-.sidePanel {
+.panel {
   z-index: 1; /* Show shadow over map */
   position: absolute;
   align-self: flex-start;
@@ -62,4 +62,26 @@
 .header {
   border-bottom: none;
   padding-bottom: 0;
+}
+
+@media screen and (max-width: 960px) {
+  .modalCover,
+  .modalCover * {
+    z-index: var(--modal);
+  }
+  .modalCover > section {
+    top: 44px; /* header offset */
+    left: 0;
+  }
+  .panel {
+    position: absolute;
+    margin: 0;
+    width: 100vw;
+    max-height: unset;
+    height: calc(100vh - 40px);
+    align-items: center;
+  }
+  .panel > div {
+    width: 100%;
+  }
 }

--- a/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.module.css
+++ b/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.module.css
@@ -65,14 +65,6 @@
 }
 
 @media screen and (max-width: 960px) {
-  .modalCover,
-  .modalCover * {
-    z-index: var(--modal);
-  }
-  .modalCover > section {
-    top: 44px; /* header offset */
-    left: 0;
-  }
   .panel {
     position: absolute;
     margin: 0;

--- a/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.module.css
+++ b/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.module.css
@@ -70,7 +70,7 @@
     margin: 0;
     width: 100vw;
     max-height: unset;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     align-items: center;
   }
   .panel > div {

--- a/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.tsx
+++ b/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { AdvancedAnalytics24, Bi24 as BivariatePanelIcon } from '@konturio/default-icons';
 import { i18n } from '~core/localization';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import s from './AdvancedAnalyticsPanel.module.css';
 
 const LazyLoadedAdvancedAnalyticsContainer = lazy(
@@ -18,7 +19,6 @@ const LazyLoadedAdvancedAnalyticsPanelHeader = lazy(
 
 export function AdvancedAnalyticsPanel() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
@@ -28,33 +28,28 @@ export function AdvancedAnalyticsPanel() {
     setIsOpen(true);
   }, [setIsOpen]);
 
-  const panel = (
-    <Panel
-      header={
-        <Text type="heading-m">{i18n.t('advanced_analytics_panel.header_title')}</Text>
-      }
-      onClose={onPanelClose}
-      className={clsx(s.panel, isOpen && s.show, !isOpen && s.hide)}
-      classes={{
-        header: s.header,
-      }}
-    >
-      <div className={s.panelBody}>
-        <LazyLoadedAdvancedAnalyticsPanelHeader />
-        <LazyLoadedAdvancedAnalyticsContainer />
-      </div>
-    </Panel>
-  );
-
   return (
     <div className={s.panelContainer}>
-      {isOpen && isMobile ? (
-        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
-          {panel}
-        </Modal>
-      ) : (
-        panel
-      )}
+      <PanelWrap onPanelClose={onPanelClose} isPanelOpen={isOpen}>
+        <Panel
+          header={
+            <Text type="heading-m">
+              {i18n.t('advanced_analytics_panel.header_title')}
+            </Text>
+          }
+          onClose={onPanelClose}
+          className={clsx(s.panel, isOpen && s.show, !isOpen && s.hide)}
+          classes={{
+            header: s.header,
+          }}
+        >
+          <div className={s.panelBody}>
+            <LazyLoadedAdvancedAnalyticsPanelHeader />
+            <LazyLoadedAdvancedAnalyticsContainer />
+          </div>
+        </Panel>
+      </PanelWrap>
+
       <PanelIcon
         clickHandler={onPanelOpen}
         className={clsx(s.panelIcon, isOpen && s.hide, !isOpen && s.show)}

--- a/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.tsx
+++ b/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.tsx
@@ -1,8 +1,9 @@
-import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
 import { lazy, useCallback, useState } from 'react';
 import clsx from 'clsx';
 import { AdvancedAnalytics24, Bi24 as BivariatePanelIcon } from '@konturio/default-icons';
 import { i18n } from '~core/localization';
+import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import s from './AdvancedAnalyticsPanel.module.css';
 
 const LazyLoadedAdvancedAnalyticsContainer = lazy(
@@ -17,6 +18,7 @@ const LazyLoadedAdvancedAnalyticsPanelHeader = lazy(
 
 export function AdvancedAnalyticsPanel() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
@@ -26,26 +28,32 @@ export function AdvancedAnalyticsPanel() {
     setIsOpen(true);
   }, [setIsOpen]);
 
+  const panel = (
+    <Panel
+      header={
+        <Text type="heading-m">{i18n.t('advanced_analytics_panel.header_title')}</Text>
+      }
+      onClose={onPanelClose}
+      className={clsx(s.panel, isOpen && s.show, !isOpen && s.hide)}
+      classes={{
+        header: s.header,
+      }}
+    >
+      <div className={s.panelBody}>
+        <LazyLoadedAdvancedAnalyticsPanelHeader />
+        <LazyLoadedAdvancedAnalyticsContainer />
+      </div>
+    </Panel>
+  );
+
   return (
     <div className={s.panelContainer}>
-      {isOpen && (
-        <Panel
-          header={
-            <Text type="heading-m">
-              {i18n.t('advanced_analytics_panel.header_title')}
-            </Text>
-          }
-          onClose={onPanelClose}
-          className={clsx(s.sidePanel, isOpen && s.show, !isOpen && s.hide)}
-          classes={{
-            header: s.header,
-          }}
-        >
-          <div className={s.panelBody}>
-            <LazyLoadedAdvancedAnalyticsPanelHeader />
-            <LazyLoadedAdvancedAnalyticsContainer />
-          </div>
-        </Panel>
+      {isOpen && isMobile ? (
+        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
+          {panel}
+        </Modal>
+      ) : (
+        panel
       )}
       <PanelIcon
         clickHandler={onPanelOpen}

--- a/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
+++ b/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
@@ -25,7 +25,7 @@
   }
 }
 
-.sidePanel {
+.analyticsPanel {
   /* RESTORE # 11728 */
   /* position: relative;  
 border-radius: var(--border-radius-unit); */
@@ -65,4 +65,24 @@ border-radius: var(--border-radius-unit); */
 .header {
   border-bottom: none;
   padding-bottom: 0;
+}
+
+@media screen and (max-width: 960px) {
+  .modalCover,
+  .modalCover * {
+    z-index: var(--modal);
+  }
+  .modalCover > section {
+    top: 44px; /* header offset */
+    left: 0;
+  }
+  .analyticsPanel {
+    margin: 0;
+    width: 100vw;
+    height: calc(100vh - 40px);
+    align-items: center;
+  }
+  .analyticsPanel > div {
+    width: 100%;
+  }
 }

--- a/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
+++ b/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
@@ -68,14 +68,6 @@ border-radius: var(--border-radius-unit); */
 }
 
 @media screen and (max-width: 960px) {
-  .modalCover,
-  .modalCover * {
-    z-index: var(--modal);
-  }
-  .modalCover > section {
-    top: 44px; /* header offset */
-    left: 0;
-  }
   .analyticsPanel {
     margin: 0;
     width: 100vw;

--- a/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
+++ b/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
@@ -71,7 +71,7 @@ border-radius: var(--border-radius-unit); */
   .analyticsPanel {
     margin: 0;
     width: 100vw;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     align-items: center;
   }
   .analyticsPanel > div {

--- a/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.tsx
+++ b/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.tsx
@@ -1,8 +1,12 @@
-import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
 import { lazy, useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { Analytics24 } from '@konturio/default-icons';
-import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
+import {
+  COLLAPSE_PANEL_QUERY,
+  IS_MOBILE_QUERY,
+  useMediaQuery,
+} from '~utils/hooks/useMediaQuery';
 import { i18n } from '~core/localization';
 import styles from './AnalyticsPanel.module.css';
 
@@ -16,12 +20,13 @@ const LazyLoadedAnalyticsPanelHeader = lazy(
 export function AnalyticsPanel() {
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
+  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
 
   useEffect(() => {
-    if (isMobile) {
+    if (shouldCollapse) {
       setIsOpen(false);
     }
-  }, [isMobile]);
+  }, [shouldCollapse]);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
@@ -31,27 +36,39 @@ export function AnalyticsPanel() {
     setIsOpen(true);
   }, [setIsOpen]);
 
+  const panel = (
+    <Panel
+      header={<Text type="heading-m">{i18n.t('analytics_panel.header_title')}</Text>}
+      onClose={onPanelClose}
+      className={clsx(
+        styles.analyticsPanel,
+        isOpen && styles.show,
+        !isOpen && styles.hide,
+      )}
+      classes={{
+        header: styles.header,
+      }}
+    >
+      <div className={styles.panelBody}>
+        <LazyLoadedAnalyticsPanelHeader />
+        <LazyLoadedAnalyticsContainer />
+      </div>
+    </Panel>
+  );
+
   return (
     <div className={styles.panelContainer}>
-      {isOpen && (
-        <Panel
-          header={<Text type="heading-m">{i18n.t('analytics_panel.header_title')}</Text>}
-          onClose={onPanelClose}
-          className={clsx(
-            styles.sidePanel,
-            isOpen && styles.show,
-            !isOpen && styles.hide,
-          )}
-          classes={{
-            header: styles.header,
-          }}
+      {isOpen && isMobile ? (
+        <Modal
+          onModalCloseCallback={() => setIsOpen(false)}
+          className={styles.modalCover}
         >
-          <div className={styles.panelBody}>
-            <LazyLoadedAnalyticsPanelHeader />
-            <LazyLoadedAnalyticsContainer />
-          </div>
-        </Panel>
+          {panel}
+        </Modal>
+      ) : (
+        panel
       )}
+
       <PanelIcon
         clickHandler={onPanelOpen}
         className={clsx(styles.panelIcon, isOpen && styles.hide, !isOpen && styles.show)}

--- a/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.tsx
+++ b/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.tsx
@@ -1,13 +1,9 @@
-import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
-import { lazy, useCallback, useEffect, useState } from 'react';
+import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { lazy, useCallback, useState } from 'react';
 import clsx from 'clsx';
 import { Analytics24 } from '@konturio/default-icons';
-import {
-  COLLAPSE_PANEL_QUERY,
-  IS_MOBILE_QUERY,
-  useMediaQuery,
-} from '~utils/hooks/useMediaQuery';
 import { i18n } from '~core/localization';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import styles from './AnalyticsPanel.module.css';
 
 const LazyLoadedAnalyticsContainer = lazy(
@@ -19,14 +15,6 @@ const LazyLoadedAnalyticsPanelHeader = lazy(
 
 export function AnalyticsPanel() {
   const [isOpen, setIsOpen] = useState<boolean>(true);
-  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
-  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
-
-  useEffect(() => {
-    if (shouldCollapse) {
-      setIsOpen(false);
-    }
-  }, [shouldCollapse]);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
@@ -36,38 +24,27 @@ export function AnalyticsPanel() {
     setIsOpen(true);
   }, [setIsOpen]);
 
-  const panel = (
-    <Panel
-      header={<Text type="heading-m">{i18n.t('analytics_panel.header_title')}</Text>}
-      onClose={onPanelClose}
-      className={clsx(
-        styles.analyticsPanel,
-        isOpen && styles.show,
-        !isOpen && styles.hide,
-      )}
-      classes={{
-        header: styles.header,
-      }}
-    >
-      <div className={styles.panelBody}>
-        <LazyLoadedAnalyticsPanelHeader />
-        <LazyLoadedAnalyticsContainer />
-      </div>
-    </Panel>
-  );
-
   return (
     <div className={styles.panelContainer}>
-      {isOpen && isMobile ? (
-        <Modal
-          onModalCloseCallback={() => setIsOpen(false)}
-          className={styles.modalCover}
+      <PanelWrap onPanelClose={onPanelClose} isPanelOpen={isOpen}>
+        <Panel
+          header={<Text type="heading-m">{i18n.t('analytics_panel.header_title')}</Text>}
+          onClose={onPanelClose}
+          className={clsx(
+            styles.analyticsPanel,
+            isOpen && styles.show,
+            !isOpen && styles.hide,
+          )}
+          classes={{
+            header: styles.header,
+          }}
         >
-          {panel}
-        </Modal>
-      ) : (
-        panel
-      )}
+          <div className={styles.panelBody}>
+            <LazyLoadedAnalyticsPanelHeader />
+            <LazyLoadedAnalyticsContainer />
+          </div>
+        </Panel>
+      </PanelWrap>
 
       <PanelIcon
         clickHandler={onPanelOpen}

--- a/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.module.css
+++ b/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.module.css
@@ -1,4 +1,4 @@
-.sidePanel {
+.bivariatePanel {
   pointer-events: auto;
   position: relative;
   z-index: 1; /* Show shadow over map */
@@ -48,8 +48,7 @@
   display: flex;
 
   &.show {
-    transition: display 0s linear 0s, visibility 0s linear 0s,
-      opacity 0.33s linear 0s;
+    transition: display 0s linear 0s, visibility 0s linear 0s, opacity 0.33s linear 0s;
     visibility: visible;
     display: flex;
     opacity: 1;
@@ -85,4 +84,29 @@
 
 .iconContainerHidden {
   display: none;
+}
+
+@media screen and (max-width: 960px) {
+  .modalCover,
+  .modalCover * {
+    z-index: var(--modal);
+  }
+  .modalCover > section {
+    top: 44px; /* header offset */
+    left: 0;
+  }
+  .bivariatePanel {
+    position: absolute;
+    margin: 0;
+    width: 100vw;
+    max-height: unset;
+    height: calc(100vh - 40px);
+    align-items: center;
+  }
+  .bivariatePanel > div {
+    width: 100%;
+  }
+  .customCloseBtn {
+    left: 0;
+  }
 }

--- a/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.module.css
+++ b/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.module.css
@@ -87,14 +87,6 @@
 }
 
 @media screen and (max-width: 960px) {
-  .modalCover,
-  .modalCover * {
-    z-index: var(--modal);
-  }
-  .modalCover > section {
-    top: 44px; /* header offset */
-    left: 0;
-  }
   .bivariatePanel {
     position: absolute;
     margin: 0;

--- a/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.module.css
+++ b/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.module.css
@@ -92,7 +92,7 @@
     margin: 0;
     width: 100vw;
     max-height: unset;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     align-items: center;
   }
   .bivariatePanel > div {

--- a/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.tsx
+++ b/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.tsx
@@ -1,9 +1,13 @@
-import { Panel, PanelIcon } from '@konturio/ui-kit';
+import { Modal, Panel, PanelIcon } from '@konturio/ui-kit';
 import { lazy, useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { BivariateMatrix24 } from '@konturio/default-icons';
 import ReactDOM from 'react-dom';
-import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
+import {
+  COLLAPSE_PANEL_QUERY,
+  IS_MOBILE_QUERY,
+  useMediaQuery,
+} from '~utils/hooks/useMediaQuery';
 import { INTERCOM_ELEMENT_ID } from '../../constants';
 import styles from './BivariatePanel.module.css';
 
@@ -30,12 +34,13 @@ export function BivariatePanel({
 }) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
+  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
 
   useEffect(() => {
-    if (isMobile) {
+    if (shouldCollapse) {
       setIsOpen(false);
     }
-  }, [isMobile]);
+  }, [shouldCollapse, setIsOpen]);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
@@ -54,20 +59,34 @@ export function BivariatePanel({
     }
   }, [setIsOpen]);
 
+  const panel = (
+    <Panel
+      onClose={onPanelClose}
+      className={clsx(
+        styles.bivariatePanel,
+        isOpen && styles.show,
+        !isOpen && styles.hide,
+      )}
+      classes={{
+        closeBtn: styles.customCloseBtn,
+      }}
+      customCloseBtn={<CustomClosePanelBtn />}
+    >
+      <div className={styles.panelBody}>
+        {isOpen && <LazyLoadedBivariateMatrixContainer />}
+      </div>
+    </Panel>
+  );
+
   return (
     <>
-      <Panel
-        onClose={onPanelClose}
-        className={clsx(styles.sidePanel, isOpen && styles.show, !isOpen && styles.hide)}
-        classes={{
-          closeBtn: styles.customCloseBtn,
-        }}
-        customCloseBtn={<CustomClosePanelBtn />}
-      >
-        <div className={styles.panelBody}>
-          {isOpen && <LazyLoadedBivariateMatrixContainer />}
-        </div>
-      </Panel>
+      {isOpen && isMobile ? (
+        <Modal onModalCloseCallback={onPanelClose} className={styles.modalCover}>
+          {panel}
+        </Modal>
+      ) : (
+        panel
+      )}
 
       {iconsContainerRef.current &&
         ReactDOM.createPortal(

--- a/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.tsx
+++ b/src/features/bivariate_manager/components/BivariatePanel/BivariatePanel.tsx
@@ -1,13 +1,9 @@
-import { Modal, Panel, PanelIcon } from '@konturio/ui-kit';
-import { lazy, useCallback, useEffect, useState } from 'react';
+import { Panel, PanelIcon } from '@konturio/ui-kit';
+import { lazy, useCallback, useState } from 'react';
 import clsx from 'clsx';
 import { BivariateMatrix24 } from '@konturio/default-icons';
 import ReactDOM from 'react-dom';
-import {
-  COLLAPSE_PANEL_QUERY,
-  IS_MOBILE_QUERY,
-  useMediaQuery,
-} from '~utils/hooks/useMediaQuery';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import { INTERCOM_ELEMENT_ID } from '../../constants';
 import styles from './BivariatePanel.module.css';
 
@@ -33,14 +29,6 @@ export function BivariatePanel({
   iconsContainerRef: React.MutableRefObject<HTMLDivElement | null>;
 }) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
-  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
-
-  useEffect(() => {
-    if (shouldCollapse) {
-      setIsOpen(false);
-    }
-  }, [shouldCollapse, setIsOpen]);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
@@ -59,34 +47,26 @@ export function BivariatePanel({
     }
   }, [setIsOpen]);
 
-  const panel = (
-    <Panel
-      onClose={onPanelClose}
-      className={clsx(
-        styles.bivariatePanel,
-        isOpen && styles.show,
-        !isOpen && styles.hide,
-      )}
-      classes={{
-        closeBtn: styles.customCloseBtn,
-      }}
-      customCloseBtn={<CustomClosePanelBtn />}
-    >
-      <div className={styles.panelBody}>
-        {isOpen && <LazyLoadedBivariateMatrixContainer />}
-      </div>
-    </Panel>
-  );
-
   return (
     <>
-      {isOpen && isMobile ? (
-        <Modal onModalCloseCallback={onPanelClose} className={styles.modalCover}>
-          {panel}
-        </Modal>
-      ) : (
-        panel
-      )}
+      <PanelWrap onPanelClose={onPanelClose} isPanelOpen={isOpen}>
+        <Panel
+          onClose={onPanelClose}
+          className={clsx(
+            styles.bivariatePanel,
+            isOpen && styles.show,
+            !isOpen && styles.hide,
+          )}
+          classes={{
+            closeBtn: styles.customCloseBtn,
+          }}
+          customCloseBtn={<CustomClosePanelBtn />}
+        >
+          <div className={styles.panelBody}>
+            {isOpen && <LazyLoadedBivariateMatrixContainer />}
+          </div>
+        </Panel>
+      </PanelWrap>
 
       {iconsContainerRef.current &&
         ReactDOM.createPortal(

--- a/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.module.css
+++ b/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.module.css
@@ -40,7 +40,7 @@
     position: absolute;
     margin: 0;
     width: 100vw;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     align-items: center;
   }
   .sidePanel > div {

--- a/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.module.css
+++ b/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.module.css
@@ -34,3 +34,16 @@
 .panelBody :first-child {
   margin-top: 0;
 }
+
+@media screen and (max-width: 960px) {
+  .sidePanel {
+    position: absolute;
+    margin: 0;
+    width: 100vw;
+    height: calc(100vh - 40px);
+    align-items: center;
+  }
+  .sidePanel > div {
+    width: 100%;
+  }
+}

--- a/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.tsx
+++ b/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.tsx
@@ -4,6 +4,7 @@ import { useAction, useAtom } from '@reatom/react';
 import { Panel, Text } from '@konturio/ui-kit';
 import { i18n } from '~core/localization';
 import { toolbarControlsAtom } from '~core/shared_state';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import { CREATE_LAYER_CONTROL_ID, EditTargets } from '../../constants';
 import { currentEditedLayerFeatures } from '../../atoms/currentEditedLayerFeatures';
 import { currentSelectedPoint } from '../../atoms/currentSelectedPoint';
@@ -49,24 +50,26 @@ export function EditFeaturesPanel() {
   if (!settings) return null;
 
   return (
-    <Panel
-      header={<Text type="heading-l">{i18n.t('create_layer.edit_features')}</Text>}
-      onClose={onPanelClose}
-      className={clsx(s.sidePanel)}
-    >
-      <div className={s.panelBody}>
-        {selectedFeature?.properties ? (
-          <EditFeatureForm
-            featureProperties={selectedFeature.properties}
-            fieldsSettings={settings}
-            geometry={selectedFeature.geometry}
-            changeProperty={changeProperty}
-            onSave={onSave}
-          />
-        ) : (
-          <EditFeaturePlaceholder />
-        )}
-      </div>
-    </Panel>
+    <PanelWrap onPanelClose={onPanelClose} isPanelOpen={true}>
+      <Panel
+        header={<Text type="heading-l">{i18n.t('create_layer.edit_features')}</Text>}
+        onClose={onPanelClose}
+        className={clsx(s.sidePanel)}
+      >
+        <div className={s.panelBody}>
+          {selectedFeature?.properties ? (
+            <EditFeatureForm
+              featureProperties={selectedFeature.properties}
+              fieldsSettings={settings}
+              geometry={selectedFeature.geometry}
+              changeProperty={changeProperty}
+              onSave={onSave}
+            />
+          ) : (
+            <EditFeaturePlaceholder />
+          )}
+        </div>
+      </Panel>
+    </PanelWrap>
   );
 }

--- a/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.module.css
+++ b/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.module.css
@@ -40,7 +40,7 @@
     position: absolute;
     margin: 0;
     width: 100vw;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     align-items: center;
   }
   .sidePanel > div {

--- a/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.module.css
+++ b/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.module.css
@@ -34,3 +34,16 @@
 .panelBody :first-child {
   margin-top: 0;
 }
+
+@media screen and (max-width: 960px) {
+  .sidePanel {
+    position: absolute;
+    margin: 0;
+    width: 100vw;
+    height: calc(100vh - 40px);
+    align-items: center;
+  }
+  .sidePanel > div {
+    width: 100%;
+  }
+}

--- a/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.tsx
+++ b/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.tsx
@@ -8,6 +8,7 @@ import { createStateMap } from '~utils/atoms';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';
 import { ErrorMessage } from '~components/ErrorMessage/ErrorMessage';
 import { editTargetAtom } from '~features/create_layer/atoms/editTarget';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import { EditLayerForm } from '../../components/EditLayerForm/EditLayerForm';
 import { editableLayerControllerAtom } from '../../atoms/editableLayerController';
 import { CREATE_LAYER_CONTROL_ID, EditTargets } from '../../constants';
@@ -35,31 +36,33 @@ export function EditLayerPanel() {
     : null;
 
   return (
-    <Panel
-      header={<Text type="heading-l">{i18n.t('create_layer.create_layer')}</Text>}
-      onClose={onPanelClose}
-      className={clsx(
-        s.sidePanel,
-        createLayerState && s.show,
-        !createLayerState && s.hide,
-      )}
-    >
-      <div className={s.panelBody}>
-        {statesToComponents &&
-          statesToComponents({
-            loading: <LoadingSpinner message={i18n.t('create_layer.saving_layer')} />,
-            error: (errorMessage) => <ErrorMessage message={errorMessage} />,
-            ready: (data) => {
-              return (
-                <EditLayerForm
-                  data={data as LayerEditorFormAtomType}
-                  onSave={saveLayer}
-                  onCancel={onPanelClose}
-                />
-              );
-            },
-          })}
-      </div>
-    </Panel>
+    <PanelWrap onPanelClose={onPanelClose} isPanelOpen={true}>
+      <Panel
+        header={<Text type="heading-l">{i18n.t('create_layer.create_layer')}</Text>}
+        onClose={onPanelClose}
+        className={clsx(
+          s.sidePanel,
+          createLayerState && s.show,
+          !createLayerState && s.hide,
+        )}
+      >
+        <div className={s.panelBody}>
+          {statesToComponents &&
+            statesToComponents({
+              loading: <LoadingSpinner message={i18n.t('create_layer.saving_layer')} />,
+              error: (errorMessage) => <ErrorMessage message={errorMessage} />,
+              ready: (data) => {
+                return (
+                  <EditLayerForm
+                    data={data as LayerEditorFormAtomType}
+                    onSave={saveLayer}
+                    onCancel={onPanelClose}
+                  />
+                );
+              },
+            })}
+        </div>
+      </Panel>
+    </PanelWrap>
   );
 }

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
@@ -63,7 +63,7 @@
   .eventsPanel {
     position: absolute;
     margin: 0;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     width: 100vw;
     align-items: center;
   }

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
@@ -28,7 +28,7 @@
   padding-bottom: var(--double-unit);
 }
 
-.sidePanel {
+.eventsPanel {
   z-index: 1; /* Show shadow over map */
   position: relative;
   align-self: flex-start;
@@ -51,5 +51,32 @@
     z-index: -1;
     opacity: 0.2;
     left: -150px;
+  }
+}
+
+@media screen and (max-width: 960px) {
+  .modalCover,
+  .modalCover * {
+    z-index: var(--modal);
+  }
+  .modalCover > section {
+    top: 44px; /* header offset */
+    left: 0;
+  }
+  .eventsPanel {
+    position: absolute;
+    margin: 0;
+    height: calc(100vh - 40px);
+    width: 100vw;
+    align-items: center;
+  }
+  .eventsPanel > div {
+    width: 100%;
+  }
+  .panelBody {
+    align-items: center;
+  }
+  .scrollable {
+    width: 100%;
   }
 }

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
@@ -55,14 +55,6 @@
 }
 
 @media screen and (max-width: 960px) {
-  .modalCover,
-  .modalCover * {
-    z-index: var(--modal);
-  }
-  .modalCover > section {
-    top: 44px; /* header offset */
-    left: 0;
-  }
   .eventsPanel {
     position: absolute;
     margin: 0;

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
@@ -1,3 +1,8 @@
+.eventsPanelComponent {
+  display: flex;
+  flex-direction: column;
+}
+
 .panelContainer {
   position: relative;
 }

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
@@ -1,12 +1,16 @@
 import { Virtuoso } from 'react-virtuoso';
-import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { Disasters24 } from '@konturio/default-icons';
 import { useAtom } from '@reatom/react';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';
 import { ErrorMessage } from '~components/ErrorMessage/ErrorMessage';
-import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
+import {
+  COLLAPSE_PANEL_QUERY,
+  IS_MOBILE_QUERY,
+  useMediaQuery,
+} from '~utils/hooks/useMediaQuery';
 import { createStateMap } from '~utils/atoms/createStateMap';
 import { i18n } from '~core/localization';
 import { toolbarControlsAtom } from '~core/shared_state';
@@ -38,16 +42,17 @@ export function EventsListPanel({
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const virtuoso = useRef(null);
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
+  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
   // TEMP files. Remove when #11728 or #11710 will be implemented
   const [wasClosed, setWasClosed] = useState<null | boolean>(null);
   const [, { enable, disable, addControl, toggleActiveState }] =
     useAtom(toolbarControlsAtom);
 
   useEffect(() => {
-    if (isMobile) {
+    if (shouldCollapse) {
       disable(EVENT_LIST_CONTROL_ID);
     }
-  }, [isMobile, disable]);
+  }, [shouldCollapse, disable]);
 
   const onPanelClose = useCallback(() => {
     disable(EVENT_LIST_CONTROL_ID);
@@ -114,15 +119,13 @@ export function EventsListPanel({
     data: eventsList,
   });
 
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <Panel
-        header={isOpen ? <Text type="heading-l">{i18n.t('disasters')}</Text> : undefined}
-        className={clsx(s.sidePanel, isOpen && s.show, !isOpen && s.hide)}
-        onClose={onPanelClose}
-      >
-        {/* RESTORE # 11728 */}
-        {/* <div className={s.panelBody}> */}
+  const panel = (
+    <Panel
+      header={isOpen ? <Text type="heading-l">{i18n.t('disasters')}</Text> : undefined}
+      className={clsx(s.eventsPanel, isOpen && s.show, !isOpen && s.hide)}
+      onClose={onPanelClose}
+    >
+      <div className={s.panelBody}>
         <EventListSettingsRow>
           <FeedSelector />
           <BBoxFilterToggle />
@@ -147,8 +150,19 @@ export function EventsListPanel({
             ),
           })}
         </div>
-        {/* </div> */}
-      </Panel>
+      </div>
+    </Panel>
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {isOpen && isMobile ? (
+        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
+          {panel}
+        </Modal>
+      ) : (
+        panel
+      )}
       {/* RESTORE  #11728 
       <PanelIcon
         clickHandler={onPanelOpen}

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
@@ -1,16 +1,11 @@
 import { Virtuoso } from 'react-virtuoso';
-import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { Panel, Text } from '@konturio/ui-kit';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { Disasters24 } from '@konturio/default-icons';
 import { useAtom } from '@reatom/react';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';
 import { ErrorMessage } from '~components/ErrorMessage/ErrorMessage';
-import {
-  COLLAPSE_PANEL_QUERY,
-  IS_MOBILE_QUERY,
-  useMediaQuery,
-} from '~utils/hooks/useMediaQuery';
 import { createStateMap } from '~utils/atoms/createStateMap';
 import { i18n } from '~core/localization';
 import { toolbarControlsAtom } from '~core/shared_state';
@@ -19,6 +14,7 @@ import {
   EVENT_LIST_CONTROL_NAME,
 } from '~features/events_list/constants';
 import { controlVisualGroup } from '~core/shared_state/toolbarControls';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import { FeedSelector } from '../FeedSelector/FeedSelector';
 import { BBoxFilterToggle } from '../BBoxFilterToggle/BBoxFilterToggle';
 import { EventListSettingsRow } from '../EventListSettingsRow/EventListSettingsRow';
@@ -41,18 +37,10 @@ export function EventsListPanel({
 }) {
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const virtuoso = useRef(null);
-  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
-  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
   // TEMP files. Remove when #11728 or #11710 will be implemented
   const [wasClosed, setWasClosed] = useState<null | boolean>(null);
   const [, { enable, disable, addControl, toggleActiveState }] =
     useAtom(toolbarControlsAtom);
-
-  useEffect(() => {
-    if (shouldCollapse) {
-      disable(EVENT_LIST_CONTROL_ID);
-    }
-  }, [shouldCollapse, disable]);
 
   const onPanelClose = useCallback(() => {
     disable(EVENT_LIST_CONTROL_ID);
@@ -119,50 +107,45 @@ export function EventsListPanel({
     data: eventsList,
   });
 
-  const panel = (
-    <Panel
-      header={isOpen ? <Text type="heading-l">{i18n.t('disasters')}</Text> : undefined}
-      className={clsx(s.eventsPanel, isOpen && s.show, !isOpen && s.hide)}
-      onClose={onPanelClose}
-    >
-      <div className={s.panelBody}>
-        <EventListSettingsRow>
-          <FeedSelector />
-          <BBoxFilterToggle />
-        </EventListSettingsRow>
-        <div className={s.scrollable}>
-          {statesToComponents({
-            loading: <LoadingSpinner message={i18n.t('loading_events')} />,
-            error: (errorMessage) => <ErrorMessage message={errorMessage} />,
-            ready: (eventsList) => (
-              <Virtuoso
-                data={eventsList}
-                itemContent={(index, event) => (
-                  <EventCard
-                    key={event.eventId}
-                    event={event}
-                    isActive={event.eventId === current}
-                    onClick={onCurrentChange}
-                  />
-                )}
-                ref={virtuoso}
-              />
-            ),
-          })}
-        </div>
-      </div>
-    </Panel>
-  );
-
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      {isOpen && isMobile ? (
-        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
-          {panel}
-        </Modal>
-      ) : (
-        panel
-      )}
+      <PanelWrap onPanelClose={onPanelClose} isPanelOpen={isOpen}>
+        <Panel
+          header={
+            isOpen ? <Text type="heading-l">{i18n.t('disasters')}</Text> : undefined
+          }
+          className={clsx(s.eventsPanel, isOpen && s.show, !isOpen && s.hide)}
+          onClose={onPanelClose}
+        >
+          <div className={s.panelBody}>
+            <EventListSettingsRow>
+              <FeedSelector />
+              <BBoxFilterToggle />
+            </EventListSettingsRow>
+            <div className={s.scrollable}>
+              {statesToComponents({
+                loading: <LoadingSpinner message={i18n.t('loading_events')} />,
+                error: (errorMessage) => <ErrorMessage message={errorMessage} />,
+                ready: (eventsList) => (
+                  <Virtuoso
+                    data={eventsList}
+                    itemContent={(index, event) => (
+                      <EventCard
+                        key={event.eventId}
+                        event={event}
+                        isActive={event.eventId === current}
+                        onClick={onCurrentChange}
+                      />
+                    )}
+                    ref={virtuoso}
+                  />
+                ),
+              })}
+            </div>
+          </div>
+        </Panel>
+      </PanelWrap>
+
       {/* RESTORE  #11728 
       <PanelIcon
         clickHandler={onPanelOpen}

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
@@ -108,7 +108,7 @@ export function EventsListPanel({
   });
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <div className={s.eventsPanelComponent}>
       <PanelWrap onPanelClose={onPanelClose} isPanelOpen={isOpen}>
         <Panel
           header={

--- a/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.module.css
+++ b/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.module.css
@@ -71,7 +71,7 @@
     margin: 0;
     width: 100vw;
     max-height: unset;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     align-items: center;
   }
   .panel > div {

--- a/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.module.css
+++ b/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.module.css
@@ -9,20 +9,20 @@
   width: 284px;
 
   &.show {
-     transition: visibility 0s linear 0s, opacity 0.33s linear 0s,
-     margin-right 0.1s linear 0s;
-     visibility: visible;
-     opacity: 1;
-     margin-right: 0;
-   }
+    transition: visibility 0s linear 0s, opacity 0.33s linear 0s,
+      margin-right 0.1s linear 0s;
+    visibility: visible;
+    opacity: 1;
+    margin-right: 0;
+  }
 
   &.hide {
-     transition: visibility 0s linear 0.33s, opacity 0.33s linear 0s,
-     margin-right 0.15s linear 0s;
-     visibility: hidden;
-     opacity: 0;
-     margin-right: -292px;
-   }
+    transition: visibility 0s linear 0.33s, opacity 0.33s linear 0s,
+      margin-right 0.15s linear 0s;
+    visibility: hidden;
+    opacity: 0;
+    margin-right: -292px;
+  }
 }
 
 .header {
@@ -33,19 +33,20 @@
   display: flex;
 
   &.show {
-     transition: display 0s linear 0s, visibility 0s linear 0s, opacity 0.33s linear 0s;
-     visibility: visible;
-     display: flex;
-     opacity: 1;
-   }
+    transition: display 0s linear 0s, visibility 0s linear 0s, opacity 0.33s linear 0s;
+    visibility: visible;
+    display: flex;
+    opacity: 1;
+  }
 
   &.hide {
-     transition: display 0s linear 0.33s, visibility 0s linear 0.33s, opacity 0.33s linear 0s;
-     visibility: hidden;
-     display: none;
-     opacity: 0;
-     width: 0;
-   }
+    transition: display 0s linear 0.33s, visibility 0s linear 0.33s,
+      opacity 0.33s linear 0s;
+    visibility: hidden;
+    display: none;
+    opacity: 0;
+    width: 0;
+  }
 }
 
 .iconContainerShown {
@@ -54,4 +55,29 @@
 
 .iconContainerHidden {
   display: none;
+}
+
+@media screen and (max-width: 960px) {
+  .modalCover,
+  .modalCover * {
+    z-index: var(--modal);
+  }
+  .modalCover > section {
+    top: 44px; /* header offset */
+    left: 0;
+  }
+  .panel {
+    position: absolute;
+    margin: 0;
+    width: 100vw;
+    max-height: unset;
+    height: calc(100vh - 40px);
+    align-items: center;
+  }
+  .panel > div {
+    width: 100%;
+  }
+  .scrollable {
+    width: 100%;
+  }
 }

--- a/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.tsx
+++ b/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.tsx
@@ -1,17 +1,13 @@
-import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
-import { useCallback, useEffect, useState } from 'react';
+import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { useCallback, useState } from 'react';
 import ReactDOM from 'react-dom';
 import clsx from 'clsx';
 import { Layers24 } from '@konturio/default-icons';
 import { useAction } from '@reatom/react';
 import { i18n } from '~core/localization';
-import {
-  COLLAPSE_PANEL_QUERY,
-  IS_MOBILE_QUERY,
-  useMediaQuery,
-} from '~utils/hooks/useMediaQuery';
 import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
 import { LAYERS_PANEL_FEATURE_ID } from '~features/layers_panel/constants';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import { LayersTree } from '../LayersTree/LayersTree';
 import s from './MapLayersPanel.module.css';
 
@@ -21,46 +17,31 @@ export function MapLayerPanel({
   iconsContainerRef: React.MutableRefObject<HTMLDivElement | null>;
 }) {
   const [isOpen, setIsOpen] = useState<boolean>(true);
-  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
-  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
   const turnOffTooltip = useAction(currentTooltipAtom.turnOffById);
-
-  useEffect(() => {
-    if (shouldCollapse) {
-      setIsOpen(false);
-      turnOffTooltip(LAYERS_PANEL_FEATURE_ID);
-    }
-  }, [shouldCollapse, turnOffTooltip, setIsOpen]);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
+    turnOffTooltip(LAYERS_PANEL_FEATURE_ID);
   }, [setIsOpen]);
 
   const onPanelOpen = useCallback(() => {
     setIsOpen(true);
   }, [setIsOpen]);
 
-  const panel = (
-    <Panel
-      className={clsx(s.panel, isOpen && s.show, !isOpen && s.hide)}
-      header={<Text type="heading-l">{i18n.t('layers')}</Text>}
-      onClose={onPanelClose}
-    >
-      <div className={s.scrollable}>
-        <LayersTree />
-      </div>
-    </Panel>
-  );
-
   return (
     <>
-      {isOpen && isMobile ? (
-        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
-          {panel}
-        </Modal>
-      ) : (
-        panel
-      )}
+      <PanelWrap onPanelClose={onPanelClose} isPanelOpen={isOpen}>
+        <Panel
+          className={clsx(s.panel, isOpen && s.show, !isOpen && s.hide)}
+          header={<Text type="heading-l">{i18n.t('layers')}</Text>}
+          onClose={onPanelClose}
+        >
+          <div className={s.scrollable}>
+            <LayersTree />
+          </div>
+        </Panel>
+      </PanelWrap>
+
       {iconsContainerRef.current &&
         ReactDOM.createPortal(
           <div className={!isOpen ? s.iconContainerShown : s.iconContainerHidden}>

--- a/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.tsx
+++ b/src/features/layers_panel/components/MapLayersPanel/MapLayersPanel.tsx
@@ -1,11 +1,15 @@
-import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
 import { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import clsx from 'clsx';
 import { Layers24 } from '@konturio/default-icons';
 import { useAction } from '@reatom/react';
 import { i18n } from '~core/localization';
-import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
+import {
+  COLLAPSE_PANEL_QUERY,
+  IS_MOBILE_QUERY,
+  useMediaQuery,
+} from '~utils/hooks/useMediaQuery';
 import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
 import { LAYERS_PANEL_FEATURE_ID } from '~features/layers_panel/constants';
 import { LayersTree } from '../LayersTree/LayersTree';
@@ -17,15 +21,16 @@ export function MapLayerPanel({
   iconsContainerRef: React.MutableRefObject<HTMLDivElement | null>;
 }) {
   const [isOpen, setIsOpen] = useState<boolean>(true);
+  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
   const turnOffTooltip = useAction(currentTooltipAtom.turnOffById);
 
   useEffect(() => {
-    if (isMobile) {
+    if (shouldCollapse) {
       setIsOpen(false);
       turnOffTooltip(LAYERS_PANEL_FEATURE_ID);
     }
-  }, [isMobile]);
+  }, [shouldCollapse, turnOffTooltip, setIsOpen]);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
@@ -35,22 +40,30 @@ export function MapLayerPanel({
     setIsOpen(true);
   }, [setIsOpen]);
 
+  const panel = (
+    <Panel
+      className={clsx(s.panel, isOpen && s.show, !isOpen && s.hide)}
+      header={<Text type="heading-l">{i18n.t('layers')}</Text>}
+      onClose={onPanelClose}
+    >
+      <div className={s.scrollable}>
+        <LayersTree />
+      </div>
+    </Panel>
+  );
+
   return (
     <>
-      <Panel
-        className={clsx(s.panel, isOpen && s.show, !isOpen && s.hide)}
-        header={<Text type="heading-l">{i18n.t('layers')}</Text>}
-        onClose={onPanelClose}
-      >
-        <div className={s.scrollable}>
-          <LayersTree />
-        </div>
-      </Panel>
+      {isOpen && isMobile ? (
+        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
+          {panel}
+        </Modal>
+      ) : (
+        panel
+      )}
       {iconsContainerRef.current &&
         ReactDOM.createPortal(
-          <div
-            className={!isOpen ? s.iconContainerShown : s.iconContainerHidden}
-          >
+          <div className={!isOpen ? s.iconContainerShown : s.iconContainerHidden}>
             <PanelIcon
               clickHandler={onPanelOpen}
               className={clsx(s.panelIcon, isOpen && s.hide, !isOpen && s.show)}

--- a/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
+++ b/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
@@ -98,7 +98,7 @@
     margin: 0;
     width: 100vw;
     max-height: unset;
-    height: calc(100vh - 40px);
+    height: calc(100vh - var(--header-height));
     align-items: center;
   }
   .legendPanel > div {

--- a/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
+++ b/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
@@ -1,4 +1,4 @@
-.sidePanel {
+.legendPanel {
   pointer-events: auto;
   position: relative;
   z-index: 1; /* Show shadow over map */
@@ -43,8 +43,7 @@
   display: flex;
 
   &.show {
-    transition: display 0s linear 0s, visibility 0s linear 0s,
-      opacity 0.33s linear 0s;
+    transition: display 0s linear 0s, visibility 0s linear 0s, opacity 0.33s linear 0s;
     visibility: visible;
     display: flex;
     opacity: 1;
@@ -91,4 +90,26 @@
 
 .alignRight {
   margin-left: auto;
+}
+
+@media screen and (max-width: 960px) {
+  .modalCover,
+  .modalCover * {
+    z-index: var(--modal);
+  }
+  .modalCover > section {
+    top: 44px; /* header offset */
+    left: 0;
+  }
+  .legendPanel {
+    position: absolute;
+    margin: 0;
+    width: 100vw;
+    max-height: unset;
+    height: calc(100vh - 40px);
+    align-items: center;
+  }
+  .legendPanel > div {
+    width: 100%;
+  }
 }

--- a/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
+++ b/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
@@ -93,14 +93,6 @@
 }
 
 @media screen and (max-width: 960px) {
-  .modalCover,
-  .modalCover * {
-    z-index: var(--modal);
-  }
-  .modalCover > section {
-    top: 44px; /* header offset */
-    left: 0;
-  }
   .legendPanel {
     position: absolute;
     margin: 0;

--- a/src/features/legend_panel/components/LegendPanel/LegendPanel.tsx
+++ b/src/features/legend_panel/components/LegendPanel/LegendPanel.tsx
@@ -1,17 +1,13 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import ReactDOM from 'react-dom';
 import clsx from 'clsx';
 import { Legend24 } from '@konturio/default-icons';
-import { Modal, Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
 import { useAction } from '@reatom/react';
 import { i18n } from '~core/localization';
-import {
-  COLLAPSE_PANEL_QUERY,
-  IS_MOBILE_QUERY,
-  useMediaQuery,
-} from '~utils/hooks/useMediaQuery';
 import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
 import { LEGEND_PANEL_FEATURE_ID } from '~features/legend_panel/constants';
+import { PanelWrap } from '~components/Panel/Wrap/PanelWrap';
 import s from './LegendPanel.module.css';
 import { LegendsList } from './LegendsList';
 import type { LayerAtom } from '~core/logical_layers/types/logicalLayer';
@@ -22,65 +18,38 @@ interface LegendPanelProps {
 }
 
 export function LegendPanel({ layers, iconsContainerRef }: LegendPanelProps) {
-  // isOpen - is an overall state of panel. Was closed stores wether the panel was closed by user -> preferred to be closed
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [wasClosed, setWasClosed] = useState<boolean>(true);
 
-  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
-  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
   const turnOffTooltip = useAction(currentTooltipAtom.turnOffById);
-
-  useEffect(() => {
-    if (shouldCollapse) {
-      setIsOpen(false);
-      turnOffTooltip(LEGEND_PANEL_FEATURE_ID);
-    }
-  }, [shouldCollapse, turnOffTooltip, LEGEND_PANEL_FEATURE_ID]);
-
-  useEffect(() => {
-    if (layers.length && !isMobile && !wasClosed && !isOpen) {
-      setIsOpen(true);
-    } else if (!layers.length && isOpen) {
-      setIsOpen(false);
-    }
-  }, [layers]);
 
   const onPanelClose = useCallback(() => {
     setIsOpen(false);
-    setWasClosed(true);
+    turnOffTooltip(LEGEND_PANEL_FEATURE_ID);
   }, [setIsOpen]);
 
   const onPanelOpen = useCallback(() => {
     setIsOpen(true);
-    setWasClosed(false);
   }, [setIsOpen]);
-
-  const panel = (
-    <Panel
-      header={<Text type="heading-l">{i18n.t('legend')}</Text>}
-      onClose={onPanelClose}
-      className={clsx(s.legendPanel, isOpen && s.show, !isOpen && s.hide)}
-      classes={{
-        header: s.header,
-      }}
-    >
-      <div className={s.panelBody}>
-        {layers.map((layer) => (
-          <LegendsList layer={layer} key={layer.id} />
-        ))}
-      </div>
-    </Panel>
-  );
 
   return (
     <>
-      {isOpen && isMobile ? (
-        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
-          {panel}
-        </Modal>
-      ) : (
-        panel
-      )}
+      <PanelWrap onPanelClose={onPanelClose} isPanelOpen={isOpen}>
+        <Panel
+          header={<Text type="heading-l">{i18n.t('legend')}</Text>}
+          onClose={onPanelClose}
+          className={clsx(s.legendPanel, isOpen && s.show, !isOpen && s.hide)}
+          classes={{
+            header: s.header,
+          }}
+        >
+          <div className={s.panelBody}>
+            {layers.map((layer) => (
+              <LegendsList layer={layer} key={layer.id} />
+            ))}
+          </div>
+        </Panel>
+      </PanelWrap>
+
       {iconsContainerRef.current &&
         ReactDOM.createPortal(
           <PanelIcon

--- a/src/global.css
+++ b/src/global.css
@@ -1,5 +1,9 @@
 @import-normalize;
 
+:root {
+  --header-height: 40px;
+}
+
 html,
 body {
   box-sizing: border-box;

--- a/src/utils/atoms/createStateMap.ts
+++ b/src/utils/atoms/createStateMap.ts
@@ -14,7 +14,7 @@ export function createStateMap<T>({
   error: string | null;
   data: T | null;
 }) {
-  return ({ loading, error, ready, init }: AtomStatesHandlers<T>) => {
+  return ({ loading, error, ready, init = null }: AtomStatesHandlers<T>) => {
     if (LoadingState && loading)
       return typeof loading === 'function' ? loading() : loading;
     if (errorMessage && error)

--- a/src/utils/hooks/useMediaQuery.tsx
+++ b/src/utils/hooks/useMediaQuery.tsx
@@ -16,4 +16,5 @@ export const useMediaQuery = (query: string) => {
   return matches;
 };
 
-export const IS_MOBILE_QUERY = '(max-width: 1280px)';
+export const IS_MOBILE_QUERY = '(max-width: 960px)';
+export const COLLAPSE_PANEL_QUERY = '(max-width: 1280px)';


### PR DESCRIPTION
Not sure whether i should make 
```
{isOpen && isMobile ? (
        <Modal onModalCloseCallback={onPanelClose} className={s.modalCover}>
          {panel}
        </Modal>
      ) : (
        panel
      )}
``` 
as a component. Should I?


Examples:
![image](https://user-images.githubusercontent.com/50058726/189613931-c794f3ea-62c6-4794-8093-1d6be6a3e484.png)
![image](https://user-images.githubusercontent.com/50058726/189613696-fb33cd4e-9efe-4d76-9751-0f1bdae9e3f3.png)
![image](https://user-images.githubusercontent.com/50058726/189613747-0cfde7e4-bb91-4a22-9df7-a6aa180bf600.png)
![image](https://user-images.githubusercontent.com/50058726/189613789-22820e2f-5604-4d11-97bb-5dcef390ab54.png)
![image](https://user-images.githubusercontent.com/50058726/189613893-b678b031-caa1-45e4-9d2e-1aa31835c55c.png)
![image](https://user-images.githubusercontent.com/50058726/189614000-24d86ced-f9fd-4253-84be-883400a62f9c.png)

