### PR TITLE
fix(event_list): 13247 - Event list panel that takes all height for disasters panel

### DIFF
--- a/src/core/store/columnContext.tsx
+++ b/src/core/store/columnContext.tsx
@@ -113,7 +113,8 @@ export class Resizer {
         const contentHeight = this.getContentHeight();
         // Find how much space out of size
         const diff = contentHeight ? contentHeight - maxHeight : 0;
-        if (diff > 0) {
+        // diff can be for example 0.0093994140625
+        if (diff > 0.1) {
           // Stop observing while apllying size changes
           containerObserver.unobserve(containerEl);
           this._adjustPanelsHeight(diff);

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
@@ -12,16 +12,14 @@
 }
 
 .scrollable {
-  overflow-y: auto;
+  overflow: hidden;
   height: 100%;
   /* a space to see at least one card */
-  min-height: 110px;
   align-items: center;
 }
 
-.scrollable > div {
-  width: 100%;
-  margin: 0;
+.nonVirtualHeightElement {
+  height: 100vh;
 }
 
 .eventsPanel {

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.module.css
@@ -18,7 +18,7 @@
   align-items: center;
 }
 
-.nonVirtualHeightElement {
+.height100vh {
   height: 100vh;
 }
 

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
@@ -86,7 +86,6 @@ export function EventsListPanel({
         classes={panelClasses}
         isOpen={isOpen}
         modal={{ onModalClick: onPanelClose, showInModal: isMobile }}
-        minContentHeightPx={MIN_HEIGHT}
         resize={isMobile ? 'none' : 'vertical'}
         contentClassName={s.contentWrap}
         contentContainerRef={handleRefChange}
@@ -101,23 +100,27 @@ export function EventsListPanel({
               loading: <LoadingSpinner message={i18n.t('loading_events')} />,
               error: (errorMessage) => <ErrorMessage message={errorMessage} />,
               ready: (eventsList) => (
-                <Virtuoso
-                  data={eventsList}
-                  itemContent={(index, event) => (
-                    <EventCard
-                      key={event.eventId}
-                      event={event}
-                      isActive={event.eventId === current}
-                      onClick={onCurrentChange}
-                      alternativeActionControl={
-                        userModel?.hasFeature(AppFeature.EPISODES_TIMELINE) ? (
-                          <EpisodeTimelineToggle isActive={event.eventId === current} />
-                        ) : null
-                      }
-                    />
-                  )}
-                  ref={virtuoso}
-                />
+                <>
+                  <Virtuoso
+                    data={eventsList}
+                    itemContent={(index, event) => (
+                      <EventCard
+                        key={event.eventId}
+                        event={event}
+                        isActive={event.eventId === current}
+                        onClick={onCurrentChange}
+                        alternativeActionControl={
+                          userModel?.hasFeature(AppFeature.EPISODES_TIMELINE) ? (
+                            <EpisodeTimelineToggle isActive={event.eventId === current} />
+                          ) : null
+                        }
+                      />
+                    )}
+                    ref={virtuoso}
+                  />
+                  {/* this element won't take visual or scroll space */}
+                  <div className={s.nonVirtualHeightElement} />
+                </>
               ),
             })}
           </div>

--- a/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
+++ b/src/features/events_list/components/EventsListPanel/EventsListPanel.tsx
@@ -118,8 +118,11 @@ export function EventsListPanel({
                     )}
                     ref={virtuoso}
                   />
-                  {/* this element won't take visual or scroll space */}
-                  <div className={s.nonVirtualHeightElement} />
+                  <div className={s.height100vh}>
+                    {/* it helps expand panel to full height 
+                    despite that virtual element has no height 
+                    without braking scroll */}
+                  </div>
                 </>
               ),
             })}


### PR DESCRIPTION
I've added 100vh-height element to the end of the virtual list so that it would stretch up panel to maximum height (height limited with <SmartColumn />)
![image](https://user-images.githubusercontent.com/50058726/201933771-2ab6704c-e7b1-44fe-835c-300653f6a610.png)

why not 100% height for panels container of `.smartColumnCocontent`? Because then we have overflow poblem - panels can be resize out of screen by height

also while trying 100% height for  `.smartColumnCocontent` i noticed a small bug at column context