### PR TITLE
fix(bivariate-matrix): 11443 - fix cutted icons of the denominators 

### DIFF
--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -552,6 +552,12 @@ msgstr ""
 msgid "Applied on the map"
 msgstr ""
 
+#: bivariate##matrix##loading_error
+msgid ""
+"Unfortunately, we cannot display the matrix. Try refreshing the page or "
+"come back later."
+msgstr ""
+
 #: bivariate##legend##high
 msgid "High"
 msgstr ""

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -183,7 +183,8 @@
       "progress": {
         "rendering": "Rendering",
         "applied": "Applied on the map"
-      }
+      },
+      "loading_error": "Unfortunately, we cannot display the matrix. Try refreshing the page or come back later."
     },
     "legend": {
       "high": "High",

--- a/src/features/bivariate_manager/atoms/bivariateMatrixSelection.ts
+++ b/src/features/bivariate_manager/atoms/bivariateMatrixSelection.ts
@@ -12,17 +12,12 @@ import { bivariateNumeratorsAtom } from '~features/bivariate_manager/atoms/bivar
 import { layersSettingsAtom } from '~core/logical_layers/atoms/layersSettings';
 import { createUpdateLayerActions } from '~core/logical_layers/utils/createUpdateActions';
 import { BivariateRenderer } from '~core/logical_layers/renderers/BivariateRenderer';
+import { onCalculateSelectedCell, selectQuotientInGroupByNumDen } from './utils';
+import type { SelectionInput } from './utils';
 import type { AxisGroup, ColorTheme } from '~core/types';
 import type { BivariateLayerStyle } from '~utils/bivariate/bivariateColorThemeUtils';
 import type { LogicalLayerState } from '~core/logical_layers/types/logicalLayer';
 import type { BivariateLegend } from '~core/logical_layers/types/legends';
-
-type SelectionInput = {
-  xNumerator: string | null;
-  xDenominator: string | null;
-  yNumerator: string | null;
-  yDenominator: string | null;
-};
 
 type SelectCellCallback = (x: number, y: number) => void;
 
@@ -380,48 +375,3 @@ export const bivariateMatrixSelectionAtom = createAtom(
   },
   'bivariateMatrixSelection',
 );
-
-const selectQuotientInGroupByNumDen = (
-  groups: AxisGroup[],
-  numId: string,
-  denId: string,
-): AxisGroup[] => {
-  const newGroups = [...groups];
-
-  let selectedQuotient;
-  const groupIndex = newGroups.findIndex(({ quotients }) => {
-    selectedQuotient = quotients.find(
-      (q: [string, string]) => q[0] === numId && q[1] === denId,
-    );
-    return selectedQuotient;
-  });
-
-  if (selectedQuotient) {
-    newGroups[groupIndex] = { ...newGroups[groupIndex], selectedQuotient };
-  }
-
-  return newGroups;
-};
-
-const onCalculateSelectedCell = (
-  xGroups: AxisGroup[],
-  yGroups: AxisGroup[],
-  matrixSelection: SelectionInput,
-): { x: number; y: number } => {
-  const xIndex = xGroups
-    ? xGroups.findIndex(
-        (group) =>
-          group.selectedQuotient[0] === matrixSelection?.xNumerator &&
-          group.selectedQuotient[1] === matrixSelection?.xDenominator,
-      )
-    : -1;
-  const yIndex = yGroups
-    ? yGroups.findIndex(
-        (group) =>
-          group.selectedQuotient[0] === matrixSelection?.yNumerator &&
-          group.selectedQuotient[1] === matrixSelection?.yDenominator,
-      )
-    : -1;
-
-  return { x: xIndex, y: yIndex };
-};

--- a/src/features/bivariate_manager/atoms/utils.test.ts
+++ b/src/features/bivariate_manager/atoms/utils.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from 'vitest';
+import { onCalculateSelectedCell } from './utils';
+import type { AxisGroup } from '~core/types';
+
+test('onCalculateSelectedCell', () => {
+  const xGroups = [
+    {
+      parent: '["avgmax_ts","one"]',
+      selectedQuotient: ['avgmax_ts', 'one'],
+    },
+    {
+      parent: '["count","area_km2"]',
+      selectedQuotient: ['count', 'area_km2'],
+    },
+    {
+      parent: '["building_count","area_km2"]',
+      selectedQuotient: ['building_count', 'area_km2'],
+    },
+    {
+      parent: '["total_hours","area_km2"]',
+      selectedQuotient: ['total_hours', 'area_km2'],
+    },
+    {
+      parent: '["view_count","area_km2"]',
+      selectedQuotient: ['view_count', 'area_km2'],
+    },
+    {
+      parent: '["local_hours","area_km2"]',
+      selectedQuotient: ['local_hours', 'area_km2'],
+    },
+    {
+      parent: '["days_mintemp_above_25c_1c","one"]',
+      selectedQuotient: ['days_mintemp_above_25c_1c', 'one'],
+    },
+    {
+      parent: '["highway_length","area_km2"]',
+      selectedQuotient: ['highway_length', 'area_km2'],
+    },
+    {
+      parent: '["herbage","total_road_length"]',
+      selectedQuotient: ['herbage', 'total_road_length'],
+    },
+  ] as AxisGroup[];
+
+  const yGroups = [
+    {
+      parent: '["avgmax_ts","one"]',
+      selectedQuotient: ['avgmax_ts', 'one'],
+    },
+    {
+      parent: '["count","area_km2"]',
+      selectedQuotient: ['count', 'area_km2'],
+    },
+    {
+      parent: '["building_count","area_km2"]',
+      selectedQuotient: ['building_count', 'area_km2'],
+    },
+    {
+      parent: '["population","area_km2"]',
+      selectedQuotient: ['population', 'area_km2'],
+    },
+    {
+      parent: '["total_hours","area_km2"]',
+      selectedQuotient: ['total_hours', 'area_km2'],
+    },
+    {
+      parent: '["view_count","area_km2"]',
+      selectedQuotient: ['view_count', 'area_km2'],
+    },
+    {
+      parent: '["local_hours","area_km2"]',
+      selectedQuotient: ['local_hours', 'area_km2'],
+    },
+    {
+      parent: '["days_mintemp_above_25c_1c","one"]',
+      selectedQuotient: ['days_mintemp_above_25c_1c', 'one'],
+    },
+    {
+      parent: '["highway_length","area_km2"]',
+      selectedQuotient: ['highway_length', 'area_km2'],
+    },
+    {
+      parent: '["herbage","total_road_length"]',
+      selectedQuotient: ['herbage', 'total_road_length'],
+    },
+  ] as AxisGroup[];
+
+  expect(
+    onCalculateSelectedCell(xGroups, yGroups, {
+      xNumerator: 'local_hours',
+      xDenominator: 'area_km2',
+      yNumerator: 'total_hours',
+      yDenominator: 'area_km2',
+    }),
+  ).toEqual({
+    x: 5,
+    y: 4,
+  });
+
+  expect(
+    onCalculateSelectedCell(xGroups, yGroups, {
+      xNumerator: 'highway_length',
+      xDenominator: 'total_road_length',
+      yNumerator: 'population',
+      yDenominator: 'area_km2',
+    }),
+  ).toEqual({
+    x: -1,
+    y: 3,
+  });
+});

