### PR TITLE
fix(events_list): 13480 - fix event card styles

### DIFF
--- a/src/features/events_list/components/EventCard/EventCard.module.css
+++ b/src/features/events_list/components/EventCard/EventCard.module.css
@@ -7,12 +7,15 @@
   text-align: left;
   width: 100%;
   transition: background-color ease-out 0.1s;
+  &:hover {
+    background-color: var(--base-weak-up);
+  }
   &.active {
     background-color: var(--accent-weak);
     box-shadow: 0px 0px 0px 0px var(--accent-strong);
     border-left: var(--half-unit) solid var(--accent-strong);
   }
-  &:focus {
+  &:focus-visible {
     box-shadow: inset 0px 0px 0px 2px var(--accent-strong);
   }
 }


### PR DESCRIPTION
Make frame only on tab selection - remove it for active card
![image](https://user-images.githubusercontent.com/50058726/208479291-b1d87f5f-9e24-4cc8-80d2-a9da63bd6778.png)
Change color on hover a bit 
![image](https://user-images.githubusercontent.com/50058726/208479465-6ed02107-d26b-4cbf-891c-ddf298439636.png)
