### PR TITLE
fix(core, user_profile): 13179 - apply changes when user profile changes 

### DIFF
--- a/src/RoutesWrap.tsx
+++ b/src/RoutesWrap.tsx
@@ -15,6 +15,7 @@ import { initModes } from '~core/modes/initializeModes';
 import { Row } from '~components/Layout/Layout';
 import { APP_ROUTES, findCurrentMode } from '~core/app_config/appRoutes';
 import { currentModeAtom } from '~core/modes/currentMode';
+import { initLanguageWatcher } from '~core/auth/atoms/languageWatcher';
 import s from './views/Main/Main.module.css';
 import type { UserDataModel } from '~core/auth';
 
@@ -54,6 +55,7 @@ export const CommonRoutesFeatures = ({
   }, [userModel]);
 
   useEffect(() => {
+    initLanguageWatcher();
     return forceRun(urlStoreAtom);
   }, []);
 

--- a/src/components/ConnectedMap/map-libre-adapter/index.tsx
+++ b/src/components/ConnectedMap/map-libre-adapter/index.tsx
@@ -378,17 +378,27 @@ function MapboxMap(
     });
   }, [map, mapLoaded]);
 
+  const [scaleControl, setScaleControl] = useState(
+    getMapControl(currentUserData?.useMetricUnits),
+  );
   /* Deck GL cursor updates */
   useEffect(() => {
-    if (!map || !mapLoaded) return;
-    const scale = new mapLibre.ScaleControl({
-      maxWidth: 120,
-      unit: currentUserData.useMetricUnits ? 'metric' : 'imperial',
-    });
-    map.addControl(scale, 'bottom-right');
-  }, [map, mapLoaded]);
+    if (!map) return;
+    map.hasControl(scaleControl) && map.removeControl(scaleControl);
+    const newControl = getMapControl(currentUserData?.useMetricUnits);
+    map.addControl(newControl, 'bottom-right');
+    setScaleControl(newControl);
+  }, [map, currentUserData]);
 
   return <div className={className} ref={mapEl} />;
 }
 
 export default forwardRef(MapboxMap);
+
+function getMapControl(useMetricUnits?: boolean) {
+  const scale = new mapLibre.ScaleControl({
+    maxWidth: 120,
+    unit: useMetricUnits ? 'metric' : 'imperial',
+  });
+  return scale;
+}

--- a/src/components/ConnectedMap/map-libre-adapter/index.tsx
+++ b/src/components/ConnectedMap/map-libre-adapter/index.tsx
@@ -378,17 +378,15 @@ function MapboxMap(
     });
   }, [map, mapLoaded]);
 
-  const [scaleControl, setScaleControl] = useState(
-    getMapControl(currentUserData?.useMetricUnits),
-  );
-  /* Deck GL cursor updates */
+  // Add single scale control
+  const [scaleControl, setScaleControl] = useState<mapLibre.ScaleControl | null>(null);
   useEffect(() => {
-    if (!map) return;
-    map.hasControl(scaleControl) && map.removeControl(scaleControl);
+    if (!map || !mapLoaded) return;
+    scaleControl && map.hasControl(scaleControl) && map.removeControl(scaleControl);
     const newControl = getMapControl(currentUserData?.useMetricUnits);
     map.addControl(newControl, 'bottom-right');
     setScaleControl(newControl);
-  }, [map, currentUserData]);
+  }, [map, currentUserData, mapLoaded]);
 
   return <div className={className} ref={mapEl} />;
 }

--- a/src/core/auth/atoms/languageWatcher.ts
+++ b/src/core/auth/atoms/languageWatcher.ts
@@ -1,0 +1,26 @@
+import { createAtom } from '~utils/atoms';
+import { currentUserAtom } from '~core/shared_state';
+import { i18n } from '~core/localization';
+import { forceRun } from '~utils/atoms/forceRun';
+
+const languageWatcher = createAtom(
+  {
+    currentUserAtom,
+  },
+  ({ onChange }, state = null) => {
+    onChange('currentUserAtom', (newUser, prevUser) => {
+      const userLanguage = newUser.language;
+      if (userLanguage && i18n.instance.language !== userLanguage) {
+        i18n.instance.changeLanguage(userLanguage).catch((e) => {
+          console.error(e);
+        });
+      }
+    });
+    return state;
+  },
+  '[Shared state] userStateAtom',
+);
+
+export function initLanguageWatcher() {
+  forceRun(languageWatcher);
+}

--- a/src/features/user_profile/atoms/userProfile.ts
+++ b/src/features/user_profile/atoms/userProfile.ts
@@ -35,18 +35,14 @@ export const currentProfileAtom = createAtom(
           5,
         );
 
-        i18n.instance
-          .changeLanguage(user.language)
-          .then((r) => {
-            location.reload();
-          })
-          .catch((e) => {
-            console.error(e);
-          });
+        dispatch(currentUserAtom.setUser(user));
       });
     });
 
     onChange('currentUserAtom', async (newUser, prevUser) => {
+      // reload to simply apply all the settings if implementation is difficult
+      // if (prevUser) location.reload()
+
       const newState = { ...newUser };
       delete newState.token;
       delete newState.loading;


### PR DESCRIPTION
Changes now applied when user logs in, out, and changes preferences

We have 3 possible choises that affect app so far: language, units (map scale) and OSM editor. They all reactivly updated on user change without reloading

Reloading is okay however in future if no-reloading implementation is dificuilt. I removed it just now as we don't seem to need it