### PR TITLE
fix(layers_in_area): 13152 - selected area is not correct for current event

### DIFF
--- a/src/core/shared_state/focusedGeometry.ts
+++ b/src/core/shared_state/focusedGeometry.ts
@@ -86,4 +86,10 @@ export const focusedGeometryAtom = createAtom(
   '[Shared state] focusedGeometryAtom',
 );
 
+export function getEvendId(focusedGeometry: FocusedGeometry | null) {
+  return focusedGeometry?.source?.type === 'event'
+    ? focusedGeometry.source.meta.eventId
+    : null;
+}
+
 export const FOCUSED_GEOMETRY_LOGICAL_LAYER_ID = 'focused-geometry';

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
@@ -1,6 +1,6 @@
 import { createAtom } from '~utils/atoms/createPrimitives';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
-import { focusedGeometryAtom } from '~core/shared_state/focusedGeometry';
+import { focusedGeometryAtom, getEvendId } from '~core/shared_state/focusedGeometry';
 import { currentEventFeedAtom } from '~core/shared_state';
 import { layersGlobalResource } from '../layersGlobalResource';
 import { layersInAreaAndEventLayerResource } from '../layersInAreaAndEventLayerResource';
@@ -25,11 +25,9 @@ export const areaLayersDetailsParamsAtom = createAtom(
     ];
     const enabledLayers = get('enabledLayersAtom');
     const focusedGeometry = getUnlistedState(focusedGeometryAtom);
-    const eventId =
-      focusedGeometry?.source?.type === 'event'
-        ? focusedGeometry.source.meta.eventId
-        : null;
+    const eventId = getEvendId(focusedGeometry);
     const cache = getUnlistedState(areaLayersDetailsResourceAtomCache);
+
     const mustBeRequested = allLayers.filter((layer) => {
       const isEnabled = enabledLayers.has(layer.id);
       const isInCache = cache.get(eventId)?.has(layer.id) ?? false;


### PR DESCRIPTION
I've simply applied cache that was already implemented but was only storing layers and stopping them from being requested

What was broken: select event A with event-related geometry layer, select event B, select event A - cached layers not applied.