### PR TITLE
fix(bivariate-matrix): 12796 - fix disabled selection when matrix open

### DIFF
--- a/src/features/bivariate_manager/components/BivariateMatrixControl/index.tsx
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/index.tsx
@@ -173,8 +173,6 @@ const BivariateMatrixControl = forwardRef<HTMLDivElement | null, any>(
     };
 
     const onSelectRowCol = (x: number, y: number) => {
-      if (x === -1 || y === -1) return;
-
       if (x !== -1 && selectedColIndex.current !== x) {
         selectedColIndex.current = x;
         const columns = cellColumnReferences[selectedColIndex.current];


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/No-way-to-choose-numerator-and-then-denominator-at-BM-independently-12796