### PR TITLE
fix(event_list): 11841 - fix autoselect fired when event is already selected

### DIFF
--- a/src/core/localization/translations/en/common-messages.json
+++ b/src/core/localization/translations/en/common-messages.json
@@ -75,7 +75,8 @@
         },
         "settled_area.tooltip": "Settled Area",
         "loss.tooltip": "Estimated loss"
-      }
+      },
+      "no_event_in_feed": "Event not found in the current event feed"
     },
     "create_layer": {
       "edit_layer": "Edit Layer",

--- a/src/core/localization/translations/en/common-messages.json
+++ b/src/core/localization/translations/en/common-messages.json
@@ -264,6 +264,9 @@
       "defaultDisasterFeed": "Default disaster feed",
       "defaultOSMeditor": "Default OpenStreetMap editor (beta)",
       "successNotification": "All changes have been applied successfully"
+    },
+    "current_event": {
+      "not_found_request": "Sorry, requested event not found."
     }
   }
 }

--- a/src/features/current_event/atoms/currentEventResource.ts
+++ b/src/features/current_event/atoms/currentEventResource.ts
@@ -2,6 +2,7 @@ import { createAtom } from '~utils/atoms';
 import { apiClient } from '~core/apiClientInstance';
 import { currentEventAtom, currentEventFeedAtom } from '~core/shared_state';
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
+import { i18n } from '~core/localization';
 import type { EventWithGeometry } from '~core/types';
 
 const eventDependencyAtom = createAtom(
@@ -29,7 +30,13 @@ export const currentEventResourceAtom = createAsyncAtom(
         `/events/${deps.feed.id}/${deps.event.id}`,
         undefined,
         undefined,
-        { signal: abortController.signal, errorsConfig: { dontShowErrors: true } },
+        {
+          signal: abortController.signal,
+          errorsConfig: {
+            dontShowErrors: false,
+            messages: i18n.t('current_event.not_found_request'),
+          },
+        },
       );
       if (responseData === undefined) throw 'No data received';
       return responseData;

--- a/src/features/current_event/atoms/currentEventResource.ts
+++ b/src/features/current_event/atoms/currentEventResource.ts
@@ -34,7 +34,7 @@ export const currentEventResourceAtom = createAsyncAtom(
           signal: abortController.signal,
           errorsConfig: {
             dontShowErrors: false,
-            messages: i18n.t('current_event.not_found_request'),
+            messages: { 404: i18n.t('current_event.not_found_request') },
           },
         },
       );

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -21,7 +21,7 @@ export const autoSelectEvent = createAtom(
       ) {
         const currentEvent = getUnlistedState(currentEventAtom);
         const currentEventNotInNewList =
-          eventListResource.data.findIndex((e) => e.eventId === currentEvent?.id) === -1;
+          !eventListResource.data.some((e) => e.eventId === currentEvent?.id);
 
         if (currentEvent?.id && currentEventNotInNewList) {
           // This case happens when call for event by provided url id didn't return event

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -25,7 +25,7 @@ export const autoSelectEvent = createAtom(
         );
 
         // do nothing
-        if (!currentEventNotInTheList) return;
+        if (!currentEventNotInTheList) return state;
 
         if (currentEvent?.id) {
           // This case happens when call for event by provided eventId didn't return event

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -28,7 +28,7 @@ export const autoSelectEvent = createAtom(
           schedule((dispatch) =>
             dispatch(
               currentNotificationAtom.showNotification(
-                'error',
+                'warning',
                 { title: i18n.t('event_list.no_event_in_feed') },
                 5,
               ),

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -24,7 +24,6 @@ export const autoSelectEvent = createAtom(
           (e) => e.eventId === currentEvent?.id,
         );
 
-        // do nothing
         if (!currentEventNotInTheList) return state;
 
         if (currentEvent?.id) {

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -1,9 +1,7 @@
 import { createAtom } from '~utils/atoms';
-import { currentEventAtom } from '~core/shared_state';
-import {
-  scheduledAutoFocus,
-  scheduledAutoSelect,
-} from '~core/shared_state/currentEvent';
+import { currentEventAtom, currentNotificationAtom } from '~core/shared_state';
+import { scheduledAutoFocus, scheduledAutoSelect } from '~core/shared_state/currentEvent';
+import { i18n } from '~core/localization';
 import { eventListResourceAtom } from './eventListResource';
 
 export const autoSelectEvent = createAtom(
@@ -23,10 +21,20 @@ export const autoSelectEvent = createAtom(
       ) {
         const currentEvent = getUnlistedState(currentEventAtom);
         const currentEventNotInNewList =
-          eventListResource.data.findIndex(
-            (e) => e.eventId === currentEvent?.id,
-          ) === -1;
-        if (currentEventNotInNewList) {
+          eventListResource.data.findIndex((e) => e.eventId === currentEvent?.id) === -1;
+
+        if (currentEvent?.id && currentEventNotInNewList) {
+          // This case happens when call for event by provided url id didn't return event
+          schedule((dispatch) =>
+            dispatch(
+              currentNotificationAtom.showNotification(
+                'error',
+                { title: i18n.t('event_list.no_event_in_feed') },
+                5,
+              ),
+            ),
+          );
+        } else if (currentEventNotInNewList) {
           const firstEventInList = eventListResource.data[0];
           schedule((dispatch) => {
             dispatch([

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -20,11 +20,15 @@ export const autoSelectEvent = createAtom(
         eventListResource.data.length
       ) {
         const currentEvent = getUnlistedState(currentEventAtom);
-        const currentEventNotInNewList =
-          !eventListResource.data.some((e) => e.eventId === currentEvent?.id);
+        const currentEventNotInTheList = !eventListResource.data.some(
+          (e) => e.eventId === currentEvent?.id,
+        );
 
-        if (currentEvent?.id && currentEventNotInNewList) {
-          // This case happens when call for event by provided url id didn't return event
+        // do nothing
+        if (!currentEventNotInTheList) return;
+
+        if (currentEvent?.id) {
+          // This case happens when call for event by provided eventId didn't return event
           schedule((dispatch) =>
             dispatch(
               currentNotificationAtom.showNotification(
@@ -34,7 +38,7 @@ export const autoSelectEvent = createAtom(
               ),
             ),
           );
-        } else if (currentEventNotInNewList) {
+        } else {
           const firstEventInList = eventListResource.data[0];
           schedule((dispatch) => {
             dispatch([

--- a/src/utils/map/cameraForGeometry.ts
+++ b/src/utils/map/cameraForGeometry.ts
@@ -8,7 +8,7 @@ function getPaddings(): PaddingOptions {
   // mobile
   if (width < MOBILE_WIDTH_PX + 1) return { left: 64, top: 44, right: 115, bottom: 0 };
   // laptop
-  if (width < LAPTOP_WIDTH_PX + 1) return { left: 348, top: 44, right: 110, bottom: 60 };
+  if (width < LAPTOP_WIDTH_PX + 1) return { left: 348, top: 44, right: 110, bottom: 95 };
   // desktop
   return { left: 340, top: 44, right: 465, bottom: 95 };
 }

--- a/src/utils/map/cameraForGeometry.ts
+++ b/src/utils/map/cameraForGeometry.ts
@@ -6,11 +6,11 @@ import type { PaddingOptions } from 'maplibre-gl';
 function getPaddings(): PaddingOptions {
   const width = window.visualViewport?.width ?? Infinity;
   // mobile
-  if (width < MOBILE_WIDTH_PX + 1) return { left: 64, top: 44, right: 115, bottom: 0 };
+  if (width < MOBILE_WIDTH_PX + 1) return { left: 64, top: 5, right: 115, bottom: 0 };
   // laptop
-  if (width < LAPTOP_WIDTH_PX + 1) return { left: 348, top: 44, right: 110, bottom: 95 };
+  if (width < LAPTOP_WIDTH_PX + 1) return { left: 435, top: 5, right: 110, bottom: 95 };
   // desktop
-  return { left: 340, top: 44, right: 465, bottom: 95 };
+  return { left: 340, top: 5, right: 465, bottom: 95 };
 }
 
 export function getCameraForGeometry(


### PR DESCRIPTION
If url was applied with event-id not presented in event list but availible through api call - warning title is presented for 5 seconds and autoselect is not fired 
![image](https://user-images.githubusercontent.com/50058726/200170410-650577cf-4429-4c16-a74c-9b65cefa797c.png)

I also added error message for 404 event requests as there was no other way for user to know that event cannot be reached