### PR TITLE
fix(i18n): 13929 - fix wrong translation keys across .po files, retur…

### DIFF
--- a/src/core/localization/gettext/ar/common.po
+++ b/src/core/localization/gettext/ar/common.po
@@ -950,7 +950,7 @@ msgid ""
 "optional cookies to improve Disaster Ninja and your experience. You can "
 "manage cookies settings or withdraw consent to optional cookies at any "
 "time.\n"
-"For more information, please, check our [Privacy Policy](/about/privacy)"
+"For more information, please, check our [Privacy Policy](about/privacy)"
 msgstr ""
 
 #: cookie_banner##decline_all

--- a/src/core/localization/gettext/de/common.po
+++ b/src/core/localization/gettext/de/common.po
@@ -966,7 +966,7 @@ msgid ""
 "optional cookies to improve Disaster Ninja and your experience. You can "
 "manage cookies settings or withdraw consent to optional cookies at any "
 "time.\n"
-"For more information, please, check our [Privacy Policy](/about/privacy)"
+"For more information, please, check our [Privacy Policy](about/privacy)"
 msgstr ""
 
 #: cookie_banner##decline_all

--- a/src/core/localization/gettext/es/common.po
+++ b/src/core/localization/gettext/es/common.po
@@ -962,7 +962,7 @@ msgid ""
 "optional cookies to improve Disaster Ninja and your experience. You can "
 "manage cookies settings or withdraw consent to optional cookies at any "
 "time.\n"
-"For more information, please, check our [Privacy Policy](/about/privacy)"
+"For more information, please, check our [Privacy Policy](about/privacy)"
 msgstr ""
 
 #: cookie_banner##decline_all

--- a/src/core/localization/gettext/id/common.po
+++ b/src/core/localization/gettext/id/common.po
@@ -958,7 +958,7 @@ msgid ""
 "optional cookies to improve Disaster Ninja and your experience. You can "
 "manage cookies settings or withdraw consent to optional cookies at any "
 "time.\n"
-"For more information, please, check our [Privacy Policy](/about/privacy)"
+"For more information, please, check our [Privacy Policy](about/privacy)"
 msgstr ""
 
 #: cookie_banner##decline_all

--- a/src/core/localization/gettext/ko/common.po
+++ b/src/core/localization/gettext/ko/common.po
@@ -949,7 +949,7 @@ msgid ""
 "optional cookies to improve Disaster Ninja and your experience. You can "
 "manage cookies settings or withdraw consent to optional cookies at any "
 "time.\n"
-"For more information, please, check our [Privacy Policy](/about/privacy)"
+"For more information, please, check our [Privacy Policy](about/privacy)"
 msgstr ""
 
 #: cookie_banner##decline_all

--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -5,8 +5,6 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-12-21T10:53:46.140Z\n"
-"PO-Revision-Date: 2022-12-21T10:53:46.140Z\n"
 
 #: km
 msgid "km"

--- a/src/features/user_profile/atoms/userProfile.ts
+++ b/src/features/user_profile/atoms/userProfile.ts
@@ -41,7 +41,7 @@ export const currentProfileAtom = createAtom(
 
     onChange('currentUserAtom', async (newUser, prevUser) => {
       // reload to simply apply all the settings if implementation is difficult
-      // if (prevUser) location.reload()
+      if (prevUser) location.reload();
 
       const newState = { ...newUser };
       delete newState.token;


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Sidebar-menu-translation-is-missed-13656
https://kontur.fibery.io/Tasks/Task/Some-of-the-modules-on-DN-changes-the-language-only-after-refreshing-the-page-13929

_Notes:_
- POT-Creation-Date and PO-Revision-Date removed from .pot - so no conflicts in future
- reason of broken i18next keys was that gettext parser couldn't process multiple references in one line 
#: layers bivariate##color_manager##layers_filter -> 
```
    "layers bivariate": {
        "color_manager": {
            "layers_filter": "Ebenen"
        }
```
fix is pretty straightforward -> need to concatenate references with \n symbols.

<img width="1001" alt="Screenshot 2022-12-23 at 16 00 45" src="https://user-images.githubusercontent.com/20676525/209340360-0f918e8d-de7c-4f36-9dea-b8bf9483237a.png">
