### PR TITLE
chore(core): 13682 - change layouts and styles for footer

### DIFF
--- a/src/components/ConnectedMap/map-libre-adapter/index.tsx
+++ b/src/components/ConnectedMap/map-libre-adapter/index.tsx
@@ -398,7 +398,7 @@ export default forwardRef(MapboxMap);
 
 function getMapControl(useMetricUnits?: boolean) {
   const scale = new mapLibre.ScaleControl({
-    maxWidth: 120,
+    maxWidth: 75,
     unit: useMetricUnits ? 'metric' : 'imperial',
   });
   return scale;

--- a/src/components/ConnectedMap/map-libre-adapter/index.tsx
+++ b/src/components/ConnectedMap/map-libre-adapter/index.tsx
@@ -398,7 +398,7 @@ export default forwardRef(MapboxMap);
 
 function getMapControl(useMetricUnits?: boolean) {
   const scale = new mapLibre.ScaleControl({
-    maxWidth: 75,
+    maxWidth: 100,
     unit: useMetricUnits ? 'metric' : 'imperial',
   });
   return scale;

--- a/src/global.css
+++ b/src/global.css
@@ -109,9 +109,12 @@ code {
   .maplibregl-control-container .maplibregl-ctrl-bottom-right {
     right: 140px;
     flex-wrap: wrap-reverse;
-    bottom: 1px;
+    bottom: calc(12px + var(--unit));
     & .mapboxgl-ctrl-scale {
       margin: 0;
+    }
+    & .mapboxgl-ctrl-attrib.mapboxgl-compact {
+      margin: 0 var(--unit);
     }
   }
 }

--- a/src/global.css
+++ b/src/global.css
@@ -72,7 +72,13 @@ code {
 }
 /* move map controls to the right so kontur logo wouldn't be overlapped */
 .maplibregl-control-container .maplibregl-ctrl-bottom-right {
-  right: 100px;
+  right: 150px;
+  display: flex;
+  align-items: center;
+  bottom: calc(2px + var(--unit));
+  & .mapboxgl-ctrl-scale {
+    margin: 0;
+  }
 }
 
 .intercom-launcher-frame,
@@ -80,7 +86,8 @@ code {
   transform: scale(0.8) !important;
 }
 .intercom-lightweight-app-launcher.intercom-launcher {
-  bottom: 28px;
+  bottom: var(--half-unit);
+  right: calc(10px + var(--half-unit));
 }
 
 /* handling app header here bacause 
@@ -94,8 +101,17 @@ code {
     display: none;
   }
   .intercom-lightweight-app-launcher.intercom-launcher {
-    right: 6px;
-    bottom: 36px;
+    bottom: var(--half-unit);
+    right: calc(10px + var(--half-unit));
+  }
+  /* move map controls to the right so kontur logo wouldn't be overlapped */
+  .maplibregl-control-container .maplibregl-ctrl-bottom-right {
+    right: 140px;
+    flex-wrap: wrap;
+    bottom: 0;
+    & .mapboxgl-ctrl-scale {
+      margin: 0;
+    }
   }
 }
 

--- a/src/global.css
+++ b/src/global.css
@@ -115,6 +115,12 @@ code {
     }
     & .mapboxgl-ctrl-attrib.mapboxgl-compact {
       margin: 0 var(--unit);
+      /* maplibre (i) logo */
+      & button {
+        height: 20px;
+        top: unset;
+        bottom: 2px;
+      }
     }
   }
 }

--- a/src/global.css
+++ b/src/global.css
@@ -75,9 +75,10 @@ code {
   right: 150px;
   display: flex;
   align-items: center;
-  bottom: calc(2px + var(--unit));
+  bottom: calc(10px + var(--unit));
   & .mapboxgl-ctrl-scale {
     margin: 0;
+    height: 20px;
   }
 }
 
