### PR TITLE
feat(event-panel): 12901 - delete osmGapsPercentage from event card

### DIFF
--- a/src/core/localization/translations/ar/common-messages.json
+++ b/src/core/localization/translations/ar/common-messages.json
@@ -70,7 +70,6 @@
           "value": "لا أثر إنساني"
         },
         "settled_area.tooltip": "منطقة مستوطنة",
-        "osm_gaps_percentage.tooltip": "نسبة فجوات OSM (كلما كانت منخفضة كان أفضل)",
         "loss.tooltip": "الخسارة المقدرة"
       }
     },

--- a/src/core/localization/translations/en/common-messages.json
+++ b/src/core/localization/translations/en/common-messages.json
@@ -74,7 +74,6 @@
           "value": "No humanitarian impact"
         },
         "settled_area.tooltip": "Settled Area",
-        "osm_gaps_percentage.tooltip": "OSM Gaps Percentage (lower is better)",
         "loss.tooltip": "Estimated loss"
       }
     },

--- a/src/core/localization/translations/es/common-messages.json
+++ b/src/core/localization/translations/es/common-messages.json
@@ -70,7 +70,6 @@
           "value": "Sin impacto humanitario"
         },
         "settled_area.tooltip": "Área habitada",
-        "osm_gaps_percentage.tooltip": "Porcentaje de brechas de OSM (cuanto más bajo, mejor)",
         "loss.tooltip": "Pérdida estimada"
       }
     },

--- a/src/features/events_list/components/EventCard/Analytics/Analytics.tsx
+++ b/src/features/events_list/components/EventCard/Analytics/Analytics.tsx
@@ -21,12 +21,10 @@ type Statistics = {
 export function Analytics({
   settledArea,
   affectedPeople,
-  osmGapsPercentage,
   loss,
 }: {
   settledArea: number;
   affectedPeople: number;
-  osmGapsPercentage: number | null;
   loss?: number;
 }) {
   const statistics = useMemo((): Statistics => {
@@ -58,12 +56,6 @@ export function Analytics({
         icon: <Area16 />,
       });
 
-    if (typeof osmGapsPercentage === 'number')
-      result.push({
-        tooltip: i18n.t('event_list.analytics.osm_gaps_percentage.tooltip'),
-        value: `${osmGapsPercentage}% gaps`,
-      });
-
     if (typeof loss === 'number')
       result.push({
         tooltip: i18n.t('event_list.analytics.loss.tooltip'),
@@ -71,7 +63,7 @@ export function Analytics({
       });
 
     return result;
-  }, [settledArea, affectedPeople, osmGapsPercentage]);
+  }, [settledArea, affectedPeople]);
 
   return (
     <div className={s.analytics}>

--- a/src/features/events_list/components/EventCard/EventCard.tsx
+++ b/src/features/events_list/components/EventCard/EventCard.tsx
@@ -52,7 +52,6 @@ export function EventCard({
       <Analytics
         settledArea={event.settledArea}
         affectedPeople={event.affectedPopulation}
-        osmGapsPercentage={event.osmGaps}
         loss={event.loss}
       />
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Delete-OSM-gaps-from-Disasters-panel-DN-FE-12901
![image](https://user-images.githubusercontent.com/20676525/199183079-6bae0a42-93e6-476d-a0c7-70fa96c4e6d3.png)
