### PR TITLE
fix(core): 13914 - reset login state if getting 401 from the server fix # 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disaster-ninja-fe",
-  "version": "2.2.8",
+  "version": "2.2.7",
   "private": true,
   "homepage": "/active/",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disaster-ninja-fe",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "private": true,
   "homepage": "/active/",
   "type": "module",

--- a/src/core/apiClientInstance.ts
+++ b/src/core/apiClientInstance.ts
@@ -1,5 +1,6 @@
 import { ApiClient } from './api_client';
 import config from './app_config';
+import { authClientInstance } from './authClientInstance';
 import { i18n } from './localization';
 import { notificationServiceInstance } from './notificationServiceInstance';
 
@@ -12,6 +13,7 @@ ApiClient.init({
   translationService: i18n,
   unauthorizedCallback(apiClient) {
     apiClient.logout();
+    authClientInstance.logout();
   },
 });
 const apiClientInstance = ApiClient.getInstance();

--- a/src/core/apiClientInstance.ts
+++ b/src/core/apiClientInstance.ts
@@ -1,8 +1,10 @@
 import { ApiClient } from './api_client';
+import app_config from './app_config';
 import config from './app_config';
-import { authClientInstance } from './authClientInstance';
+import { userStateAtom } from './auth';
 import { i18n } from './localization';
 import { notificationServiceInstance } from './notificationServiceInstance';
+import { currentUserAtom } from './shared_state';
 
 // initialize main api client
 ApiClient.init({
@@ -12,8 +14,19 @@ ApiClient.init({
   refreshTokenApiPath: `${config.keycloakUrl}/auth/realms/${config.keycloakRealm}/protocol/openid-connect/token`,
   translationService: i18n,
   unauthorizedCallback(apiClient) {
+    // TODO refactor: same pice of logic exists in AuthClient.logout()
     apiClient.logout();
-    authClientInstance.logout();
+    currentUserAtom.setUser.dispatch();
+    userStateAtom.logout.dispatch();
+
+    if (window['Intercom']) {
+      app_config.intercom.name = window.konturAppConfig.INTERCOM_DEFAULT_NAME;
+      app_config.intercom['email'] = null;
+      window['Intercom']('update', {
+        name: app_config.intercom.name,
+        email: app_config.intercom['email'],
+      });
+    }
   },
 });
 const apiClientInstance = ApiClient.getInstance();

--- a/src/core/apiClientInstance.ts
+++ b/src/core/apiClientInstance.ts
@@ -1,10 +1,7 @@
 import { ApiClient } from './api_client';
-import app_config from './app_config';
 import config from './app_config';
-import { userStateAtom } from './auth';
 import { i18n } from './localization';
 import { notificationServiceInstance } from './notificationServiceInstance';
-import { currentUserAtom } from './shared_state';
 
 // initialize main api client
 ApiClient.init({
@@ -14,21 +11,11 @@ ApiClient.init({
   refreshTokenApiPath: `${config.keycloakUrl}/auth/realms/${config.keycloakRealm}/protocol/openid-connect/token`,
   translationService: i18n,
   unauthorizedCallback(apiClient) {
-    // TODO refactor: same pice of logic exists in AuthClient.logout()
     apiClient.logout();
-    currentUserAtom.setUser.dispatch();
-    userStateAtom.logout.dispatch();
-
-    if (window['Intercom']) {
-      app_config.intercom.name = window.konturAppConfig.INTERCOM_DEFAULT_NAME;
-      app_config.intercom['email'] = null;
-      window['Intercom']('update', {
-        name: app_config.intercom.name,
-        email: app_config.intercom['email'],
-      });
-    }
+    apiClient.expiredTokenCallback?.();
   },
 });
+
 const apiClientInstance = ApiClient.getInstance();
 
 export const apiClient = apiClientInstance;

--- a/src/core/api_client/apiClient.ts
+++ b/src/core/api_client/apiClient.ts
@@ -42,7 +42,7 @@ export class ApiClient {
   private refreshToken = '';
   private tokenWillExpire: Date | undefined;
   private checkTokenPromise: Promise<boolean> | undefined;
-  private expiredTokenCallback?: () => void;
+  public expiredTokenCallback?: () => void;
 
   /**
    * The Singleton's constructor should always be private to prevent direct
@@ -138,9 +138,9 @@ export class ApiClient {
     return 'Wrong data received!';
   }
 
-  async checkAuth(
+  getLocalAuthToken(
     callback: () => void,
-  ): Promise<{ token: string; refreshToken: string; jwtData: JWTData } | undefined> {
+  ): { token: string; refreshToken: string; jwtData: JWTData } | undefined {
     this.expiredTokenCallback = callback;
     const authStr = localStorage.getItem(LOCALSTORAGE_AUTH_KEY);
     if (authStr) {

--- a/src/core/auth/client/AuthClient.ts
+++ b/src/core/auth/client/AuthClient.ts
@@ -108,8 +108,8 @@ export class AuthClient {
 
   public async checkAuth(): Promise<void> {
     try {
-      const response = await this._apiClient.checkAuth(this.onTokenExpired);
-      if (response && typeof response === 'object' && 'token' in response) {
+      const response = this._apiClient.getLocalAuthToken(this.onTokenExpired);
+      if (response?.token) {
         this.processAuthResponse(response);
       }
     } catch (e) {


### PR DESCRIPTION
what's the problem:
after getting 401 for bad token user bad token is erased but user state doesn't change

how i've fixed that:
idea was to clear user states in `ApiClient.init` `unauthorizedCallback` method
this process was described in `AuthClient` `logout` method
``` ts
public logout() {
    this._apiClient.logout();
    currentUserAtom.setUser.dispatch();
    userStateAtom.logout.dispatch();

    if (window['Intercom']) {
      appConfig.intercom.name = window.konturAppConfig.INTERCOM_DEFAULT_NAME;
      appConfig.intercom['email'] = null;
      window['Intercom']('update', {
        name: appConfig.intercom.name,
        email: appConfig.intercom['email'],
      });
    }
  }
```

however putting this block into `ApiClient.init` `unauthorizedCallback` caused circular dependencies
I've found out that `ApiClient` `expiredTokenCallback` can have needed functionality after `AuthClient.checkAuth()` method fired. So i did small refactor inside `checkAuth` method and made `expiredTokenCallback` public to be able to run it inside `unauthorizedCallback`