### PR TITLE
chore(analytics, advanced_analytics): 11670 - decouple disaster links from analytical panel

### DIFF
--- a/src/features/analytics_panel/components/AnalyticsContainer/AnalyticsContainer.tsx
+++ b/src/features/analytics_panel/components/AnalyticsContainer/AnalyticsContainer.tsx
@@ -38,10 +38,7 @@ const AnalyticsContainer = () => {
           </TabList>
           <TabPanels>
             <TabPanel>
-              <AnalyticsDataList
-                data={dataList}
-                links={(focusedGeometry?.source as any)?.meta?.externalUrls ?? undefined}
-              />
+              <AnalyticsDataList data={dataList} />
             </TabPanel>
           </TabPanels>
         </Tabs>

--- a/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsData.module.css
+++ b/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsData.module.css
@@ -25,9 +25,3 @@
     margin-top: var(--half-unit);
   }
 }
-
-.markdown {
-  & p {
-    margin: 0;
-  }
-}

--- a/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
+++ b/src/features/analytics_panel/components/AnalyticsDataList/AnalyticsDataList.tsx
@@ -1,15 +1,9 @@
-import ReactMarkdown from 'react-markdown';
-import { nanoid } from 'nanoid';
-import { i18n } from '~core/localization';
 import { Tooltip } from '~components/Tooltip';
-import { parseLinksAsTags } from '~utils/markdown/parser';
-import { ShortLinkRenderer } from '~components/LinkRenderer/LinkRenderer';
 import s from './AnalyticsData.module.css';
 import type { AnalyticsData } from '~core/types';
 
 interface AnalyticsDataListProps {
   data?: AnalyticsData[] | null;
-  links?: string[];
 }
 
 const Sub = ({ children }) => (
@@ -30,7 +24,7 @@ function textFormatter(txt: string) {
   }
 }
 
-export const AnalyticsDataList = ({ data, links }: AnalyticsDataListProps) => {
+export const AnalyticsDataList = ({ data }: AnalyticsDataListProps) => {
   return (
     <>
       {data &&
@@ -50,22 +44,6 @@ export const AnalyticsDataList = ({ data, links }: AnalyticsDataListProps) => {
             </div>
           </div>
         ))}
-      {links && links.length ? (
-        <div className={s.stat}>
-          <div className={s.statHead}>{i18n.t('details')}</div>
-          <div className={s.statContent}>
-            {links.map((link) => (
-              <ReactMarkdown
-                components={{ a: ShortLinkRenderer, p: (props) => <div {...props} /> }}
-                className={s.markdown}
-                key={nanoid(4)}
-              >
-                {parseLinksAsTags(link)}
-              </ReactMarkdown>
-            ))}
-          </div>
-        </div>
-      ) : null}
     </>
   );
 };

--- a/src/features/events_list/components/EventCard/EventCard.module.css
+++ b/src/features/events_list/components/EventCard/EventCard.module.css
@@ -9,7 +9,8 @@
   transition: background-color ease-out 0.1s;
   &.active {
     background-color: var(--accent-weak);
-    box-shadow: 0px 0px 0px 1px var(--accent-strong);
+    box-shadow: 0px 0px 0px 0px var(--accent-strong);
+    border-left: var(--half-unit) solid var(--accent-strong);
   }
   &:focus {
     box-shadow: inset 0px 0px 0px 2px var(--accent-strong);
@@ -28,4 +29,21 @@
   color: var(--text-faint-strong);
   justify-content: space-between;
   width: 100%;
+}
+
+.linkContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--unit);
+  font-family: var(--font-family);
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.markdown {
+  & p {
+    margin: 0;
+  }
 }

