### PR TITLE
fix (analytical_panel): 13168 - analytics not crushing app when boundary selected

### DIFF
--- a/src/components/Analytics/AnalyticsPanelHeader/AnalyticsPanelHeader.tsx
+++ b/src/components/Analytics/AnalyticsPanelHeader/AnalyticsPanelHeader.tsx
@@ -10,14 +10,6 @@ import type { AsyncAtomState } from '~utils/atoms/createAsyncAtom/types';
 import type { FocusedGeometry, GeometrySource } from '~core/shared_state/focusedGeometry';
 import type { Atom } from '@reatom/core';
 
-interface PanelHeadingProps {
-  event: {
-    eventName: string;
-    severity: Severity;
-    externalUrls: string[];
-  };
-}
-
 function PanelHeading({ source }: { source?: GeometrySource }) {
   if (source?.type !== 'event') return null;
   return (
@@ -36,10 +28,8 @@ interface AnalyticsPanelHeaderParams {
 }
 
 function getBoundaryName(source?: GeometrySource) {
-  if (!source) return '';
+  if (!source || source.type !== 'boundaries') return '';
   if (source.type === 'boundaries') return source.meta.name;
-  if (source.type === 'event') return source.meta.eventName;
-  if (source.type === 'episode') return source.meta.name;
   return '';
 }
 

--- a/src/components/Analytics/AnalyticsPanelHeader/AnalyticsPanelHeader.tsx
+++ b/src/components/Analytics/AnalyticsPanelHeader/AnalyticsPanelHeader.tsx
@@ -7,7 +7,7 @@ import { SeverityIndicator } from '~components/SeverityIndicator/SeverityIndicat
 import styles from './AnalyticsPanelHeader.module.css';
 import type { AdvancedAnalyticsData, AnalyticsData, Severity } from '~core/types';
 import type { AsyncAtomState } from '~utils/atoms/createAsyncAtom/types';
-import type { FocusedGeometry } from '~core/shared_state/focusedGeometry';
+import type { FocusedGeometry, GeometrySource } from '~core/shared_state/focusedGeometry';
 import type { Atom } from '@reatom/core';
 
 interface PanelHeadingProps {
@@ -18,11 +18,12 @@ interface PanelHeadingProps {
   };
 }
 
-function PanelHeading({ event }: PanelHeadingProps) {
+function PanelHeading({ source }: { source?: GeometrySource }) {
+  if (source?.type !== 'event') return null;
   return (
     <div className={styles.head}>
-      <Text type="heading-m">{event.eventName}</Text>
-      <SeverityIndicator severity={event.severity} />
+      <Text type="heading-m">{source.meta.eventName}</Text>
+      <SeverityIndicator severity={source.meta.severity} />
     </div>
   );
 }
@@ -32,6 +33,14 @@ interface AnalyticsPanelHeaderParams {
     | Atom<AsyncAtomState<FocusedGeometry | null, AnalyticsData[] | null>>
     | Atom<AsyncAtomState<FocusedGeometry | null, AdvancedAnalyticsData[] | null>>;
   loadingMessage: string;
+}
+
+function getBoundaryName(source?: GeometrySource) {
+  if (!source) return '';
+  if (source.type === 'boundaries') return source.meta.name;
+  if (source.type === 'event') return source.meta.eventName;
+  if (source.type === 'episode') return source.meta.name;
+  return '';
 }
 
 const AnalyticsPanelHeader = ({
@@ -60,9 +69,9 @@ const AnalyticsPanelHeader = ({
       error: () => null,
       ready: () =>
         ({
-          event: <PanelHeading event={(focusedGeometry?.source as any).meta} />,
+          event: <PanelHeading source={focusedGeometry?.source} />,
           boundaries: (
-            <Text type="heading-m">{(focusedGeometry?.source as any).meta}</Text>
+            <Text type="heading-m">{getBoundaryName(focusedGeometry?.source)}</Text>
           ),
         }[sourceType]),
     }) || <></>

--- a/src/core/shared_state/focusedGeometry.ts
+++ b/src/core/shared_state/focusedGeometry.ts
@@ -30,7 +30,7 @@ interface GeometrySourceDrawn {
   type: 'drawn';
 }
 
-type GeometrySource =
+export type GeometrySource =
   | GeometrySourceEpisode
   | GeometrySourceEvent
   | GeometrySourceCustom


### PR DESCRIPTION
removed type casting and added checks that fixed the bug - analytics not crashing for boundaries now