### PR TITLE
feat(core): 13108 init map in center from url, fix epig sequence

### DIFF
--- a/src/components/ConnectedMap/useMapPositionSmoothSync.ts
+++ b/src/components/ConnectedMap/useMapPositionSmoothSync.ts
@@ -1,17 +1,13 @@
 import { useEffect } from 'react';
 import { useAtom } from '@reatom/react';
 import { currentMapPositionAtom } from '~core/shared_state';
-import { mapIdle } from '~core/shared_state/currentMapPosition';
 
 /**
  * This effect allow to listen state changes, and fly to position that set externally in atom
  * And allow to read current map position and update atom state with actual data.
  * */
 export function useMapPositionSmoothSync(mapRef) {
-  const [currentMapPosition, currentMapPositionActions] = useAtom(
-    currentMapPositionAtom,
-  );
-  const [, { setTrue: markMapIdle }] = useAtom(mapIdle);
+  const [currentMapPosition, currentMapPositionActions] = useAtom(currentMapPositionAtom);
 
   useEffect(() => {
     if (mapRef.current && currentMapPosition !== null) {
@@ -27,9 +23,6 @@ export function useMapPositionSmoothSync(mapRef) {
               center: [newMapPosition.lng, newMapPosition.lat],
               zoom: newMapPosition.zoom,
               duration: 0,
-            });
-            map.once('idle', () => {
-              markMapIdle();
             });
           });
         });
@@ -52,7 +45,7 @@ export function useMapPositionSmoothSync(mapRef) {
         };
       }
     }
-  }, [mapRef, currentMapPosition, markMapIdle]);
+  }, [mapRef, currentMapPosition]);
 
   useEffect(() => {
     if (mapRef.current) {

--- a/src/core/metrics/sequences/eventReadyForScreenShot.ts
+++ b/src/core/metrics/sequences/eventReadyForScreenShot.ts
@@ -13,7 +13,7 @@ export function eventReadyForScreenShot(mtr: AppMetrics) {
         return { continueSq: false };
       }
     })
-    .on('done_areaLayersDetailsResourceAtom')
+    .on('_done_areaLayersDetailsResourceAtom')
     .on('change_layersLegends')
     .on('setTrue_mapIdle', () => {
       setTimeout(() => {

--- a/src/core/store/store.ts
+++ b/src/core/store/store.ts
@@ -4,6 +4,11 @@ import { appMetrics } from '~core/metrics';
 
 // enable with localStorage.setItem('KONTUR_DEBUG', 'true')
 const KONTUR_DEBUG = !!globalThis.window?.localStorage.getItem('KONTUR_DEBUG');
+
+// enable with localStorage.setItem('KONTUR_WARN', 'true')
+// will add stacktrace
+const KONTUR_WARN = !!globalThis.window?.localStorage.getItem('KONTUR_WARN');
+
 // enable with localStorage.setItem('KONTUR_TRACE_ERROR', '_error')
 const KONTUR_TRACE_TYPE = globalThis.window?.localStorage.getItem('KONTUR_TRACE_TYPE');
 
@@ -35,6 +40,9 @@ function configureStore() {
             }
             if (KONTUR_DEBUG) {
               console.debug(action.type, action.payload);
+            }
+            if (KONTUR_WARN) {
+              console.warn(action.type, action.payload);
             }
           }
         }


### PR DESCRIPTION
When opening link with map= in it, the map never jumps during initialization and map opens in correct place from the start. https://kontur.fibery.io/Tasks/Task/Initialize-map-centered-to-coordinates-in-map-parameter-13108

Also fix EPIG event sequence to enable screenshots
