### PR TITLE
fix(components, analytics_panel): 8798 - make links shorter

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -29,12 +29,19 @@ export function RoutedApp() {
   const [{ data, loading }] = useAtom(userResourceAtom);
   const userModel = data && !loading ? data : null;
 
+  // FIXME: this logic will be removed on PR #262 or by demand - to be discussed
+  // written as is it wouldn't even allow to start page
   useEffect(() => {
     if (userModel) {
       metricsInit();
-      return forceRun(urlStoreAtom);
+      // This one never runs initially
+      // return forceRun(urlStoreAtom);
     }
   }, [userModel]);
+
+  useEffect(() => {
+    forceRun(urlStoreAtom);
+  }, []);
 
   useEffect(() => {
     const isFirstTimeVisit = () =>

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -29,19 +29,12 @@ export function RoutedApp() {
   const [{ data, loading }] = useAtom(userResourceAtom);
   const userModel = data && !loading ? data : null;
 
-  // FIXME: this logic will be removed on PR #262 or by demand - to be discussed
-  // written as is it wouldn't even allow to start page
   useEffect(() => {
     if (userModel) {
       metricsInit();
-      // This one never runs initially
-      // return forceRun(urlStoreAtom);
+      return forceRun(urlStoreAtom);
     }
   }, [userModel]);
-
-  useEffect(() => {
-    forceRun(urlStoreAtom);
-  }, []);
 
   useEffect(() => {
     const isFirstTimeVisit = () =>

--- a/src/components/LinkRenderer/LinkRenderer.module.css
+++ b/src/components/LinkRenderer/LinkRenderer.module.css
@@ -1,0 +1,35 @@
+.linkWidthWrap {
+  position: relative;
+  max-width: 192px;
+  & .linkOverflowWrap {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
+  & .link {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width: 100%;
+    display: block;
+    text-decoration: none;
+    color: var(--accent-strong);
+    cursor: pointer;
+  }
+
+  & .link::after {
+    content: attr(data-truncate);
+    position: absolute;
+    left: 100%;
+    top: 0;
+    white-space: nowrap;
+  }
+
+  & .link:hover {
+    text-decoration: underline;
+    &::after {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/components/LinkRenderer/LinkRenderer.module.css
+++ b/src/components/LinkRenderer/LinkRenderer.module.css
@@ -1,6 +1,5 @@
 .linkWidthWrap {
   position: relative;
-  max-width: 192px;
   & .linkOverflowWrap {
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/components/LinkRenderer/LinkRenderer.tsx
+++ b/src/components/LinkRenderer/LinkRenderer.tsx
@@ -1,19 +1,42 @@
 import { memo } from 'react';
+import s from './LinkRenderer.module.css';
 
-export const LinkRenderer = memo(function (props: any) {
+// types from react-markdown expected types
+type ReactMemoElementWrapProps = React.DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>;
+
+export const LinkRenderer = memo(function (props: ReactMemoElementWrapProps) {
   return (
-    <a
-      href={props.href}
-      target="_blank"
-      rel="noreferrer"
-      onClick={stopPropagation}
-    >
+    <a href={props.href} target="_blank" rel="noreferrer" onClick={stopPropagation}>
       {props.children}
     </a>
   );
 });
+
+export const LinkRendererShort = memo(function ({
+  children: linkArr,
+}: ReactMemoElementWrapProps) {
+  return (
+    <div className={s.linkWidthWrap}>
+      <div className={s.linkOverflowWrap}>
+        <a
+          className={s.link}
+          target="_blank"
+          rel="noreferrer"
+          data-truncate={linkArr?.[0].slice(-12)}
+        >
+          {linkArr?.[0]}
+        </a>
+      </div>
+    </div>
+  );
+});
+
+LinkRenderer.displayName = 'LinkRenderer';
+LinkRendererShort.displayName = 'LinkRendererShort';
+
 function stopPropagation(e) {
   e.stopPropagation();
 }
-
-LinkRenderer.displayName = 'LinkRenderer';

--- a/src/components/LinkRenderer/LinkRenderer.tsx
+++ b/src/components/LinkRenderer/LinkRenderer.tsx
@@ -1,13 +1,13 @@
 import { memo } from 'react';
 import s from './LinkRenderer.module.css';
 
-// types from react-markdown expected types
-type ReactMemoElementWrapProps = React.DetailedHTMLProps<
+// types expected by react-markdown library
+type ElementWrapProps = React.DetailedHTMLProps<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   HTMLAnchorElement
 >;
 
-export const LinkRenderer = memo(function (props: ReactMemoElementWrapProps) {
+export const LinkRenderer = memo(function (props: ElementWrapProps) {
   return (
     <a href={props.href} target="_blank" rel="noreferrer" onClick={stopPropagation}>
       {props.children}
@@ -15,28 +15,32 @@ export const LinkRenderer = memo(function (props: ReactMemoElementWrapProps) {
   );
 });
 
-export const LinkRendererShort = memo(function ({
-  children: linkArr,
-}: ReactMemoElementWrapProps) {
-  return (
-    <div className={s.linkWidthWrap}>
-      <div className={s.linkOverflowWrap}>
-        <a
-          className={s.link}
-          target="_blank"
-          rel="noreferrer"
-          data-truncate={linkArr?.[0].slice(-12)}
-        >
-          {linkArr?.[0]}
-        </a>
+// 192 and 12 are the values proposed by the task #8798
+export function getShortLinkRenderer(
+  maxWidth: number | null = 192,
+  truncateAmount = 12,
+) {
+  return function ShortLinkRenderer({ children: linkArr }: ElementWrapProps) {
+    const style = { maxWidth: maxWidth || 'unset' };
+    return (
+      <div className={s.linkWidthWrap} style={style}>
+        <div className={s.linkOverflowWrap}>
+          <a
+            className={s.link}
+            target="_blank"
+            rel="noreferrer"
+            data-truncate={linkArr?.[0].slice(-truncateAmount)}
+          >
+            {linkArr?.[0]}
+          </a>
+        </div>
       </div>
-    </div>
-  );
-});
-
-LinkRenderer.displayName = 'LinkRenderer';
-LinkRendererShort.displayName = 'LinkRendererShort';
+    );
+  };
+}
 
 function stopPropagation(e) {
   e.stopPropagation();
 }
+
+LinkRenderer.displayName = 'LinkRenderer';

--- a/src/components/LinkRenderer/LinkRenderer.tsx
+++ b/src/components/LinkRenderer/LinkRenderer.tsx
@@ -20,6 +20,7 @@ export function ShortLinkRenderer({
   children: linksArr,
   maxWidth = 192,
   truncateAmount = 12,
+  href,
 }: ElementWrapProps & { maxWidth?: number; truncateAmount?: number }) {
   const style = { maxWidth: maxWidth || 'unset' };
   // react-markdown passes links like that ['link'].
@@ -35,6 +36,7 @@ export function ShortLinkRenderer({
           target="_blank"
           rel="noreferrer"
           data-truncate={truncatedData}
+          href={href}
         >
           {passedLink}
         </a>

--- a/src/components/LinkRenderer/LinkRenderer.tsx
+++ b/src/components/LinkRenderer/LinkRenderer.tsx
@@ -16,27 +16,28 @@ export const LinkRenderer = memo(function (props: ElementWrapProps) {
 });
 
 // 192 and 12 are the values proposed by the task #8798
-export function getShortLinkRenderer(
-  maxWidth: number | null = 192,
+export function ShortLinkRenderer({
+  children: linksArr,
+  maxWidth = 192,
   truncateAmount = 12,
-) {
-  return function ShortLinkRenderer({ children: linkArr }: ElementWrapProps) {
-    const style = { maxWidth: maxWidth || 'unset' };
-    return (
-      <div className={s.linkWidthWrap} style={style}>
-        <div className={s.linkOverflowWrap}>
-          <a
-            className={s.link}
-            target="_blank"
-            rel="noreferrer"
-            data-truncate={linkArr?.[0].slice(-truncateAmount)}
-          >
-            {linkArr?.[0]}
-          </a>
-        </div>
+}: ElementWrapProps & { maxWidth?: number; truncateAmount?: number }) {
+  const style = { maxWidth: maxWidth || 'unset' };
+  const passedLink: string | undefined = linksArr?.[0];
+  const truncatedData = passedLink?.slice(-truncateAmount);
+  return (
+    <div className={s.linkWidthWrap} style={style}>
+      <div className={s.linkOverflowWrap}>
+        <a
+          className={s.link}
+          target="_blank"
+          rel="noreferrer"
+          data-truncate={truncatedData}
+        >
+          {passedLink}
+        </a>
       </div>
-    );
-  };
+    </div>
+  );
 }
 
 function stopPropagation(e) {

--- a/src/components/LinkRenderer/LinkRenderer.tsx
+++ b/src/components/LinkRenderer/LinkRenderer.tsx
@@ -22,6 +22,9 @@ export function ShortLinkRenderer({
   truncateAmount = 12,
 }: ElementWrapProps & { maxWidth?: number; truncateAmount?: number }) {
   const style = { maxWidth: maxWidth || 'unset' };
+  // react-markdown passes links like that ['link'].
+  // If several links were provided in .md source like [label1](link1)[label2](link2)
+  // still each one of them would have it's own wrapper
   const passedLink: string | undefined = linksArr?.[0];
   const truncatedData = passedLink?.slice(-truncateAmount);
   return (

--- a/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsData.module.css
+++ b/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsData.module.css
@@ -26,16 +26,8 @@
   }
 }
 
-.link {
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  width: 100%;
-  display: block;
-  text-decoration: none;
-  color: var(--accent-strong);
-}
-
-.link:hover {
-  text-decoration: underline;
+.markdown {
+  & p {
+    margin: 0;
+  }
 }

--- a/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
+++ b/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid';
 import { i18n } from '~core/localization';
 import { Tooltip } from '~components/Tooltip';
 import { parseLinksAsTags } from '~utils/markdown/parser';
-import { LinkRendererShort } from '~components/LinkRenderer/LinkRenderer';
+import { getShortLinkRenderer } from '~components/LinkRenderer/LinkRenderer';
 import s from './AnalyticsData.module.css';
 import type { AnalyticsData } from '~core/types';
 
@@ -56,7 +56,7 @@ export const AnalyticsDataList = ({ data, links }: AnalyticsDataListProps) => {
           <div className={s.statContent}>
             {links.map((link) => (
               <ReactMarkdown
-                components={{ a: LinkRendererShort }}
+                components={{ a: getShortLinkRenderer() }}
                 className={s.markdown}
                 key={nanoid(4)}
               >

--- a/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
+++ b/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
@@ -1,5 +1,9 @@
+import ReactMarkdown from 'react-markdown';
+import { nanoid } from 'nanoid';
 import { i18n } from '~core/localization';
 import { Tooltip } from '~components/Tooltip';
+import { parseLinksAsTags } from '~utils/markdown/parser';
+import { LinkRendererShort } from '~components/LinkRenderer/LinkRenderer';
 import s from './AnalyticsData.module.css';
 import type { AnalyticsData } from '~core/types';
 
@@ -39,8 +43,7 @@ export const AnalyticsDataList = ({ data, links }: AnalyticsDataListProps) => {
             <div className={s.statContent}>
               {typeof dataItem.percentValue !== 'undefined' ? (
                 <>
-                  {dataItem.percentValue}%
-                  <span className={s.statSplitter}>|</span>
+                  {dataItem.percentValue}%<span className={s.statSplitter}>|</span>
                 </>
               ) : null}
               {textFormatter(dataItem.text)}
@@ -52,15 +55,13 @@ export const AnalyticsDataList = ({ data, links }: AnalyticsDataListProps) => {
           <div className={s.statHead}>{i18n.t('details')}</div>
           <div className={s.statContent}>
             {links.map((link) => (
-              <a
-                className={s.link}
-                href={link}
-                key={link}
-                target="_blank"
-                rel="noreferrer"
+              <ReactMarkdown
+                components={{ a: LinkRendererShort }}
+                className={s.markdown}
+                key={nanoid(4)}
               >
-                {link}
-              </a>
+                {parseLinksAsTags(link)}
+              </ReactMarkdown>
             ))}
           </div>
         </div>

--- a/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
+++ b/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
@@ -56,7 +56,7 @@ export const AnalyticsDataList = ({ data, links }: AnalyticsDataListProps) => {
           <div className={s.statContent}>
             {links.map((link) => (
               <ReactMarkdown
-                components={{ a: ShortLinkRenderer }}
+                components={{ a: ShortLinkRenderer, p: (props) => <div {...props} /> }}
                 className={s.markdown}
                 key={nanoid(4)}
               >

--- a/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
+++ b/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid';
 import { i18n } from '~core/localization';
 import { Tooltip } from '~components/Tooltip';
 import { parseLinksAsTags } from '~utils/markdown/parser';
-import { getShortLinkRenderer } from '~components/LinkRenderer/LinkRenderer';
+import { ShortLinkRenderer } from '~components/LinkRenderer/LinkRenderer';
 import s from './AnalyticsData.module.css';
 import type { AnalyticsData } from '~core/types';
 
@@ -56,7 +56,7 @@ export const AnalyticsDataList = ({ data, links }: AnalyticsDataListProps) => {
           <div className={s.statContent}>
             {links.map((link) => (
               <ReactMarkdown
-                components={{ a: getShortLinkRenderer() }}
+                components={{ a: ShortLinkRenderer }}
                 className={s.markdown}
                 key={nanoid(4)}
               >

--- a/src/utils/markdown/parser.ts
+++ b/src/utils/markdown/parser.ts
@@ -14,12 +14,12 @@ export function parseLinksAsTags(text?: string): string {
   const matchIterable = text.matchAll(regex);
 
   // After pasting in link in markdown format text length will increase
-  // pointer will help us follow that to paste next link in the right place
-  let pointer = 0;
+  // offset will help us follow that to paste next link in the right place
+  let offset = 0;
 
   [...matchIterable].forEach((matchEntity) => {
     const [match, protocol, , domain, path] = matchEntity;
-    const matchIndex = matchEntity.index!;
+    const matchIndex = matchEntity.index ?? 0;
     const matchLength = match.length;
     // skip links in propper markdown format
     if (match.startsWith('](') || match.indexOf('[http') > -1) return;
@@ -27,16 +27,17 @@ export function parseLinksAsTags(text?: string): string {
     const linkStartIndex = match.indexOf('http');
     const fullLink = match.substring(linkStartIndex);
     const beforeLink = match.substring(0, linkStartIndex);
+    const minimalisticDomain = domain.replace('www.', '');
 
     const finalText = spliceString(parsed)(
-      matchIndex + pointer,
-      matchLength + pointer,
-      `${beforeLink}[${domain}${path ?? ''}](${fullLink})`,
+      matchIndex + offset,
+      matchLength,
+      `${beforeLink}[${minimalisticDomain}${path ?? ''}](${fullLink})`,
     );
 
-    pointer +=
-      `[${domain}${path ?? ''}](${fullLink})`.length -
-      (matchLength - beforeLink.length);
+    offset +=
+      `${beforeLink}[${minimalisticDomain}${path ?? ''}](${fullLink})`.length -
+      matchLength;
     parsed = finalText;
   });
 

--- a/src/utils/markdown/parser.ts
+++ b/src/utils/markdown/parser.ts
@@ -27,17 +27,17 @@ export function parseLinksAsTags(text?: string): string {
     const linkStartIndex = match.indexOf('http');
     const fullLink = match.substring(linkStartIndex);
     const beforeLink = match.substring(0, linkStartIndex);
-    const minimalisticDomain = domain.replace('www.', '');
+    const noW3domain = domain.replace('www.', '');
+
+    const mdLinkWithPrefix = `${beforeLink}[${noW3domain}${path ?? ''}](${fullLink})`;
 
     const finalText = spliceString(parsed)(
       matchIndex + offset,
       matchLength,
-      `${beforeLink}[${minimalisticDomain}${path ?? ''}](${fullLink})`,
+      mdLinkWithPrefix,
     );
 
-    offset +=
-      `${beforeLink}[${minimalisticDomain}${path ?? ''}](${fullLink})`.length -
-      matchLength;
+    offset += mdLinkWithPrefix.length - matchLength;
     parsed = finalText;
   });
 

--- a/src/utils/markdown/test/parseLinks.test.ts
+++ b/src/utils/markdown/test/parseLinks.test.ts
@@ -27,9 +27,7 @@ test('do not transform propper marked link', () => {
 
 test('have trailing slash', () => {
   const result = parseLinksAsTags('Lets have https://some.link/with-slash/');
-  expect(result).toBe(
-    'Lets have [some.link/with-slash/](https://some.link/with-slash/)',
-  );
+  expect(result).toBe('Lets have [some.link/with-slash/](https://some.link/with-slash/)');
 });
 
 test('Transform inline links to markdown link format', () => {
@@ -41,9 +39,7 @@ test('Transform inline links to markdown link format', () => {
   const result2 = parseLinksAsTags('https://some.link lorem lorem');
   expect(result2).toBe('[some.link](https://some.link) lorem lorem');
 
-  const result3 = parseLinksAsTags(
-    'https://some.link/with-path and following text',
-  );
+  const result3 = parseLinksAsTags('https://some.link/with-path and following text');
   expect(result3).toBe(
     '[some.link/with-path](https://some.link/with-path) and following text',
   );
@@ -66,12 +62,19 @@ test('Transform multiple links to markdown link format', () => {
     'Lorem lorem [some.link](https://some.link) and [with.some/other-link](http://with.some/other-link)',
   );
 
-  const result2 = parseLinksAsTags(
-    'https://some.link http://another.link/with-path',
-  );
+  const result2 = parseLinksAsTags('https://some.link http://another.link/with-path');
   expect(result2).toBe(
     '[some.link](https://some.link) [another.link/with-path](http://another.link/with-path)',
   );
+});
+
+test('cut off `www.` for link label', () => {
+  const result = parseLinksAsTags(
+    `Some link (https://www.some.link/) ...was passed.
+    Also check https://www.some.link/1 and https://www.some.link/2`,
+  );
+  expect(result).toBe(`Some link ([some.link/](https://www.some.link/)) ...was passed.
+    Also check [some.link/1](https://www.some.link/1) and [some.link/2](https://www.some.link/2)`);
 });
 
 test('real life case - newline, parenthesis and repeating', () => {
@@ -80,6 +83,6 @@ test('real life case - newline, parenthesis and repeating', () => {
     https://www.iom.int, https://displacement.iom.int/reports`,
   );
   expect(result)
-    .toBe(`This map shows visualization of survey results conducted by IOM ([www.iom.int/](https://www.iom.int/)) ...end of paragraph.
-    [www.iom.int](https://www.iom.int), [displacement.iom.int/reports](https://displacement.iom.int/reports)`);
+    .toBe(`This map shows visualization of survey results conducted by IOM ([iom.int/](https://www.iom.int/)) ...end of paragraph.
+    [iom.int](https://www.iom.int), [displacement.iom.int/reports](https://displacement.iom.int/reports)`);
 });


### PR DESCRIPTION
Fixed bug appeared on links parsed that was only detected on 3+ number of links per parse.
Created component for short links
Links for analytics became shorter and 'www.' prefix is cutted off
Tests updated accordingly
Links before:
![image](https://user-images.githubusercontent.com/50058726/204158973-b7eb0f5e-e939-4fd8-80b8-709340727337.png)
Links now on analytics panel
![image](https://user-images.githubusercontent.com/50058726/204158986-a3d83c9a-13a5-4ffa-a9d4-1cc924122cb8.png)

P.s. fix on `./Routes` is not meant to be part of this PR, it just won't load otherwise - so it's weird to push broken app. FIXME added and i'll remove it in case assigned developer would find better solution