### PR TITLE
fix(panels): 12804 - collapse panels only for mobile widths

### DIFF
--- a/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.tsx
+++ b/src/features/advanced_analytics_panel/components/AdvancedAnalyticsPanel/AdvancedAnalyticsPanel.tsx
@@ -20,7 +20,6 @@ const LazyLoadedAdvancedAnalyticsPanelHeader = lazy(
 
 export function AdvancedAnalyticsPanel() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const isMobile = useMediaQuery(IS_MOBILE_QUERY);
 
   const togglePanel = useCallback(() => {
     setIsOpen((prevState) => !prevState);

--- a/src/features/side_bar/components/SideBar/SideBar.tsx
+++ b/src/features/side_bar/components/SideBar/SideBar.tsx
@@ -12,10 +12,11 @@ import { i18n } from '~core/localization';
 import { currentTooltipAtom } from '~core/shared_state/currentTooltip';
 import { searchStringAtom } from '~core/url_store/atoms/urlStore';
 import s from './SideBar.module.css';
+const wasClosed = 'sidebarClosed';
 
 export function SideBar() {
   const [controls] = useAtom(modesControlsAtom);
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(localStorage.getItem(wasClosed) ? false : true);
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
   const setTooltip = useAction(currentTooltipAtom.setCurrentTooltip);
   const resetTooltip = useAction(currentTooltipAtom.resetCurrentTooltip);
@@ -49,6 +50,15 @@ export function SideBar() {
     setIsOpen((prevState) => !prevState);
     resetTooltip();
   }, [setIsOpen]);
+
+  // store locally user preferation to close sidebar
+  useEffect(() => {
+    if (!isOpen) {
+      localStorage.setItem(wasClosed, 'true');
+    } else {
+      localStorage.removeItem(wasClosed);
+    }
+  }, [isOpen]);
 
   return (
     <div className={s.sidebar}>

--- a/src/utils/hooks/useMediaQuery.tsx
+++ b/src/utils/hooks/useMediaQuery.tsx
@@ -17,5 +17,5 @@ export const useMediaQuery = (query: string) => {
 };
 
 export const IS_MOBILE_QUERY = '(max-width: 960px)';
-export const COLLAPSE_PANEL_QUERY = '(max-width: 1280px)';
+export const COLLAPSE_PANEL_QUERY = IS_MOBILE_QUERY;
 export const IS_LAPTOP_QUERY = '(max-width: 1900px) and (min-width: 961px)';


### PR DESCRIPTION
I have a task to stop collapsing panels for laptop widths
However we still need to collapse them for mobile screens as every panel modal-like when opened

also i've added storing user choise to close sidebar locally