@@ -107,8 +108,8 @@ code {
   /* move map controls to the right so kontur logo wouldn't be overlapped */
   .maplibregl-control-container .maplibregl-ctrl-bottom-right {
     right: 140px;
-    flex-wrap: wrap;
-    bottom: 0;
+    flex-wrap: wrap-reverse;
+    bottom: 1px;
     & .mapboxgl-ctrl-scale {
       margin: 0;
     }

--- a/src/global.css
+++ b/src/global.css
@@ -109,7 +109,7 @@ code {
   .maplibregl-control-container .maplibregl-ctrl-bottom-right {
     right: 140px;
     flex-wrap: wrap-reverse;
-    bottom: calc(12px + var(--unit));
+    bottom: calc(10px + var(--unit));
     & .mapboxgl-ctrl-scale {
       margin: 0;
     }

--- a/src/views/Map/Layouts/Desktop/Desktop.module.css
+++ b/src/views/Map/Layouts/Desktop/Desktop.module.css
@@ -8,22 +8,19 @@
   grid-template-columns:
     minmax(320px, 1fr) minmax(440px, 10fr)
     minmax(320px, 1fr);
-  grid-template-rows: calc(100% - 40px) 40px;
+  grid-template-rows: calc(100% - 40px - var(--unit)) 40px var(--unit);
 }
 
-.analyticsColumn,
-.layersColumn {
-  display: flex;
-  flex-direction: column;
-  gap: var(--unit);
-  z-index: 1;
+.analytics {
+  grid-column: 1;
+  grid-row: 1/3;
 }
 
 .mapWrap {
   display: flex;
   flex-flow: column nowrap;
   grid-column: 2;
-  grid-row: 1/2;
+  grid-row: 1/3;
 }
 
 .mapSpaceBlank {
@@ -35,11 +32,6 @@
   flex-direction: column;
   justify-content: center;
   gap: var(--unit);
-}
-
-.intercomPlaceholder {
-  height: 30px;
-  flex: 1 0 auto;
 }
 
 .footerWrap {

--- a/src/views/Map/Layouts/Desktop/Desktop.module.css
+++ b/src/views/Map/Layouts/Desktop/Desktop.module.css
@@ -20,7 +20,7 @@
   display: flex;
   flex-flow: column nowrap;
   grid-column: 2;
-  grid-row: 1/3;
+  grid-row: 1/2;
 }
 
 .mapSpaceBlank {

--- a/src/views/Map/Layouts/Desktop/Desktop.module.css
+++ b/src/views/Map/Layouts/Desktop/Desktop.module.css
@@ -35,8 +35,8 @@
 }
 
 .footerWrap {
-  height: 40px;
   width: 100%;
+  height: calc(100% - var(--unit));
   grid-row: 2;
   grid-column: 1/-1;
 }

--- a/src/views/Map/Layouts/Desktop/Desktop.tsx
+++ b/src/views/Map/Layouts/Desktop/Desktop.tsx
@@ -4,17 +4,14 @@ import s from './Desktop.module.css';
 export function DesktopLayout({ analyticsColumn, layersColumn, mapColumn, footer }) {
   return (
     <div className={s.contentWrap}>
-      <SmartColumn>{analyticsColumn}</SmartColumn>
+      <SmartColumn className={s.analytics}>{analyticsColumn}</SmartColumn>
 
       <div className={s.mapWrap}>
         <div className={s.mapSpaceBlank}></div>
         <div className={s.mapSpaceBottom}>{mapColumn}</div>
       </div>
 
-      <SmartColumn>
-        {layersColumn}
-        <div className={s.intercomPlaceholder}></div>
-      </SmartColumn>
+      <SmartColumn>{layersColumn}</SmartColumn>
 
       <div className={s.footerWrap}>{footer}</div>
     </div>

--- a/src/views/Map/Layouts/Laptop/Laptop.module.css
+++ b/src/views/Map/Layouts/Laptop/Laptop.module.css
@@ -4,7 +4,7 @@
   gap: var(--unit);
   padding: var(--unit);
   grid-template-columns: minmax(320px, 1fr) minmax(440px, 4fr);
-  grid-template-rows: calc(100% - 20px - var(--unit)) 20px var(--unit);
+  grid-template-rows: calc(100% - 20px - var(--unit) - var(--unit)) 20px var(--unit);
 }
 
 .panelsColumn {
@@ -35,8 +35,5 @@
   width: 100%;
   grid-row: 2;
   grid-column: 1/-1;
-  height: 20px;
-  & > div {
-    height: 20px;
-  }
+  height: 100%;
 }

--- a/src/views/Map/Layouts/Laptop/Laptop.module.css
+++ b/src/views/Map/Layouts/Laptop/Laptop.module.css
@@ -4,7 +4,12 @@
   gap: var(--unit);
   padding: var(--unit);
   grid-template-columns: minmax(320px, 1fr) minmax(440px, 4fr);
-  grid-template-rows: calc(100% - 40px) 40px;
+  grid-template-rows: calc(100% - 20px - var(--unit)) 20px var(--unit);
+}
+
+.panelsColumn {
+  grid-column: 1;
+  grid-row: 1/2;
 }
 
 .mapWrap {
@@ -30,4 +35,8 @@
   width: 100%;
   grid-row: 2;
   grid-column: 1/-1;
+  height: 20px;
+  & > div {
+    height: 20px;
+  }
 }

--- a/src/views/Map/Layouts/Laptop/Laptop.tsx
+++ b/src/views/Map/Layouts/Laptop/Laptop.tsx
@@ -4,7 +4,7 @@ import s from './Laptop.module.css';
 export function LaptopLayout({ firstColumn, mapColumn, footer }) {
   return (
     <div className={s.contentWrap}>
-      <SmartColumn>{firstColumn}</SmartColumn>
+      <SmartColumn className={s.panelsColumn}>{firstColumn}</SmartColumn>
       <div className={s.mapWrap}>
         <div className={s.mapSpaceBlank}></div>
         <div className={s.mapSpaceBottom}>{mapColumn}</div>

--- a/src/views/Map/Layouts/Mobile/Mobile.module.css
+++ b/src/views/Map/Layouts/Mobile/Mobile.module.css
@@ -3,12 +3,12 @@
   width: 100%;
   height: 100%;
   grid-template-columns: calc(40px + var(--double-unit)) minmax(40px, 100vw);
-  grid-template-rows: 180px 1fr 30px;
+  grid-template-rows: 180px 1fr 10px var(--unit);
 }
 
 .toolbox {
   grid-row: 1;
-  grid-column: 1/3;
+  grid-column: 1/-1;
   padding: var(--unit);
 }
 
@@ -35,6 +35,13 @@
 }
 
 .footerWrap {
-  grid-row: -1;
   grid-column: 1/-1;
+  grid-row: 3;
+  height: calc(10px + var(--unit));
+}
+
+.fakeFooter {
+  grid-column: 1/-1;
+  grid-row: -1;
+  height: var(--unit);
 }

--- a/src/views/Map/Layouts/Mobile/Mobile.module.css
+++ b/src/views/Map/Layouts/Mobile/Mobile.module.css
@@ -40,7 +40,7 @@
   height: calc(10px + var(--unit));
 }
 
-.fakeFooter {
+.bottomBorder {
   grid-column: 1/-1;
   grid-row: -1;
   height: var(--unit);

--- a/src/views/Map/Layouts/Mobile/Mobile.module.css
+++ b/src/views/Map/Layouts/Mobile/Mobile.module.css
@@ -37,7 +37,7 @@
 .footerWrap {
   grid-column: 1/-1;
   grid-row: 3;
-  height: calc(8px + var(--unit));
+  height: calc(10px + var(--unit));
 }
 
 .fakeFooter {

--- a/src/views/Map/Layouts/Mobile/Mobile.module.css
+++ b/src/views/Map/Layouts/Mobile/Mobile.module.css
@@ -37,7 +37,7 @@
 .footerWrap {
   grid-column: 1/-1;
   grid-row: 3;
-  height: calc(10px + var(--unit));
+  height: calc(8px + var(--unit));
 }
 
 .fakeFooter {

--- a/src/views/Map/Layouts/Mobile/Mobile.tsx
+++ b/src/views/Map/Layouts/Mobile/Mobile.tsx
@@ -9,7 +9,7 @@ export function MobileLayout({ firstColumn, mapColumn, footer, drawToolbox }) {
         <div className={s.mapSpaceRight}>{mapColumn}</div>
       </div>
       <div className={s.footerWrap}>{footer}</div>
-      <div className={s.fakeFooter}></div>
+      <div className={s.bottomBorder}></div>
     </div>
   );
 }

--- a/src/views/Map/Layouts/Mobile/Mobile.tsx
+++ b/src/views/Map/Layouts/Mobile/Mobile.tsx
@@ -9,6 +9,7 @@ export function MobileLayout({ firstColumn, mapColumn, footer, drawToolbox }) {
         <div className={s.mapSpaceRight}>{mapColumn}</div>
       </div>
       <div className={s.footerWrap}>{footer}</div>
+      <div className={s.fakeFooter}></div>
     </div>
   );
 }

--- a/src/views/Map/Map.module.css
+++ b/src/views/Map/Map.module.css
@@ -33,15 +33,15 @@
 }
 
 .footer {
-  height: 40px;
+  height: 100%;
   width: 100%;
   position: relative;
 }
 
 .logo {
   position: absolute;
-  right: var(--unit);
-  bottom: var(--unit);
+  bottom: 0;
+  right: calc(54px + var(--half-unit));
 }
 
 /* laptop viewport */
@@ -56,11 +56,8 @@
 /* Mobile view */
 @media screen and (max-width: 960px) {
   .footer {
-    position: relative;
-    grid-column: 1/2;
-    grid-row: 6;
     & .logo {
-      position: static;
+      right: calc(58px + var(--half-unit));
     }
   }
 }

--- a/src/views/Map/Map.module.css
+++ b/src/views/Map/Map.module.css
@@ -40,7 +40,7 @@
 
 .logo {
   position: absolute;
-  bottom: 0;
+  bottom: 0px;
   right: calc(54px + var(--half-unit));
 }
 

--- a/src/views/Map/Map.module.css
+++ b/src/views/Map/Map.module.css
@@ -58,6 +58,7 @@
   .footer {
     & .logo {
       right: calc(58px + var(--half-unit));
+      bottom: var(--unit);
     }
   }
 }

--- a/src/views/Map/SmartColumn/SmartColumn.tsx
+++ b/src/views/Map/SmartColumn/SmartColumn.tsx
@@ -1,8 +1,15 @@
+import clsx from 'clsx';
 import { useRef, useLayoutEffect, useState } from 'react';
 import { ColumnContext, Resizer } from '~core/store/columnContext';
 import s from './SmartColumn.module.css';
 
-export function SmartColumn({ children }) {
+export function SmartColumn({
+  children,
+  className,
+}: {
+  className?: string;
+  children: JSX.Element;
+}) {
   const columnRef = useRef<null | HTMLDivElement>(null);
   const limiterRef = useRef<null | HTMLDivElement>(null);
 
@@ -14,7 +21,7 @@ export function SmartColumn({ children }) {
     return () => resizer.destroy();
   }, [setResizer]);
   return (
-    <div className={s.smartColumn} ref={limiterRef}>
+    <div className={clsx(s.smartColumn, className)} ref={limiterRef}>
       <div className={s.smartColumnContent} ref={columnRef}>
         {resizer && (
           <ColumnContext.Provider value={resizer}>{children}</ColumnContext.Provider>


### PR DESCRIPTION
Changes in design according to https://kontur.fibery.io/Tasks/Task/Reorder-modes-on-sidebar-14007
I've added extra row in layouts grids to implement design requirements and not let columns overflow page bottom

desktop:
![image](https://user-images.githubusercontent.com/50058726/212280147-b526ffeb-1c18-4e97-b16c-ace74c4c97fd.png)

laptop:
![image](https://user-images.githubusercontent.com/50058726/212280292-cfa97f49-28c0-4d67-be7e-72b7a6c25dfb.png)

mobile:
![image](https://user-images.githubusercontent.com/50058726/212280036-290e7bdd-2515-4a4d-b85d-c17b19d53ed1.png)
