### PR TITLE
fix(bivariate-hexagon-hover): 12194 - Remove hex hover when ruler/dra…

### DIFF
--- a/src/core/draw_tools/renderers/DrawModeRenderer.ts
+++ b/src/core/draw_tools/renderers/DrawModeRenderer.ts
@@ -38,6 +38,7 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
   private _createDrawingLayer: DrawModeType | null;
   private _editDrawingLayer: DrawModeType | null;
   private _removeClickListener: null | (() => void) = null;
+  private _removeMousemoveListener: null | (() => void) = null;
   private _previousValidGeometry: FeatureCollection = {
     type: 'FeatureCollection',
     features: [],
@@ -87,6 +88,8 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
     this._removeAllDeckLayers(args.map);
     this._removeClickListener?.();
     this._removeClickListener = null;
+    this._removeMousemoveListener?.();
+    this._removeMousemoveListener = null;
   }
 
   willHide(args: NotNullableMap & CommonHookArgs): void {
@@ -163,11 +166,19 @@ export class DrawModeRenderer extends LogicalLayerDefaultRenderer<CombinedAtom> 
 
   public addClickListener() {
     if (this._removeClickListener !== null) return;
-    function listener(e) {
+    function preventClicking(e) {
       e.preventDefault();
       return false;
     }
-    this._removeClickListener = registerMapListener('click', listener, 10);
+    function preventMousemove(e) {
+      return false;
+    }
+    this._removeClickListener = registerMapListener('click', preventClicking, 10);
+    this._removeMousemoveListener = registerMapListener(
+      'mousemove',
+      preventMousemove,
+      10,
+    );
   }
 
   // Private methods

--- a/src/features/boundary_selector/atoms/clickCoordinatesAtom.ts
+++ b/src/features/boundary_selector/atoms/clickCoordinatesAtom.ts
@@ -5,6 +5,7 @@ import { registerMapListener } from '~core/shared_state/mapListeners';
 
 interface ScheduleContext {
   removeClickListener?: () => void;
+  removeMousemoveListener?: () => void;
 }
 
 let isAtomEnabled = false;
@@ -34,6 +35,14 @@ export const clickCoordinatesAtom = createAtom(
           },
           10,
         );
+        function preventMousemove(e) {
+          return false;
+        }
+        ctx.removeMousemoveListener ??= registerMapListener(
+          'mousemove',
+          preventMousemove,
+          10,
+        );
         setMapInteractivity(map, false);
       });
 
@@ -41,7 +50,9 @@ export const clickCoordinatesAtom = createAtom(
       schedule((dispatch, ctx: ScheduleContext = {}) => {
         setMapInteractivity(map, true);
         ctx.removeClickListener?.();
+        ctx.removeMousemoveListener?.();
         delete ctx.removeClickListener;
+        delete ctx.removeMousemoveListener;
       });
 
     onAction('_set', (coords) => {

--- a/src/features/map_ruler/renderers/MapRulerRenderer.ts
+++ b/src/features/map_ruler/renderers/MapRulerRenderer.ts
@@ -32,6 +32,7 @@ export class MapRulerRenderer extends LogicalLayerDefaultRenderer {
   public readonly id: string;
   private _deckLayer?: MapboxLayer<unknown>;
   private _removeClickListener: null | (() => void) = null;
+  private _removeMousemoveListener: null | (() => void) = null;
   public constructor(id: string) {
     super();
     this.id = id;
@@ -92,6 +93,9 @@ export class MapRulerRenderer extends LogicalLayerDefaultRenderer {
       args.map.removeLayer(this._deckLayer.id);
     }
     this._removeClickListener?.();
+    this._removeMousemoveListener?.();
+    this._removeClickListener = null;
+    this._removeMousemoveListener = null;
   }
 
   public addClickListener() {
@@ -100,6 +104,10 @@ export class MapRulerRenderer extends LogicalLayerDefaultRenderer {
       e.preventDefault();
       return false;
     }
+    function preventMousemove(e) {
+      return false;
+    }
     this._removeClickListener = registerMapListener('click', preventClicking, 1);
+    this._removeMousemoveListener = registerMapListener('mousemove', preventMousemove, 1);
   }
 }


### PR DESCRIPTION
…w/boundary tool is used

https://kontur.fibery.io/Tasks/Task/Remove-hex-hover-when-ruler-draw-boundary-tool-is-used-13194