### PR TITLE
fix(panels): 12588, 12590 - fix panel scrolls and resize

### DIFF
--- a/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
+++ b/src/features/analytics_panel/components/AnalyticsPanel/AnalyticsPanel.module.css
@@ -34,8 +34,13 @@
 
 /* laptop */
 @media screen and (max-width: 1900px) {
+  .analyticsPanel {
+    /* Temporary restrict height to fit all panels until  #12580 is done */
+    & > div:nth-child(2) {
+      height: 260px;
+    }
+  }
   .panelBody {
-    height: 260px;
     width: 320px;
     padding: var(--double-unit);
     overflow-y: auto;

--- a/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
+++ b/src/features/legend_panel/components/LegendPanel/LegendPanel.module.css
@@ -1,3 +1,11 @@
+.panelContainer {
+  height: var(--panel-header-height);
+  min-height: var(--panel-header-height);
+  &.open {
+    height: auto;
+    min-height: calc(var(--panel-header-height) + 60px);
+  }
+}
 .legendPanel {
   pointer-events: auto;
   position: relative;
@@ -5,9 +13,15 @@
   margin-right: var(--unit);
   align-self: flex-start;
   border-radius: var(--border-radius);
-  height: auto;
-  max-height: calc(100vh - 140px);
+  height: 100%;
   width: 100%;
+
+  /* Allow resize for content container */
+  & > div:nth-child(2) {
+    min-height: 60px;
+    overflow-y: auto;
+    resize: vertical;
+  }
 
   &.collapse {
     & div:not(:first-child) {
@@ -17,12 +31,9 @@
 }
 
 .panelBody {
-  height: 100%;
   width: 100%;
   padding: var(--double-unit);
-  overflow-y: auto;
   overflow-x: hidden;
-  resize: vertical;
 }
 .panelBody :first-child {
   margin-top: 0;

--- a/src/features/legend_panel/components/LegendPanel/LegendPanel.tsx
+++ b/src/features/legend_panel/components/LegendPanel/LegendPanel.tsx
@@ -42,7 +42,7 @@ export function LegendPanel({ layers }: LegendPanelProps) {
   useAutoCollapsePanel(isOpen, onPanelClose);
 
   return (
-    <div className={s.panelContainer}>
+    <div className={clsx(s.panelContainer, isOpen && s.open)}>
       <Panel
         header={String(i18n.t('legend'))}
         headerIcon={<Legend24 />}


### PR DESCRIPTION
Legend panel has scroll again
![image](https://user-images.githubusercontent.com/50058726/192848091-361f57b5-6909-4e5f-a950-dd4bf350414e.png)
Analytics can be expanded as expected
![image](https://user-images.githubusercontent.com/50058726/192848215-7e7323d7-6829-4679-8271-7068614096b8.png)
