### PR TITLE
fix(core): 12940-link-preview-doesn-t-work

### DIFF
--- a/src/core/metrics/sequences/eventReadyForScreenShot.ts
+++ b/src/core/metrics/sequences/eventReadyForScreenShot.ts
@@ -4,7 +4,7 @@ export function eventReadyForScreenShot(mtr: AppMetrics) {
   mtr
     .addSequence('eventReadyForScreenShot')
     .on('appConfig_loaded')
-    .on('done_userResourceAtom')
+    .on('_done_userResourceAtom')
     .on('setMap_[Shared state] currentMapAtom', (ctx, map: maplibregl.Map) => {
       ctx.map = map;
     })


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Link-preview-doesn't-work-12940

some event names were changed after refactoring, which caused sequence to fail