--- a/src/features/bivariate_manager/atoms/utils.ts
+++ b/src/features/bivariate_manager/atoms/utils.ts
@@ -1,0 +1,53 @@
+import type { AxisGroup } from '~core/types';
+
+export type SelectionInput = {
+  xNumerator: string | null;
+  xDenominator: string | null;
+  yNumerator: string | null;
+  yDenominator: string | null;
+};
+
+export const onCalculateSelectedCell = (
+  xGroups: AxisGroup[],
+  yGroups: AxisGroup[],
+  matrixSelection: SelectionInput,
+): { x: number; y: number } => {
+  const xIndex = xGroups
+    ? xGroups.findIndex(
+        (group) =>
+          group.selectedQuotient[0] === matrixSelection?.xNumerator &&
+          group.selectedQuotient[1] === matrixSelection?.xDenominator,
+      )
+    : -1;
+  const yIndex = yGroups
+    ? yGroups.findIndex(
+        (group) =>
+          group.selectedQuotient[0] === matrixSelection?.yNumerator &&
+          group.selectedQuotient[1] === matrixSelection?.yDenominator,
+      )
+    : -1;
+
+  return { x: xIndex, y: yIndex };
+};
+
+export const selectQuotientInGroupByNumDen = (
+  groups: AxisGroup[],
+  numId: string,
+  denId: string,
+): AxisGroup[] => {
+  const newGroups = [...groups];
+
+  let selectedQuotient;
+  const groupIndex = newGroups.findIndex(({ quotients }) => {
+    selectedQuotient = quotients.find(
+      (q: [string, string]) => q[0] === numId && q[1] === denId,
+    );
+    return selectedQuotient;
+  });
+
+  if (selectedQuotient) {
+    newGroups[groupIndex] = { ...newGroups[groupIndex], selectedQuotient };
+  }
+
+  return newGroups;
+};

--- a/src/features/bivariate_manager/components/BivariateMatrixContainer/BivariateMatrixContainer.module.css
+++ b/src/features/bivariate_manager/components/BivariateMatrixContainer/BivariateMatrixContainer.module.css
@@ -1,5 +1,8 @@
 .bivariateContainer {
   overflow: hidden;
+  margin-top: 50px; /* panel header offset */
+  display: flex;
+  justify-content: flex-end;
 }
 
 .header {
@@ -20,17 +23,6 @@
     line-height: 16px;
     color: var(--faint-strong-up);
   }
-}
-
-.matrixContainer {
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transform: scale(0.7);
-  position: relative;
-  left: 100px;
-  top: 40px;
 }
 
 .loadingContainer {

--- a/src/features/bivariate_manager/components/BivariateMatrixContainer/bivariateMatrixContext.ts
+++ b/src/features/bivariate_manager/components/BivariateMatrixContainer/bivariateMatrixContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+export type MatrixPositionRecalculatedCb = (
+  baseDimension: number,
+  matrixSize: number,
+) => void;
+
+export interface BivariateMatrixContextInterface {
+  onMatrixPositionRecalculated: MatrixPositionRecalculatedCb;
+}
+
+export const BivariateMatrixContext =
+  createContext<BivariateMatrixContextInterface | null>(null);

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/components/AxisCaptions/AxisCaptions.module.css
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/components/AxisCaptions/AxisCaptions.module.css
@@ -5,7 +5,6 @@
 
 .axisCaptionAnchor {
   position: absolute;
-  top: -15;
 }
 
 .axisCaptionBody {

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixCell/BivariateMatrixCell.module.css
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixCell/BivariateMatrixCell.module.css
@@ -12,6 +12,8 @@
   font-size: 12px;
   cursor: pointer;
   border: 1px dashed #eee;
+  height: 37px;
+  width: 37px;
 }
 
 .rotatedCell {

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixConnector/BivariateMatrixCellConnector.module.css
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixConnector/BivariateMatrixCellConnector.module.css
@@ -17,6 +17,14 @@
   height: 100%;
 }
 
+.horConnector > div {
+  transform: skewY(22.5deg);
+}
+
+.vertConnector > div {
+  transform: skewX(22.5deg);
+}
+
 .horConnector > div.hovered,
 .vertConnector > div.hovered {
   background: var(--hover-bg-color);

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixHeadingEntry/BivariateMatrixHeadingEntry.module.css
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixHeadingEntry/BivariateMatrixHeadingEntry.module.css
@@ -60,9 +60,9 @@
   content: '';
   position: absolute;
   top: 100%;
-  left: -1.5px;
-  width: 24px;
-  height: 23px;
+  left: 100%;
+  width: 1px;
+  height: 22px;
   border-right: var(--header-border-style);
   z-index: 1;
 }
@@ -90,8 +90,8 @@
   content: '';
   position: absolute;
   left: 100%;
-  width: 21px;
-  height: 24px;
+  width: 22px;
+  height: 23px;
   border-bottom: var(--header-border-style);
   z-index: 1;
 }

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixHeadingEntry/BivariateMatrixHeadingEntry.tsx
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixHeadingEntry/BivariateMatrixHeadingEntry.tsx
@@ -26,11 +26,11 @@ interface BivariateMatrixHeadingEntry {
       id: [string, string];
       label?: string;
     };
