### PR TITLE
fix(bivariate-hexagon-tooltip): 12683 - add missing label processing

### DIFF
--- a/src/components/MapHexTooltip/MapHexTooltip.tsx
+++ b/src/components/MapHexTooltip/MapHexTooltip.tsx
@@ -7,6 +7,7 @@ import {
   LOW,
   MEDIUM,
 } from '~components/BivariateLegend/const';
+import { formatBivariateAxisLabel } from '~utils/bivariate';
 import s from './MapHexTooltip.module.css';
 import type { BivariateLegend } from '~core/logical_layers/types/legends';
 
@@ -47,8 +48,8 @@ export const MapHexTooltip = ({
 
       <div className={s.labels}>
         <div className={s.column}>
-          <span>{axis.x.label}</span>
-          <span>{axis.y.label}</span>
+          <span>{axis.x.label || formatBivariateAxisLabel(axis.x.quotients)}</span>
+          <span>{axis.y.label || formatBivariateAxisLabel(axis.y.quotients)}</span>
         </div>
 
         {values && (


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Missing-axes-names-on-the-tooltip-13683
![image](https://user-images.githubusercontent.com/20676525/205943322-eb670422-a1ef-47ca-b7be-5c3aa76f0970.png)
