### PR TITLE
fix(bivariate-matrix): 14215 - bivariateStatisticsResourceAtom loadin…

### DIFF
--- a/src/utils/atoms/createAsyncAtom/createAsyncAtom.ts
+++ b/src/utils/atoms/createAsyncAtom/createAsyncAtom.ts
@@ -239,6 +239,11 @@ export function createAsyncAtom<
             // Deps is primitive
             if (depsAtomState !== null)
               schedule((dispatch) => dispatch(create('request', depsAtomState as any)));
+            else {
+              console.info(
+                `Resource atom with name ${name} skips running as its dependency state ${deps?.depsAtom?.id} is null`,
+              );
+            }
           }
         });
       } else {


### PR DESCRIPTION
…g without geometry fix

https://kontur.fibery.io/Tasks/Task/Matrix-not-loading-after-deleting-geometry-and-page-refresh-14215

Resource atoms don't run if dependency is null. 
In atom's language it means that resource is waiting for input from dependency to run. 
That's why in a lot of AsyncAtoms dependencies accumulated in separate atom. 
Check currentEventResourceAtom and editableLayersListResource.
So in this PR we just provide dependency as not null object, so resource atom runs correctly.