### PR TITLE
fix(modes): 12974 symbol from landing page incorrectly shown on mobile

### DIFF
--- a/src/features/user_profile/components/LoginForm/LoginForm.module.css
+++ b/src/features/user_profile/components/LoginForm/LoginForm.module.css
@@ -2,7 +2,7 @@
   z-index: var(--modal);
 }
 .modalCard {
-  box-shadow: none;
+  box-shadow: none !important;
 }
 
 .loginDescription {

--- a/src/views/About/About.tsx
+++ b/src/views/About/About.tsx
@@ -86,7 +86,7 @@ function AboutText() {
 
         <p>
           <span className={s.linkToMain} onClick={gotoMap}>
-            {i18n.t('about.goToMap')} ⭢
+            {i18n.t('about.goToMap')} ➜
           </span>
         </p>
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/12974
<img width="214" alt="image" src="https://user-images.githubusercontent.com/112831093/199054452-0406d8a5-fd08-4513-9408-3f8df949d34b.png">

 also fix for css shadow
<img width="205" alt="image" src="https://user-images.githubusercontent.com/112831093/199054380-aed1e23d-e2a7-4de7-be2d-5faed8a7bd19.png">
<img width="241" alt="image" src="https://user-images.githubusercontent.com/112831093/199054662-c3c3deb2-18f7-46d0-9c97-19af6ec7319e.png">

