### PR TITLE
fix(reports): 13006 - fix report page styles

### DIFF
--- a/src/features/reports/atoms/tableAtom.ts
+++ b/src/features/reports/atoms/tableAtom.ts
@@ -77,7 +77,9 @@ export const tableAtom = createAtom(
       });
     });
 
-    onAction('setState', (newState) => (state = newState));
+    onAction('setState', (newState) => {
+      state = newState;
+    });
 
     onAction('sort', () => {
       const sorted = (function sortTable() {

--- a/src/features/reports/components/ReportInfo/Report.module.css
+++ b/src/features/reports/components/ReportInfo/Report.module.css
@@ -7,9 +7,9 @@
 }
 
 .mainWrap {
-  padding: 88px 0 20px 0;
+  padding: 88px var(--double-unit) 20px var(--double-unit);
   margin: 0 auto;
-  width: 90vw;
+  width: 100%;
   max-height: calc(100vh - 44px);
   overflow-y: auto;
 }
@@ -66,7 +66,7 @@
 
 @media screen and (max-width: 1200px) {
   .mainWrap {
-    padding: 44px 0.5vw 44px 0.5vw;
+    padding: 44px var(--unit) 44px var(--unit);
     width: 99vw;
     max-height: 100vh;
     overflow-y: auto;

--- a/src/features/reports/components/ReportInfo/Report.module.css
+++ b/src/features/reports/components/ReportInfo/Report.module.css
@@ -34,9 +34,10 @@
 .lastUpdated {
   font-size: 18px;
   line-height: 23px;
-  color: #8c949b;
+  color: var(--neutral-neutral-60);
 }
 
+/* designated design for big screens with lots of width -> big paddings */
 @media screen and (min-width: 1921px) {
   .mainWrap {
     padding: 100px 216px 100px 216px;
@@ -62,23 +63,30 @@
     font-size: 22px;
     line-height: 28.6px;
   }
+
+  thead {
+    top: -100px;
+  }
 }
 
-@media screen and (max-width: 1200px) {
+/* below desktop */
+@media screen and (max-width: 1900px) {
   .mainWrap {
-    padding: 44px var(--unit) 44px var(--unit);
-    width: 99vw;
-    max-height: 100vh;
-    overflow-y: auto;
+    padding: 44px 1vw 44px 1vw;
   }
 
+  thead {
+    top: -44px;
+  }
+}
+/* laptop and below */
+@media screen and (max-width: 1200px) {
   table {
     display: block;
-    overflow-x: auto;
     white-space: nowrap;
   }
   thead tr {
-    border-bottom: 1px solid #b9b9b9;
+    border-bottom: 1px solid var(--primary-border-disabled);
   }
   th {
     padding: var(--double-unit) var(--unit);

--- a/src/features/reports/components/ReportInfo/Report.module.css
+++ b/src/features/reports/components/ReportInfo/Report.module.css
@@ -7,8 +7,8 @@
 }
 
 .mainWrap {
-  padding: 88px var(--double-unit) 20px var(--double-unit);
-  margin: 0 auto;
+  padding: 88px 176px 20px 176px;
+  margin: 0;
   width: 100%;
   max-height: calc(100vh - 44px);
   overflow-y: auto;

--- a/src/features/reports/components/ReportTable/ReportTable.module.css
+++ b/src/features/reports/components/ReportTable/ReportTable.module.css
@@ -7,11 +7,11 @@ table {
 thead {
   box-shadow: inset 0px 1px 0px var(--faint-weak);
   background: #f0f0f0;
+  top: -88px;
+  position: sticky;
 }
 
 th {
-  top: 44px;
-  position: sticky;
   background: #f0f0f0;
   padding: 6px 8px;
   text-align: left;

--- a/src/features/reports/components/ReportTable/ReportTable.module.css
+++ b/src/features/reports/components/ReportTable/ReportTable.module.css
@@ -6,13 +6,13 @@ table {
 
 thead {
   box-shadow: inset 0px 1px 0px var(--faint-weak);
-  background: #f0f0f0;
+  background: var(--neutral-neutral-20);
   top: -88px;
   position: sticky;
 }
 
 th {
-  background: #f0f0f0;
+  background: var(--neutral-neutral-20);
   padding: 6px 8px;
   text-align: left;
   font: var(--font);
@@ -25,7 +25,7 @@ th {
 }
 
 tbody tr {
-  box-shadow: inset 0 -1px #b9b9b9;
+  box-shadow: inset 0 -1px var(--primary-border-disabled);
 }
 
 tbody tr:nth-child(even) {

--- a/src/features/reports/components/ReportTable/ReportTable.tsx
+++ b/src/features/reports/components/ReportTable/ReportTable.tsx
@@ -24,12 +24,6 @@ export function ReportTable() {
     useAtom(tableAtom);
   const [meta] = useAtom(currentReportAtom);
 
-  useEffect(() => {
-    return () => {
-      setState({ sortIndex: 0, ascending: null });
-    };
-  }, []);
-
   if (data === null) {
     return <Text type="heading-xl">{i18n.t('reports.no_data')}</Text>;
   }

--- a/src/features/reports/components/ReportsList/ReportsList.tsx
+++ b/src/features/reports/components/ReportsList/ReportsList.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@konturio/ui-kit';
-import { Link, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import clsx from 'clsx';
 import { Trans } from 'react-i18next';
 import { useEffect } from 'react';
@@ -9,7 +9,6 @@ import { i18n } from '~core/localization';
 import config from '~core/app_config';
 import { LinkRenderer } from '~components/LinkRenderer/LinkRenderer';
 import { reportsAtom } from '../../atoms/reportsAtom';
-import arrowIcon from '../../icons/arrow.svg';
 import styles from './ReportsList.module.css';
 
 export function ReportsList() {
@@ -39,15 +38,16 @@ export function ReportsList() {
             >
               Kontur{' '}
             </a>{' '}
-            generates several reports that help validate OpenStreetMap quality. 
-            They contain links to areas on{' '}
+            generates several reports that help validate OpenStreetMap quality. They
+            contain links to areas on{' '}
             <a
               href="https://www.openstreetmap.org/"
               className={clsx(styles.paragraphLink, styles.link)}
             >
               osm.org{' '}
             </a>{' '}
-            and links to open them in the JOSM editor with enabled remote control for editing.
+            and links to open them in the JOSM editor with enabled remote control for
+            editing.
           </Trans>
         </div>
       </Text>

--- a/src/views/Report/Report.tsx
+++ b/src/views/Report/Report.tsx
@@ -1,9 +1,5 @@
 import { ReportInfo } from '~features/reports/components/ReportInfo/ReportInfo';
 
 export function ReportPage() {
-  return (
-    <div>
-      <ReportInfo />
-    </div>
-  );
+  return <ReportInfo />;
 }


### PR DESCRIPTION
Scroll bar is now at it's place
Sticky header is visible
Paddings fixed for laptops
![image](https://user-images.githubusercontent.com/50058726/197173314-66714d58-7cd4-4f3c-b205-dadbb0805c31.png)
![image](https://user-images.githubusercontent.com/50058726/197173551-fd007b04-fabe-406e-8c8b-b5c0cbf98d5c.png)
stick bar fixed for big screens (> 1920px width)
![image](https://user-images.githubusercontent.com/50058726/197173686-f9d6bf11-3b77-4721-a902-70479200d7da.png)
