### PR TITLE
chore(events_list): 10166 - add description for active event and short state event

### DIFF
--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -50,6 +50,8 @@ export interface Event {
   /** Time in UTC (ISO8601) */
   updatedAt: string;
   externalUrls: string[];
+  /** Additional info about event if presented*/
+  description?: string;
 }
 
 export interface AnalyticsData {

--- a/src/features/events_list/components/CurrentEvent/CurrentEvent.tsx
+++ b/src/features/events_list/components/CurrentEvent/CurrentEvent.tsx
@@ -7,7 +7,13 @@ import { createStateMap } from '~utils/atoms';
 import { EpisodeTimelineToggle } from '../EpisodeTimelineToggle/EpisodeTimelineToggle';
 import { EventCard } from '../EventCard/EventCard';
 
-export function CurrentEvent({ hasTimeline }: { hasTimeline?: boolean }) {
+export function CurrentEvent({
+  hasTimeline,
+  showDescription,
+}: {
+  hasTimeline?: boolean;
+  showDescription?: boolean;
+}) {
   const [{ data, error, loading }] = useAtom(currentEventResourceAtom);
 
   const statesToComponents = createStateMap({
@@ -28,6 +34,7 @@ export function CurrentEvent({ hasTimeline }: { hasTimeline?: boolean }) {
           hasTimeline ? <EpisodeTimelineToggle isActive={true} /> : null
         }
         externalUrls={event.externalUrls}
+        showDescription={showDescription}
       />
     ),
   });

--- a/src/features/events_list/components/CurrentEvent/CurrentEvent.tsx
+++ b/src/features/events_list/components/CurrentEvent/CurrentEvent.tsx
@@ -8,11 +8,11 @@ import { EpisodeTimelineToggle } from '../EpisodeTimelineToggle/EpisodeTimelineT
 import { EventCard } from '../EventCard/EventCard';
 
 export function CurrentEvent({
-  hasTimeline,
-  showDescription,
+  hasTimeline = false,
+  showDescription = false,
 }: {
-  hasTimeline?: boolean;
-  showDescription?: boolean;
+  hasTimeline: boolean;
+  showDescription: boolean;
 }) {
   const [{ data, error, loading }] = useAtom(currentEventResourceAtom);
 

--- a/src/features/events_list/components/EventCard/EventCard.module.css
+++ b/src/features/events_list/components/EventCard/EventCard.module.css
@@ -39,7 +39,7 @@
 .linkContainer {
   display: flex;
   flex-direction: column;
-  gap: var(--unit);
+  gap: var(--half-unit);
   font: var(--font-xs);
 }
 

--- a/src/features/events_list/components/EventCard/EventCard.tsx
+++ b/src/features/events_list/components/EventCard/EventCard.tsx
@@ -30,12 +30,14 @@ export function EventCard({
   onClick,
   alternativeActionControl,
   externalUrls,
+  showDescription,
 }: {
   event: Event;
   isActive: boolean;
   onClick?: (id: string) => void;
   alternativeActionControl: JSX.Element | null;
   externalUrls?: string[];
+  showDescription?: boolean;
 }) {
   const formattedTime = useMemo(
     () => formatTime(parseISO(event.updatedAt)),
@@ -51,8 +53,16 @@ export function EventCard({
         <SeverityIndicator severity={event.severity} />
       </div>
 
-      <div className={s.location}>
-        <Text type="caption">{event.location}</Text>
+      <div>
+        <div className={s.location}>
+          <Text type="caption">{event.location}</Text>
+        </div>
+
+        {showDescription && event.description && (
+          <div className={s.description}>
+            <Text type="caption">{event.description}</Text>
+          </div>
+        )}
       </div>
 
       <Analytics

--- a/src/features/events_list/components/EventCard/EventCard.tsx
+++ b/src/features/events_list/components/EventCard/EventCard.tsx
@@ -53,17 +53,15 @@ export function EventCard({
         <SeverityIndicator severity={event.severity} />
       </div>
 
-      <div>
-        <div className={s.location}>
-          <Text type="caption">{event.location}</Text>
-        </div>
-
-        {showDescription && event.description && (
-          <div className={s.description}>
-            <Text type="caption">{event.description}</Text>
-          </div>
-        )}
+      <div className={s.location}>
+        <Text type="caption">{event.location}</Text>
       </div>
+
+      {showDescription && event.description && (
+        <div className={s.description}>
+          <Text type="caption">{event.description}</Text>
+        </div>
+      )}
 
       <Analytics
         settledArea={event.settledArea}

--- a/src/features/events_list/components/FullState/FullState.tsx
+++ b/src/features/events_list/components/FullState/FullState.tsx
@@ -56,7 +56,9 @@ export function FullState({
 
   return (
     <div className={s.panelBody}>
-      {hasUnlistedEvent && <CurrentEvent hasTimeline={hasTimeline} />}
+      {hasUnlistedEvent && (
+        <CurrentEvent hasTimeline={hasTimeline} showDescription={true} />
+      )}
       <EventListSettingsRow>
         <FeedSelector />
         <BBoxFilterToggle />
@@ -83,6 +85,7 @@ export function FullState({
                       ) : null
                     }
                     externalUrls={event.externalUrls}
+                    showDescription={event.eventId === currentEventId}
                   />
                 )}
                 ref={virtuoso}

--- a/src/features/events_list/components/FullState/FullState.tsx
+++ b/src/features/events_list/components/FullState/FullState.tsx
@@ -57,7 +57,7 @@ export function FullState({
   return (
     <div className={s.panelBody}>
       {hasUnlistedEvent && (
-        <CurrentEvent hasTimeline={hasTimeline} showDescription={true} />
+        <CurrentEvent hasTimeline={Boolean(hasTimeline)} showDescription={true} />
       )}
       <EventListSettingsRow>
         <FeedSelector />

--- a/src/features/events_list/components/ShortState/ShortState.tsx
+++ b/src/features/events_list/components/ShortState/ShortState.tsx
@@ -10,11 +10,11 @@ import type { MouseEventHandler } from 'react';
 import type { Event } from '~core/types';
 
 export function ShortState({
-  hasTimeline,
+  hasTimeline = false,
   openFullState,
   currentEventId,
 }: {
-  hasTimeline?: boolean;
+  hasTimeline: boolean;
   openFullState: MouseEventHandler<HTMLButtonElement | HTMLDivElement>;
   currentEventId?: string | null;
 }) {

--- a/src/features/events_list/components/ShortState/ShortState.tsx
+++ b/src/features/events_list/components/ShortState/ShortState.tsx
@@ -35,7 +35,9 @@ export function ShortState({
     if (!event && currentEvent) setEvent(currentEvent);
   }, [currentEvent, event, setEvent]);
 
-  const eventInfo = event ? <CurrentEvent hasTimeline={hasTimeline} /> : null;
+  const eventInfo = event ? (
+    <CurrentEvent hasTimeline={hasTimeline} showDescription={true} />
+  ) : null;
 
   const panelContent = eventInfo || (
     <div className={s.noDisasters}>

--- a/src/features/events_list/components/ShortState/ShortState.tsx
+++ b/src/features/events_list/components/ShortState/ShortState.tsx
@@ -10,11 +10,11 @@ import type { MouseEventHandler } from 'react';
 import type { Event } from '~core/types';
 
 export function ShortState({
-  hasTimeline = false,
+  hasTimeline,
   openFullState,
   currentEventId,
 }: {
-  hasTimeline: boolean;
+  hasTimeline?: boolean;
   openFullState: MouseEventHandler<HTMLButtonElement | HTMLDivElement>;
   currentEventId?: string | null;
 }) {
@@ -36,7 +36,7 @@ export function ShortState({
   }, [currentEvent, event, setEvent]);
 
   const eventInfo = event ? (
-    <CurrentEvent hasTimeline={hasTimeline} showDescription={true} />
+    <CurrentEvent hasTimeline={Boolean(hasTimeline)} showDescription={true} />
   ) : null;
 
   const panelContent = eventInfo || (


### PR DESCRIPTION
event description is now provided
![image](https://user-images.githubusercontent.com/50058726/208899132-fe463fd4-5d01-455c-8f29-4b2d96cd9807.png)
so we show it for active event in full panel state
![image](https://user-images.githubusercontent.com/50058726/208900554-e7c0c5b0-7f97-4d31-b7ec-25eacaf6af37.png)
![image](https://user-images.githubusercontent.com/50058726/208900515-c16215cf-d3b0-4b40-95cb-f5c0d26d75c8.png)

and for short state too
![image](https://user-images.githubusercontent.com/50058726/208900384-72af2c81-26e7-4d02-9610-f2222818987e.png)
