### PR TITLE
fix(core, focused_geomtetry_editor): 12806 - change draw tools initial state

### DIFF
--- a/src/core/draw_tools/atoms/combinedAtom.ts
+++ b/src/core/draw_tools/atoms/combinedAtom.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { createAtom } from '~utils/atoms';
 import { currentMapAtom, currentNotificationAtom } from '~core/shared_state';
 import { setMapInteractivity } from '~utils/map/setMapInteractivity';
@@ -7,7 +8,7 @@ import { drawnGeometryAtom } from './drawnGeometryAtom';
 import { drawModeLogicalLayerAtom } from './logicalLayerAtom';
 import {
   selectedIndexesAtom,
-  selIndexesForCurrentGeometryAtom,
+  setIndexesForCurrentGeometryAtom,
 } from './selectedIndexesAtom';
 import { isDrawingStartedAtom } from './isDrawingStartedAtom';
 import { drawModeRenderer } from './logicalLayerAtom';
@@ -47,7 +48,7 @@ export const combinedAtom = createAtom(
 
     selectedIndexesAtom,
     setIndexes: (indexes: number[]) => indexes,
-    selIndexesForCurrentGeometryAtom,
+    setIndexesForCurrentGeometryAtom,
 
     setDrawingIsStarted: (isStarted: boolean) => isStarted,
 
@@ -62,7 +63,7 @@ export const combinedAtom = createAtom(
     state: CombinedAtomCallbacksType = {},
   ) => {
     const actions: Action[] = [];
-    const selectCurrentGeometryWasRequested = get('selIndexesForCurrentGeometryAtom');
+    const selectCurrentGeometryWasRequested = get('setIndexesForCurrentGeometryAtom');
 
     onChange('activeDrawModeAtom', (mode) => {
       const map = get('currentMapAtom');
@@ -102,11 +103,10 @@ export const combinedAtom = createAtom(
 
     onChange('drawnGeometryAtom', (featureCollection, prevCollection) => {
       if (selectCurrentGeometryWasRequested) {
-        actions.push(selIndexesForCurrentGeometryAtom.set(false));
+        // add indexes to select and disable request for setting indexes
+        actions.push(setIndexesForCurrentGeometryAtom.set(false));
         const indexes: number[] = [];
-        for (let i = 0; i < featureCollection.features.length; i++) {
-          indexes.push(i);
-        }
+        _.times(featureCollection.features.length, (index) => indexes.push(index));
         actions.push(selectedIndexesAtom.setIndexes(indexes));
       }
       (state.drawnGeometryAtom ?? []).forEach((cb) => cb(featureCollection));

--- a/src/core/draw_tools/atoms/combinedAtom.ts
+++ b/src/core/draw_tools/atoms/combinedAtom.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import times from 'lodash/times';
 import { createAtom } from '~utils/atoms';
 import { currentMapAtom, currentNotificationAtom } from '~core/shared_state';
 import { setMapInteractivity } from '~utils/map/setMapInteractivity';
@@ -106,7 +106,7 @@ export const combinedAtom = createAtom(
         // add indexes to select and disable request for setting indexes
         actions.push(setIndexesForCurrentGeometryAtom.set(false));
         const indexes: number[] = [];
-        _.times(featureCollection.features.length, (index) => indexes.push(index));
+        times(featureCollection.features.length, (index) => indexes.push(index));
         actions.push(selectedIndexesAtom.setIndexes(indexes));
       }
       (state.drawnGeometryAtom ?? []).forEach((cb) => cb(featureCollection));

--- a/src/core/draw_tools/atoms/selectedIndexesAtom.ts
+++ b/src/core/draw_tools/atoms/selectedIndexesAtom.ts
@@ -1,4 +1,5 @@
 import { createAtom } from '~utils/atoms';
+import { createPrimitiveAtom } from '~utils/atoms/createPrimitives';
 
 export const selectedIndexesAtom = createAtom(
   {
@@ -13,3 +14,5 @@ export const selectedIndexesAtom = createAtom(
   },
   'selectedIndexesAtom',
 );
+
+export const selIndexesForCurrentGeometryAtom = createPrimitiveAtom(false);

--- a/src/core/draw_tools/atoms/selectedIndexesAtom.ts
+++ b/src/core/draw_tools/atoms/selectedIndexesAtom.ts
@@ -15,4 +15,4 @@ export const selectedIndexesAtom = createAtom(
   'selectedIndexesAtom',
 );
 
-export const selIndexesForCurrentGeometryAtom = createPrimitiveAtom(false);
+export const setIndexesForCurrentGeometryAtom = createPrimitiveAtom(false);

--- a/src/core/draw_tools/components/DrawToolsToolbox/DrawToolsToolbox.tsx
+++ b/src/core/draw_tools/components/DrawToolsToolbox/DrawToolsToolbox.tsx
@@ -97,13 +97,14 @@ export const DrawToolsToolbox = () => {
 
   return activeDrawMode ? (
     <div className={s.drawToolsContainer}>
-      {!drawingIsStarted && (
+      {/* This logic and elements might reapper on draw tools refactor so i'm keeping them */}
+      {/* {!drawingIsStarted && (
         <div className={s.drawHint}>
           <Text type="caption">
             <span>{i18n.t('draw_tools.caption')}</span>
           </Text>
         </div>
-      )}
+      )} */}
 
       <div className={s.bGroupWrap}>
         <ButtonGroup

--- a/src/core/draw_tools/map-daw-tools/customDrawModes/CustomModifyMode.ts
+++ b/src/core/draw_tools/map-daw-tools/customDrawModes/CustomModifyMode.ts
@@ -20,8 +20,8 @@ type SubmodeType = GeoJsonEditMode | CompositeMode;
 
 export class CustomModifyMode extends GeoJsonEditMode {
   _submodesCache: { [key: string]: SubmodeType } = {};
-  _currentSubMode: SubmodeType | null = null;
-  _currentSubModeName = '';
+  _currentSubMode: SubmodeType | null = this.createSubmode('Modify');
+  _currentSubModeName = 'Modify';
   _selectedIndex = -1;
 
   // on click
@@ -85,9 +85,7 @@ export class CustomModifyMode extends GeoJsonEditMode {
   }
 
   // @ts-expect-error we need to handle null here
-  getGuides(
-    props: ModeProps<FeatureCollection>,
-  ): GuideFeatureCollection | null {
+  getGuides(props: ModeProps<FeatureCollection>): GuideFeatureCollection | null {
     return this._currentSubMode ? this._currentSubMode.getGuides(props) : null;
   }
 
@@ -97,28 +95,19 @@ export class CustomModifyMode extends GeoJsonEditMode {
     }
   }
 
-  handleStartDragging(
-    event: StartDraggingEvent,
-    props: ModeProps<FeatureCollection>,
-  ) {
+  handleStartDragging(event: StartDraggingEvent, props: ModeProps<FeatureCollection>) {
     if (this._currentSubMode) {
       this._currentSubMode.handleStartDragging(event, props);
     }
   }
 
-  handleStopDragging(
-    event: StopDraggingEvent,
-    props: ModeProps<FeatureCollection>,
-  ) {
+  handleStopDragging(event: StopDraggingEvent, props: ModeProps<FeatureCollection>) {
     if (this._currentSubMode) {
       this._currentSubMode.handleStopDragging(event, props);
     }
   }
 
-  handlePointerMove(
-    event: PointerMoveEvent,
-    props: ModeProps<FeatureCollection>,
-  ) {
+  handlePointerMove(event: PointerMoveEvent, props: ModeProps<FeatureCollection>) {
     if (this._currentSubMode) {
       this._currentSubMode.handlePointerMove(event, props);
     }
@@ -128,10 +117,7 @@ export class CustomModifyMode extends GeoJsonEditMode {
     event.stopPropagation();
     const { key } = event;
 
-    if (
-      (key === 'Delete' || key === 'Backspace') &&
-      this._selectedIndex !== -1
-    ) {
+    if ((key === 'Delete' || key === 'Backspace') && this._selectedIndex !== -1) {
       const updatedData = new ImmutableFeatureCollection(props.data)
         .deleteFeature(this._selectedIndex)
         .getObject();

--- a/src/core/draw_tools/renderers/DrawModeRenderer.ts
+++ b/src/core/draw_tools/renderers/DrawModeRenderer.ts
@@ -9,10 +9,7 @@ import { layersConfigs } from '../configs';
 import type { ApplicationMap } from '~components/ConnectedMap/ConnectedMap';
 import type { DrawModeType } from '../constants';
 import type { FeatureCollection, Feature } from 'geojson';
-import type {
-  NotNullableMap,
-  CommonHookArgs,
-} from '~core/logical_layers/types/renderer';
+import type { NotNullableMap, CommonHookArgs } from '~core/logical_layers/types/renderer';
 import type { CombinedAtom } from '../atoms/combinedAtom';
 import type { NotificationType } from '~core/shared_state/currentNotifications';
 import type { NotificationMessage } from '~core/types/notification';
@@ -53,14 +50,12 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
   private _updateTempFeaturesAction: (
     features: Feature[],
     updateIndexes: number[],
-  ) => void = () =>
-    console.error('updateTempFeatures action isn`t available yet');
+  ) => void = () => console.error('updateTempFeatures action isn`t available yet');
   private _showNotificationAction: (
     type: NotificationType,
     message: NotificationMessage,
     lifetimeSec: number,
-  ) => void = () =>
-    console.error('showNotification action isn`t available yet');
+  ) => void = () => console.error('showNotification action isn`t available yet');
 
   private _setSelectedIndexes: (indexes: number[]) => void = () =>
     console.error('setIndexes action isn`t available yet');
@@ -99,10 +94,8 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
   }
 
   setupExtension(extentionAtom: CombinedAtom): void {
-    this._setFeaturesAction = (features) =>
-      extentionAtom.setFeatures.dispatch(features);
-    this._addFeatureAction = (feature) =>
-      extentionAtom.addFeature.dispatch(feature);
+    this._setFeaturesAction = (features) => extentionAtom.setFeatures.dispatch(features);
+    this._addFeatureAction = (feature) => extentionAtom.addFeature.dispatch(feature);
     extentionAtom.hookWithAtom.dispatch([
       'drawnGeometryAtom',
       (featureCollection) => {
@@ -117,15 +110,21 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
       (featureCollection) => {
         // temporary geometry clears out after every deletion of any amount of features
         // if we cleared temporaryGeometry, there's no need to clear all displayed geometry (geometry from drawnGeometryAtom)
-        if (featureCollection.features.length)
-          this._updateData(featureCollection);
+        if (featureCollection.features.length) this._updateData(featureCollection);
       },
     ]);
-    this._setSelectedIndexes = (indexes) =>
-      extentionAtom.setIndexes.dispatch(indexes);
+    this._setSelectedIndexes = (indexes) => extentionAtom.setIndexes.dispatch(indexes);
     extentionAtom.hookWithAtom.dispatch([
       'selectedIndexesAtom',
-      (indexes) => (this.selectedIndexes = [...indexes]),
+      (indexes) => {
+        this.selectedIndexes = [...indexes];
+        if (this.mode) {
+          const layer = this.mountedDeckLayers[this.mode];
+          layer?.setProps({
+            selectedFeatureIndexes: this.selectedIndexes,
+          });
+        }
+      },
     ]);
 
     this._setDrawingStarted = (isStarted) =>
@@ -189,15 +188,13 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
         )
           return 'pointIcon';
         if (!('featureIndex' in d.properties)) return null;
-        const featureToHandle =
-          this.drawnData.features[d.properties.featureIndex];
+        const featureToHandle = this.drawnData.features[d.properties.featureIndex];
         if (featureToHandle.geometry.type !== 'Point') return 'pointIcon';
         return 'selectedIcon';
       };
       config.getEditHandleIconSize = (d) => {
         if (!('featureIndex' in d.properties)) return 1.8;
-        const featureToHandle =
-          this.drawnData.features[d.properties.featureIndex];
+        const featureToHandle = this.drawnData.features[d.properties.featureIndex];
         if (featureToHandle.geometry.type !== 'Point') return 1.8;
         return 6;
       };
@@ -212,16 +209,17 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
     config._subLayerProps.guides.pointRadiusMinPixels = 4;
     config._subLayerProps.guides.pointRadiusMaxPixels = 4;
     const deckLayer = new MapboxLayer({ ...config });
+
     if (!this._map.getLayer(deckLayer.id)) {
       this._map.addLayer(deckLayer);
     }
+
     this.mountedDeckLayers[mode] = deckLayer;
   }
 
   _removeDeckLayer(mode: DrawModeType): void {
     const deckLayer = this.mountedDeckLayers[mode];
-    if (!deckLayer)
-      return console.error(`cannot remove ${mode} as it wasn't mounted`);
+    if (!deckLayer) return console.error(`cannot remove ${mode} as it wasn't mounted`);
     this._map.removeLayer(deckLayer.id);
     delete this.mountedDeckLayers[mode];
   }

--- a/src/features/focused_geometry_editor/index.tsx
+++ b/src/features/focused_geometry_editor/index.tsx
@@ -12,7 +12,7 @@ import { drawModeLogicalLayerAtom } from '~core/draw_tools/atoms/logicalLayerAto
 import { forceRun } from '~utils/atoms/forceRun';
 import { toolboxAtom } from '~core/draw_tools/atoms/toolboxAtom';
 import { store } from '~core/store/store';
-import { selIndexesForCurrentGeometryAtom } from '~core/draw_tools/atoms/selectedIndexesAtom';
+import { setIndexesForCurrentGeometryAtom } from '~core/draw_tools/atoms/selectedIndexesAtom';
 import { isEditorActiveAtom } from './atoms/isEditorActive';
 import { focusedGeometryEditorAtom } from './atoms/focusedGeometryEditorAtom';
 
@@ -44,7 +44,7 @@ export function initFocusedGeometry() {
           }),
           drawModeLogicalLayerAtom.enable(),
           activeDrawModeAtom.setDrawMode(drawModes.ModifyMode),
-          selIndexesForCurrentGeometryAtom.set(true),
+          setIndexesForCurrentGeometryAtom.set(true),
         ]);
       } else {
         store.dispatch([

--- a/src/features/focused_geometry_editor/index.tsx
+++ b/src/features/focused_geometry_editor/index.tsx
@@ -12,6 +12,7 @@ import { drawModeLogicalLayerAtom } from '~core/draw_tools/atoms/logicalLayerAto
 import { forceRun } from '~utils/atoms/forceRun';
 import { toolboxAtom } from '~core/draw_tools/atoms/toolboxAtom';
 import { store } from '~core/store/store';
+import { selIndexesForCurrentGeometryAtom } from '~core/draw_tools/atoms/selectedIndexesAtom';
 import { isEditorActiveAtom } from './atoms/isEditorActive';
 import { focusedGeometryEditorAtom } from './atoms/focusedGeometryEditorAtom';
 
@@ -43,9 +44,8 @@ export function initFocusedGeometry() {
           }),
           drawModeLogicalLayerAtom.enable(),
           activeDrawModeAtom.setDrawMode(drawModes.ModifyMode),
+          selIndexesForCurrentGeometryAtom.set(true),
         ]);
-        // TODO fix that logic in layer.setMode() in #9782
-        store.dispatch(activeDrawModeAtom.setDrawMode(drawModes.DrawPolygonMode));
       } else {
         store.dispatch([
           isEditorActiveAtom.set(false),


### PR DESCRIPTION
Focused geometry editor now started with modify mode with selection of all geometry passed to it
Hint to start drawing was removed
![image](https://user-images.githubusercontent.com/50058726/199255824-41983cf9-7961-4d76-ae0a-27be43e71c29.png)

This was done by creating boolean-flag atom, that activated by feature and when geometry is provided - no matter the feature ammount - they get selected
![image](https://user-images.githubusercontent.com/50058726/199256300-d6bb0a29-1e10-4192-8133-3670daf90a55.png)