-    quality?: number;
+    quality?: string;
     quotients: {
       id: [string, string];
       label?: string;
-      quality?: number;
+      quality?: string;
     }[];
   };
   id: string;

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/components/QuotientSelector/QuotientSelector.tsx
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/components/QuotientSelector/QuotientSelector.tsx
@@ -8,7 +8,7 @@ interface QuotientItemProps {
   numeratorId: string;
   denominatorId: string;
   numeratorLabel?: string;
-  quality?: number | null;
+  quality?: string | null;
   isSelected?: boolean;
   onSelectQuotient: (numId: string, denId: string) => void;
 }
@@ -45,7 +45,7 @@ const QuotientItem = ({
 type Quotient = {
   id: [string, string];
   label?: string;
-  quality?: number;
+  quality?: string;
 };
 
 interface QuotientSelectorProps {

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/constants.ts
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/constants.ts
@@ -1,3 +1,7 @@
-// auto-size calculation params
-export const BIVARIATE_MATRIX_WIDTH_SHIFT = 25.5;
-export const BIVARIATE_MATRIX_HEIGHT_SHIFT = 27.5;
+export const MATRIX_CELL_SIDE = 37; // from .valueCell
+export const MATRIX_SCALE = 0.7; // from .rotatedMatrix
+export const AXIS_CAPTIONS_WIDTH = 20; // width of <AxisCaptions>
+
+// we use a Pythagorean theorem to calculate the side of isosceles triangle by it's hypotenuse
+export const BIVARIATE_MATRIX_WIDTH_SHIFT = MATRIX_CELL_SIDE / Math.sqrt(2);
+export const BIVARIATE_MATRIX_HEIGHT_SHIFT = MATRIX_CELL_SIDE / Math.sqrt(2);

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/index.tsx
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/index.tsx
@@ -1,6 +1,7 @@
-import { forwardRef, memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { useAction } from '@reatom/react';
 import { bivariateMatrixSelectionAtom } from '~features/bivariate_manager/atoms/bivariateMatrixSelection';
+import { BivariateMatrixContext } from '../BivariateMatrixContainer/bivariateMatrixContext';
 import {
   calculateHeadingsStyle,
   generateCellStyles,
@@ -12,16 +13,18 @@ import styles from './style.module.css';
 import { BivariateMatrixCellConnector } from './components/BivariateMatrixConnector/BivariateMatrixCellConnector';
 import { BivariateMatrixHeadingEntry } from './components/BivariateMatrixHeadingEntry/BivariateMatrixHeadingEntry';
 import { AxisCaptions } from './components/AxisCaptions/AxisCaptions';
+import { MATRIX_CELL_SIDE, MATRIX_SCALE } from './constants';
 import type { BivariateMatrixHeadingType } from './types';
 import type { MouseEvent } from 'react';
 
 const CELL_INDEX_X_OFFSET = 3;
 const CELL_INDEX_Y_OFFSET = 3;
+const MATRIX_CORNERS_OVERFLOW = 15;
 
 interface BivariateMatrixControlProps {
   angle?: number;
   onSelectCell: (x: number, y: number, e?: MouseEvent<Element>) => void;
-  selectedCell?: { x: number; y: number };
+  selectedCell: { x: number; y: number } | null;
   cellSize?: number;
   matrix: (number | null)[][];
   xHeadings: BivariateMatrixHeadingType[];
@@ -35,291 +38,316 @@ interface BivariateMatrixControlProps {
   ) => void;
 }
 
-const BivariateMatrixControl = forwardRef<HTMLDivElement | null, any>(
-  (
-    {
-      matrix,
-      xHeadings,
-      yHeadings,
-      onSelectCell,
-      selectedCell,
-      cellSize = 0,
-      onSelectQuotient,
-    }: BivariateMatrixControlProps,
-    ref: any,
-  ) => {
-    const cellRowReferences: any[] = [];
-    const cellColumnReferences: any[] = [];
-    let hoveredColIndex = -1;
-    let hoveredRowIndex = -1;
-    const selectedColIndex = useRef(selectedCell?.x ?? -1);
-    const selectedRowIndex = useRef(selectedCell?.y ?? -1);
+const BivariateMatrixControl = ({
+  matrix,
+  xHeadings,
+  yHeadings,
+  onSelectCell,
+  selectedCell,
+  cellSize = 0,
+  onSelectQuotient,
+}: BivariateMatrixControlProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const bivariateMatrixContext = useContext(BivariateMatrixContext);
+  const cellRowReferences: any[] = [];
+  const cellColumnReferences: any[] = [];
+  let hoveredColIndex = -1;
+  let hoveredRowIndex = -1;
+  const selectedColIndex = useRef(selectedCell?.x ?? -1);
+  const selectedRowIndex = useRef(selectedCell?.y ?? -1);
 
-    const setSelectCellCallback = useAction(
-      bivariateMatrixSelectionAtom.setSelectCellCallback,
-    );
+  const setSelectCellCallback = useAction(
+    bivariateMatrixSelectionAtom.setSelectCellCallback,
+  );
 
-    const setCellReference = (ref, rowIndex, colIndex) => {
-      if (rowIndex >= 0) {
-        if (!cellRowReferences[rowIndex]) {
-          cellRowReferences[rowIndex] = [];
-        }
-        cellRowReferences[rowIndex].push(ref);
+  const setCellReference = (ref, rowIndex, colIndex) => {
+    if (rowIndex >= 0) {
+      if (!cellRowReferences[rowIndex]) {
+        cellRowReferences[rowIndex] = [];
       }
+      cellRowReferences[rowIndex].push(ref);
+    }
 
-      if (colIndex >= 0) {
-        if (!cellColumnReferences[colIndex]) {
-          cellColumnReferences[colIndex] = [];
-        }
-        cellColumnReferences[colIndex].push(ref);
+    if (colIndex >= 0) {
+      if (!cellColumnReferences[colIndex]) {
+        cellColumnReferences[colIndex] = [];
       }
-    };
+      cellColumnReferences[colIndex].push(ref);
+    }
+  };
 
-    const onMouseOver = (x: number, y: number) => {
-      if (hoveredColIndex !== x) {
-        hoveredColIndex = x;
-        if (hoveredColIndex !== -1) {
-          const columns = cellColumnReferences[hoveredColIndex];
-          if (columns) {
-            columns.forEach((clmn) => {
-              clmn?.setHovered();
-            });
-          }
-        }
-      }
-
-      if (hoveredRowIndex !== y) {
-        hoveredRowIndex = y;
-        if (hoveredRowIndex !== -1) {
-          const rows = cellRowReferences[hoveredRowIndex];
-          if (rows) {
-            rows.forEach((rw) => {
-              rw?.setHovered();
-            });
-          }
-        }
-      }
-    };
-
-    const onMouseOut = () => {
+  const onMouseOver = (x: number, y: number) => {
+    if (hoveredColIndex !== x) {
+      hoveredColIndex = x;
       if (hoveredColIndex !== -1) {
         const columns = cellColumnReferences[hoveredColIndex];
         if (columns) {
           columns.forEach((clmn) => {
-            clmn?.resetHovered();
+            clmn?.setHovered();
           });
         }
-        hoveredColIndex = -1;
       }
+    }
 
+    if (hoveredRowIndex !== y) {
+      hoveredRowIndex = y;
       if (hoveredRowIndex !== -1) {
         const rows = cellRowReferences[hoveredRowIndex];
         if (rows) {
           rows.forEach((rw) => {
-            rw?.resetHovered();
-          });
-        }
-        hoveredRowIndex = -1;
-      }
-    };
-
-    const onCellHoverX = (cellIndex: number | null) => {
-      onMouseOut();
-      if (cellIndex) {
-        onMouseOver(cellIndex, hoveredRowIndex);
-      }
-    };
-
-    const onCellHoverY = (cellIndex: number | null) => {
-      onMouseOut();
-      if (cellIndex) {
-        onMouseOver(hoveredColIndex, cellIndex);
-      }
-    };
-
-    const onResetSelected = () => {
-      if (selectedColIndex.current !== -1) {
-        const columns = cellColumnReferences[selectedColIndex.current];
-        if (columns) {
-          columns.forEach((clmn) => {
-            clmn?.resetSelectedCol();
-          });
-        }
-        selectedColIndex.current = -1;
-      }
-
-      if (selectedRowIndex.current !== -1) {
-        const rows = cellRowReferences[selectedRowIndex.current];
-        if (rows) {
-          rows.forEach((rw) => {
-            rw?.resetSelectedRow();
-          });
-        }
-        selectedRowIndex.current = -1;
-      }
-    };
-
-    // onInnerSelect is triggered only when clicking by mouse on matrix elements
-    const onInnerSelect = (x: number, y: number, e?: MouseEvent<Element>) => {
-      onResetSelected();
-      onSelectRowCol(x, y);
-      onSelectCell(x, y, e);
-    };
-
-    // onOuterSelect is triggered only when you select overlay and we need to preselect layers in matrix
-    const onOuterSelect = (x: number, y: number) => {
-      onResetSelected();
-      onSelectRowCol(x, y);
-    };
-
-    const onSelectRowCol = (x: number, y: number) => {
-      if (x !== -1 && selectedColIndex.current !== x) {
-        selectedColIndex.current = x;
-        const columns = cellColumnReferences[selectedColIndex.current];
-        if (columns) {
-          columns.forEach((clmn) => {
-            clmn?.setSelectedCol();
+            rw?.setHovered();
           });
         }
       }
+    }
+  };
 
-      if (y !== -1 && selectedRowIndex.current !== y) {
-        selectedRowIndex.current = y;
-        const rows = cellRowReferences[selectedRowIndex.current];
-        if (rows) {
-          rows.forEach((rw) => {
-            rw?.setSelectedRow();
-          });
-        }
+  const onMouseOut = () => {
+    if (hoveredColIndex !== -1) {
+      const columns = cellColumnReferences[hoveredColIndex];
+      if (columns) {
+        columns.forEach((clmn) => {
+          clmn?.resetHovered();
+        });
       }
-    };
+      hoveredColIndex = -1;
+    }
 
-    const onCellSelectX = (cellIndex: number, e: MouseEvent<Element>) => {
-      onInnerSelect(cellIndex, selectedRowIndex.current, e);
-    };
+    if (hoveredRowIndex !== -1) {
+      const rows = cellRowReferences[hoveredRowIndex];
+      if (rows) {
+        rows.forEach((rw) => {
+          rw?.resetHovered();
+        });
+      }
+      hoveredRowIndex = -1;
+    }
+  };
 
-    const onCellSelectY = (cellIndex: number, e: MouseEvent<Element>) => {
-      onInnerSelect(selectedColIndex.current, cellIndex, e);
-    };
+  const onCellHoverX = (cellIndex: number | null) => {
+    onMouseOut();
+    if (cellIndex) {
+      onMouseOver(cellIndex, hoveredRowIndex);
+    }
+  };
 
-    const selectQuotientX = useCallback(
-      (index: number, numId: string, denId: string, e?: MouseEvent<Element>) => {
-        onSelectQuotient(false, index, numId, denId, e);
-      },
-      [onSelectQuotient],
+  const onCellHoverY = (cellIndex: number | null) => {
+    onMouseOut();
+    if (cellIndex) {
+      onMouseOver(hoveredColIndex, cellIndex);
+    }
+  };
+
+  const onResetSelected = () => {
+    if (selectedColIndex.current !== -1) {
+      const columns = cellColumnReferences[selectedColIndex.current];
+      if (columns) {
+        columns.forEach((clmn) => {
+          clmn?.resetSelectedCol();
+        });
+      }
+      selectedColIndex.current = -1;
+    }
+
+    if (selectedRowIndex.current !== -1) {
+      const rows = cellRowReferences[selectedRowIndex.current];
+      if (rows) {
+        rows.forEach((rw) => {
+          rw?.resetSelectedRow();
+        });
+      }
+      selectedRowIndex.current = -1;
+    }
+  };
+
+  // onInnerSelect is triggered only when clicking by mouse on matrix elements
+  const onInnerSelect = (x: number, y: number, e?: MouseEvent<Element>) => {
+    onResetSelected();
+    onSelectRowCol(x, y);
+    onSelectCell(x, y, e);
+  };
+
+  // onOuterSelect is triggered only when you select overlay and we need to preselect layers in matrix
+  const onOuterSelect = (x: number, y: number) => {
+    onResetSelected();
+    onSelectRowCol(x, y);
+  };
+
+  const onSelectRowCol = (x: number, y: number) => {
+    if (x !== -1 && selectedColIndex.current !== x) {
+      selectedColIndex.current = x;
+      const columns = cellColumnReferences[selectedColIndex.current];
+      if (columns) {
+        columns.forEach((clmn) => {
+          clmn?.setSelectedCol();
+        });
+      }
+    }
+
+    if (y !== -1 && selectedRowIndex.current !== y) {
+      selectedRowIndex.current = y;
+      const rows = cellRowReferences[selectedRowIndex.current];
+      if (rows) {
+        rows.forEach((rw) => {
+          rw?.setSelectedRow();
+        });
+      }
+    }
+  };
+
+  const onCellSelectX = (cellIndex: number, e: MouseEvent<Element>) => {
+    onInnerSelect(cellIndex, selectedRowIndex.current, e);
+  };
+
+  const onCellSelectY = (cellIndex: number, e: MouseEvent<Element>) => {
+    onInnerSelect(selectedColIndex.current, cellIndex, e);
+  };
+
+  const selectQuotientX = useCallback(
+    (index: number, numId: string, denId: string, e?: MouseEvent<Element>) => {
+      onSelectQuotient(false, index, numId, denId, e);
+    },
+    [onSelectQuotient],
+  );
+
+  const selectQuotientY = useCallback(
+    (index: number, numId: string, denId: string, e?: MouseEvent<Element>) => {
+      onSelectQuotient(true, index, numId, denId, e);
+    },
+    [onSelectQuotient],
+  );
+
+  const baseDimension = useBaseMatrixDimension(xHeadings, yHeadings);
+  const rotatedMatrixWrapperSide =
+    Math.sqrt(
+      Math.pow(xHeadings.length * MATRIX_CELL_SIDE, 2) +
+        Math.pow(yHeadings.length * MATRIX_CELL_SIDE, 2),
+    ) *
+      MATRIX_SCALE +
+    MATRIX_CORNERS_OVERFLOW;
+
+  useEffect(() => {
+    bivariateMatrixContext?.onMatrixPositionRecalculated(
+      baseDimension,
+      rotatedMatrixWrapperSide,
     );
 
-    const selectQuotientY = useCallback(
-      (index: number, numId: string, denId: string, e?: MouseEvent<Element>) => {
-        onSelectQuotient(true, index, numId, denId, e);
-      },
-      [onSelectQuotient],
+    // we hide matrix before all placements calculated
+    if (containerRef.current) containerRef.current.style.visibility = 'visible';
+  }, [baseDimension]);
+
+  const gridStyle = useGridStyle(xHeadings.length + 1, yHeadings.length + 1, cellSize);
+  const matrixContainerStyles = useMemo(
+    () => ({
+      width: rotatedMatrixWrapperSide,
+      height: rotatedMatrixWrapperSide,
+    }),
+    [rotatedMatrixWrapperSide],
+  );
+  const cellStyles = useMemo(() => {
+    return generateCellStyles(
+      xHeadings.length + CELL_INDEX_X_OFFSET,
+      yHeadings.length + CELL_INDEX_Y_OFFSET,
     );
+  }, [xHeadings, yHeadings]);
 
-    const baseDimension = useBaseMatrixDimension(xHeadings, yHeadings);
-    const gridStyle = useGridStyle(xHeadings.length + 1, yHeadings.length + 1, cellSize);
+  useEffect(() => {
+    setSelectCellCallback(onOuterSelect.bind(this));
+    if (selectedCell && (selectedCell.x !== -1 || selectedCell.y !== -1)) {
+      onOuterSelect(selectedCell.x, selectedCell.y);
+    }
+  }, [matrix]);
 
-    const cellStyles = useMemo(() => {
-      return generateCellStyles(
-        xHeadings.length + CELL_INDEX_X_OFFSET,
-        yHeadings.length + CELL_INDEX_Y_OFFSET,
-      );
-    }, [xHeadings, yHeadings]);
+  return (
+    <div
+      ref={containerRef}
+      className={styles.matrixContainer}
+      style={matrixContainerStyles}
+    >
+      <div style={gridStyle} className={styles.rotatedMatrix}>
+        {matrix.map((_row, rowIndex) => (
+          <BivariateMatrixCellConnector
+            key={`${rowIndex}_row_connector`}
+            type="horizontal"
+            style={cellStyles[-1 + CELL_INDEX_X_OFFSET][rowIndex + CELL_INDEX_Y_OFFSET]}
+            ref={(rf) => setCellReference(rf, rowIndex, -1)}
+          />
+        ))}
+        {matrix[0].map((_col, colIndex) => (
+          <BivariateMatrixCellConnector
+            key={`${colIndex}_col_connector`}
+            type="vertical"
+            style={cellStyles[colIndex + CELL_INDEX_X_OFFSET][-1 + CELL_INDEX_Y_OFFSET]}
+            ref={(rf) => setCellReference(rf, -1, colIndex)}
+          />
+        ))}
 
-    useEffect(() => {
-      setSelectCellCallback(onOuterSelect.bind(this));
-      if (selectedCell && (selectedCell.x !== -1 || selectedCell.y !== -1)) {
-        onOuterSelect(selectedCell.x, selectedCell.y);
-      }
-    }, [matrix]);
+        {matrix.map((row, rowIndex) =>
+          row.map((val, colIndex) => {
+            return (
+              <BivariateMatrixCell
+                x={colIndex}
+                y={rowIndex}
+                key={`matrix_cell_${colIndex}_${rowIndex}`}
+                onClick={onInnerSelect}
+                onMouseOver={onMouseOver}
+                onMouseOut={onMouseOut}
+                style={
+                  cellStyles[colIndex + CELL_INDEX_X_OFFSET][
+                    rowIndex + CELL_INDEX_Y_OFFSET
+                  ]
+                }
+                ref={(rf) => setCellReference(rf, rowIndex, colIndex)}
+                value={val === null ? undefined : val}
+                disabled={val === null}
+                firstRow={rowIndex === 0}
+                firstCol={colIndex === 0}
+                lastRow={rowIndex === matrix.length - 1}
+                lastCol={colIndex === row.length - 1}
+              />
+            );
+          }),
+        )}
 
-    return (
-      <div ref={ref} data-base-dimension={baseDimension} className={styles.rotatedMatrix}>
-        <div style={gridStyle}>
-          {matrix.map((row, rowIndex) => (
-            <BivariateMatrixCellConnector
-              key={`${rowIndex}_row_connector`}
-              type="horizontal"
-              style={cellStyles[-1 + CELL_INDEX_X_OFFSET][rowIndex + CELL_INDEX_Y_OFFSET]}
-              ref={(rf) => setCellReference(rf, rowIndex, -1)}
-            />
-          ))}
-          {matrix[0].map((col, colIndex) => (
-            <BivariateMatrixCellConnector
-              key={`${colIndex}_col_connector`}
-              type="vertical"
-              style={cellStyles[colIndex + CELL_INDEX_X_OFFSET][-1 + CELL_INDEX_Y_OFFSET]}
-              ref={(rf) => setCellReference(rf, -1, colIndex)}
-            />
-          ))}
+        {[...yHeadings].reverse().map((entry, index) => (
+          <BivariateMatrixHeadingEntry
+            key={`hor_${yHeadings.length - 1 - index}`}
+            id={`hor_${yHeadings.length - 1 - index}`}
+            index={yHeadings.length - 1 - index}
+            type="horizontal"
+            selectedIndex={selectedCell?.y}
+            headerCell={entry}
+            onCellHover={onCellHoverY}
+            onCellClick={onCellSelectY}
+            onSelectQuotient={selectQuotientY}
+            baseDimension={baseDimension}
+            calculateHeadingsStyle={calculateHeadingsStyle}
+            ref={(rf) => setCellReference(rf, yHeadings.length - 1 - index, -1)}
+          />
+        ))}
 
-          {matrix.map((row, rowIndex) =>
-            row.map((val, colIndex) => {
-              return (
-                <BivariateMatrixCell
-                  x={colIndex}
-                  y={rowIndex}
-                  key={`matrix_cell_${colIndex}_${rowIndex}`}
-                  onClick={onInnerSelect}
-                  onMouseOver={onMouseOver}
-                  onMouseOut={onMouseOut}
-                  style={
-                    cellStyles[colIndex + CELL_INDEX_X_OFFSET][
-                      rowIndex + CELL_INDEX_Y_OFFSET
-                    ]
-                  }
-                  ref={(rf) => setCellReference(rf, rowIndex, colIndex)}
-                  value={val === null ? undefined : val}
-                  disabled={val === null}
-                  firstRow={rowIndex === 0}
-                  firstCol={colIndex === 0}
-                  lastRow={rowIndex === matrix.length - 1}
-                  lastCol={colIndex === row.length - 1}
-                />
-              );
-            }),
-          )}
+        <AxisCaptions baseDimension={baseDimension} />
 
-          {[...yHeadings].reverse().map((entry, index) => (
-            <BivariateMatrixHeadingEntry
-              key={`hor_${yHeadings.length - 1 - index}`}
-              id={`hor_${yHeadings.length - 1 - index}`}
-              index={yHeadings.length - 1 - index}
-              type="horizontal"
-              selectedIndex={selectedCell?.y}
-              headerCell={entry}
-              onCellHover={onCellHoverY}
-              onCellClick={onCellSelectY}
-              onSelectQuotient={selectQuotientY}
-              baseDimension={baseDimension}
-              calculateHeadingsStyle={calculateHeadingsStyle}
-              ref={(rf) => setCellReference(rf, yHeadings.length - 1 - index, -1)}
-            />
-          ))}
-
-          <AxisCaptions baseDimension={baseDimension} />
-
-          {xHeadings.map((entry, index) => (
-            <BivariateMatrixHeadingEntry
-              key={`vert_${index}`}
-              id={`vert_${index}`}
-              index={index}
-              type="vertical"
-              selectedIndex={selectedCell?.x}
-              headerCell={entry}
-              onCellHover={onCellHoverX}
-              onCellClick={onCellSelectX}
-              onSelectQuotient={selectQuotientX}
-              baseDimension={baseDimension}
-              calculateHeadingsStyle={calculateHeadingsStyle}
-              ref={(rf) => setCellReference(rf, -1, index)}
-            />
-          ))}
-        </div>
+        {xHeadings.map((entry, index) => (
+          <BivariateMatrixHeadingEntry
+            key={`vert_${index}`}
+            id={`vert_${index}`}
+            index={index}
+            type="vertical"
+            selectedIndex={selectedCell?.x}
+            headerCell={entry}
+            onCellHover={onCellHoverX}
+            onCellClick={onCellSelectX}
+            onSelectQuotient={selectQuotientX}
+            baseDimension={baseDimension}
+            calculateHeadingsStyle={calculateHeadingsStyle}
+            ref={(rf) => setCellReference(rf, -1, index)}
+          />
+        ))}
       </div>
-    );
-  },
-);
+    </div>
+  );
+};
 
 BivariateMatrixControl.displayName = 'BivariateMatrixControl';
 

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/style.module.css
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/style.module.css
@@ -11,6 +11,13 @@
   align-items: flex-end;
 }
 
+.matrixContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  visibility: hidden;
+}
+
 .rotatedMatrix {
-  transform: rotate(-45deg);
+  transform: scale(0.7) rotate(-45deg);
 }

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/types.ts
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/types.ts
@@ -1,22 +1,17 @@
 export type BivariateMatrixQuotientType = {
   id: [string, string];
   label?: string;
-  quality?: number;
+  quality?: string;
 };
 
 export type BivariateMatrixHeadingType = {
   label: string;
   selectedQuotient: BivariateMatrixQuotientType;
-  quality?: number;
+  quality?: string;
   quotients: BivariateMatrixQuotientType[];
 };
 
-export type CornerRange =
-  | 'good'
-  | 'bad'
-  | 'important'
-  | 'unimportant'
-  | 'neutral';
+export type CornerRange = 'good' | 'bad' | 'important' | 'unimportant' | 'neutral';
 
 export type Copyright = string;
 

--- a/src/features/bivariate_manager/components/BivariateMatrixControl/utils/utils.ts
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/utils/utils.ts
@@ -16,12 +16,8 @@ export function useGridStyle(x, y, cellSize = 0) {
     () => ({
       display: 'inline-grid',
       '--cell-size': cellSize === 0 ? 'initial' : `${cellSize}px`,
-      gridTemplateRows: `repeat(${y}, ${
-        cellSize === 0 ? 'auto' : cellSize + 'px'
-      })`,
-      gridTemplateColumns: `repeat(${x}, ${
-        cellSize === 0 ? 'auto' : cellSize + 'px'
-      })`,
+      gridTemplateRows: `repeat(${y}, ${cellSize === 0 ? 'auto' : cellSize + 'px'})`,
+      gridTemplateColumns: `repeat(${x}, ${cellSize === 0 ? 'auto' : cellSize + 'px'})`,
     }),
     [x, y, cellSize],
   );
@@ -49,8 +45,7 @@ export function generateCellStyles(
 export function useBaseMatrixDimension(xHeadings, yHeadings) {
   // calculate base width of header item
   const memoizedBaseDimension = useMemo(() => {
-    if (!xHeadings || !xHeadings.length || !yHeadings || !yHeadings.length)
-      return 0;
+    if (!xHeadings || !xHeadings.length || !yHeadings || !yHeadings.length) return 0;
 
     let xLength = calculateStringWidth(xHeadings[0].label);
     for (let i = 1; i < xHeadings.length; i++) {
@@ -80,9 +75,10 @@ const canvas = document.createElement('canvas');
 const context: any = canvas.getContext('2d') || {};
 context.font = 'normal 13px Roboto';
 
+const QUOTIENT_ICON_SIZE = 30;
+const QUOTIENTS_DROPDOWN_SIZE = 90;
 export function calculateStringWidth(str: string): number {
-  // coeff 0.85 here is because of transform: scale(0.85) applied to matrix
-  return (context.measureText(str).width + 80) / 0.85;
+  return context.measureText(str).width + QUOTIENT_ICON_SIZE + QUOTIENTS_DROPDOWN_SIZE;
 }
 
 export function calculateHeadingsStyle(

--- a/src/features/bivariate_manager/components/ConnectedBivariateMatrix/ConnectedBivariateMatrix.tsx
+++ b/src/features/bivariate_manager/components/ConnectedBivariateMatrix/ConnectedBivariateMatrix.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useAction, useAtom } from '@reatom/react';
 import debounce from 'lodash/debounce';
 import { bivariateMatrixSelectionAtom } from '~features/bivariate_manager/atoms/bivariateMatrixSelection';
@@ -48,7 +48,8 @@ const mapHeaderCell = (
     ),
   })),
 });
-const ConnectedBivariateMatrix = forwardRef<HTMLDivElement | null, any>(({}, ref) => {
+
+const ConnectedBivariateMatrix = () => {
   const [{ selectedCell }, { setMatrixSelection, setPreselectMode }] = useAtom(
     bivariateMatrixSelectionAtom,
   );
@@ -166,7 +167,6 @@ const ConnectedBivariateMatrix = forwardRef<HTMLDivElement | null, any>(({}, ref
 
   return matrix && headings ? (
     <BivariateMatrixControlComponent
-      ref={ref}
       matrix={matrix}
       xHeadings={headings.x}
       yHeadings={headings.y}
@@ -175,7 +175,7 @@ const ConnectedBivariateMatrix = forwardRef<HTMLDivElement | null, any>(({}, ref
       onSelectQuotient={onSelectQuotient}
     />
   ) : null;
-});
+};
 
 ConnectedBivariateMatrix.displayName = 'ConnectedBivariateMatrix';
 

--- a/src/features/bivariate_manager/fixtures/BivariateMatrixControl.fixture.tsx
+++ b/src/features/bivariate_manager/fixtures/BivariateMatrixControl.fixture.tsx
@@ -21,17 +21,15 @@ const mapHeaderCell = (group: AxisGroup, indicators: Indicator[]) => ({
     label: indicators.find((indicator) => indicator.name === group.selectedQuotient[1])
       ?.label,
   },
-  quality: 1,
+  quality: '1',
   quotients: group.quotients.map((quotient) => ({
     id: quotient,
     label: indicators.find((indicator) => indicator.name === quotient[0])?.label,
-    quality: 1,
+    quality: '1',
   })),
 });
 
 export default function BivariateMatrixControlFixture() {
-  const ref = useRef(null);
-
   const headings = useMemo(() => {
     if (
       !mock.indicators ||
@@ -65,10 +63,10 @@ export default function BivariateMatrixControlFixture() {
     setSelectedCell({ x, y });
   }, []);
 
-  const onSelectDenominator = useCallback(
+  const onSelectQuotient = useCallback(
     (horizontal: boolean, index: number, numId: string, denId: string) => {
       /* eslint-disable */
-      console.log('onSelectDenominator', horizontal, index, numId, denId);
+      console.log('onSelectQuotient', horizontal, index, numId, denId);
     },
     [],
   );
@@ -77,13 +75,12 @@ export default function BivariateMatrixControlFixture() {
     <div className={styles.axisMatrix}>
       <Router>
         <BivariateMatrixControlComponent
-          ref={ref}
           matrix={mock.matrix}
-          xHeadings={headings?.x}
-          yHeadings={headings?.y}
+          xHeadings={headings?.x!}
+          yHeadings={headings?.y!}
           onSelectCell={onSelectCellHandler}
           selectedCell={selectedCell}
-          onSelectDenominator={onSelectDenominator}
+          onSelectQuotient={onSelectQuotient}
         />
         <PopupTooltip />
       </Router>


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Cutted-icons-of-the-denominators-in-the-Bivariate-Manager-11443

- removed forwardRef chain and used context for passing callback
- types fixed after forwardRef removed, they were not working
- shifting row/col fixed, matric cell sides are set as particular values
- rotated matrix is wrapped in container with calculated size, and this container is flex-end to the right (that's how matrix jumping fixed, had a discussion there - https://konturio.slack.com/archives/C02DEKP2MKP/p1671023811699569) 
- until calculation finished - matrix is hidden (to prevent first draw jumping)
- small boxes skewed 45/2=22.5 degrees, to help the person to more smoothly follow the bend

Notes: 
src/features/bivariate_manager/components/BivariateMatrixControl/index.tsx diff looks broken in github, please check it locally, there are not so many changes here


**Screenshots:** 
_borders on screenshots are just to show correct matrix positioning
small matrix_
![image](https://user-images.githubusercontent.com/20676525/207900244-5f279162-874b-48c5-bb80-3c179ab28fe2.png)
big matrix
![image](https://user-images.githubusercontent.com/20676525/207900428-eaffa46f-5895-4d8f-8dbb-ca393063f3c7.png)
![image](https://user-images.githubusercontent.com/20676525/207900506-34d86cdd-a15c-4313-88bf-e36c02dcfe0f.png)
![image](https://user-images.githubusercontent.com/20676525/207900581-8b4da450-e4b6-496c-b7fb-45cfe25b9dae.png)
![image](https://user-images.githubusercontent.com/20676525/207900649-18beaf8b-74b3-4ee8-979c-a71df8d98c0e.png)