--- a/src/features/events_list/components/EventCard/EventCard.module.css
+++ b/src/features/events_list/components/EventCard/EventCard.module.css
@@ -35,11 +35,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--unit);
-  font-family: var(--font-family);
-  font-style: normal;
-  font-weight: normal;
-  font-size: 12px;
-  line-height: 16px;
+  font: var(--font-xs);
 }
 
 .markdown {

--- a/src/features/events_list/components/EventCard/EventCard.tsx
+++ b/src/features/events_list/components/EventCard/EventCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import cn from 'clsx';
+import cn, { clsx } from 'clsx';
 import { parseISO } from 'date-fns';
 import { Text } from '@konturio/ui-kit';
 import ReactMarkdown from 'react-markdown';
@@ -62,18 +62,16 @@ export function EventCard({
       />
 
       {isActive && externalUrls?.length ? (
-        <div>
-          <div className={s.linkContainer}>
-            {externalUrls.map((link) => (
-              <ReactMarkdown
-                components={{ a: ShortLinkRenderer, p: (props) => <div {...props} /> }}
-                className={s.markdown}
-                key={nanoid(4)}
-              >
-                {parseLinksAsTags(link)}
-              </ReactMarkdown>
-            ))}
-          </div>
+        <div className={clsx(s.linkContainer)}>
+          {externalUrls.map((link) => (
+            <ReactMarkdown
+              components={{ a: ShortLinkRenderer, p: (props) => <div {...props} /> }}
+              className={s.markdown}
+              key={nanoid(4)}
+            >
+              {parseLinksAsTags(link)}
+            </ReactMarkdown>
+          ))}
         </div>
       ) : null}
 

--- a/src/features/events_list/components/EventCard/EventCard.tsx
+++ b/src/features/events_list/components/EventCard/EventCard.tsx
@@ -2,8 +2,12 @@ import { useMemo } from 'react';
 import cn from 'clsx';
 import { parseISO } from 'date-fns';
 import { Text } from '@konturio/ui-kit';
+import ReactMarkdown from 'react-markdown';
+import { nanoid } from 'nanoid';
 import { SeverityIndicator } from '~components/SeverityIndicator/SeverityIndicator';
 import { i18n } from '~core/localization';
+import { ShortLinkRenderer } from '~components/LinkRenderer/LinkRenderer';
+import { parseLinksAsTags } from '~utils/markdown/parser';
 import { Analytics } from './Analytics/Analytics';
 import s from './EventCard.module.css';
 import type { Event } from '~core/types';
@@ -25,11 +29,13 @@ export function EventCard({
   isActive,
   onClick,
   alternativeActionControl,
+  externalUrls,
 }: {
   event: Event;
   isActive: boolean;
   onClick?: (id: string) => void;
   alternativeActionControl: JSX.Element | null;
+  externalUrls?: string[];
 }) {
   const formattedTime = useMemo(
     () => formatTime(parseISO(event.updatedAt)),
@@ -54,6 +60,22 @@ export function EventCard({
         affectedPeople={event.affectedPopulation}
         loss={event.loss}
       />
+
+      {isActive && externalUrls?.length ? (
+        <div>
+          <div className={s.linkContainer}>
+            {externalUrls.map((link) => (
+              <ReactMarkdown
+                components={{ a: ShortLinkRenderer, p: (props) => <div {...props} /> }}
+                className={s.markdown}
+                key={nanoid(4)}
+              >
+                {parseLinksAsTags(link)}
+              </ReactMarkdown>
+            ))}
+          </div>
+        </div>
+      ) : null}
 
       <div className={s.footer}>
         <Text type="caption">{i18n.t('updated') + ` ${formattedTime}`}</Text>

--- a/src/features/events_list/components/EventCard/EventCard.tsx
+++ b/src/features/events_list/components/EventCard/EventCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import cn, { clsx } from 'clsx';
+import cn from 'clsx';
 import { parseISO } from 'date-fns';
 import { Text } from '@konturio/ui-kit';
 import ReactMarkdown from 'react-markdown';
@@ -62,7 +62,7 @@ export function EventCard({
       />
 
       {isActive && externalUrls?.length ? (
-        <div className={clsx(s.linkContainer)}>
+        <div className={s.linkContainer}>
           {externalUrls.map((link) => (
             <ReactMarkdown
               components={{ a: ShortLinkRenderer, p: (props) => <div {...props} /> }}

--- a/src/features/events_list/components/FullState/FullState.tsx
+++ b/src/features/events_list/components/FullState/FullState.tsx
@@ -73,6 +73,7 @@ export function FullState({
                         />
                       ) : null
                     }
+                    externalUrls={event.externalUrls}
                   />
                 )}
                 ref={virtuoso}

--- a/src/features/events_list/components/ShortState/ShortState.tsx
+++ b/src/features/events_list/components/ShortState/ShortState.tsx
@@ -10,7 +10,7 @@ import { eventListResourceAtom } from '~features/events_list/atoms/eventListReso
 import { EpisodeTimelineToggle } from '../EpisodeTimelineToggle/EpisodeTimelineToggle';
 import { EventCard } from '../EventCard/EventCard';
 import s from './ShortState.module.css';
-import type { MouseEventHandler} from 'react';
+import type { MouseEventHandler } from 'react';
 import type { Event } from '~core/types';
 
 const SingleEventCard = ({
@@ -26,6 +26,7 @@ const SingleEventCard = ({
     alternativeActionControl={
       hasTimeline ? <EpisodeTimelineToggle isActive={true} /> : null
     }
+    externalUrls={event.externalUrls}
   />
 );
 


### PR DESCRIPTION
Links moved from analytics to active event card according to new design
![image](https://user-images.githubusercontent.com/50058726/205611243-9ce8100c-a4b8-4ab6-b3ae-b02799fbe07e.png)
 