### PR TITLE
fix: check it map loaded and load it call init handler without adding subscription

### DIFF
--- a/src/components/ConnectedMap/map-libre-adapter/index.test.tsx
+++ b/src/components/ConnectedMap/map-libre-adapter/index.test.tsx
@@ -12,6 +12,7 @@ vi.mock('maplibre-gl', () => ({
     Map: function () {
       this.fitBounds = mockFitBounds;
       this.on = () => null;
+      this.loaded = () => false;
     },
     getRTLTextPluginStatus: () => null,
   },
@@ -29,9 +30,7 @@ describe('<MapboxMap />', () => {
     const { container } = render(
       <Map style={''} accessToken={''} className={className} />,
     );
-    expect(container.getElementsByClassName('SuperDuperClassName').length).toBe(
-      1,
-    );
+    expect(container.getElementsByClassName('SuperDuperClassName').length).toBe(1);
   });
 
   test.todo('Should call fitBounds with bounds props');

--- a/src/components/ConnectedMap/map-libre-adapter/index.tsx
+++ b/src/components/ConnectedMap/map-libre-adapter/index.tsx
@@ -169,7 +169,11 @@ function MapboxMap(
       onLoad && onLoad(true);
     };
 
-    map.on('load', loadHandler);
+    if (map.loaded()) {
+      loadHandler();
+    } else {
+      map.on('load', loadHandler);
+    }
     return () => {
       map.off('load', loadHandler);
     };

--- a/src/core/logical_layers/utils/layersOrder/layersOrder.ts
+++ b/src/core/logical_layers/utils/layersOrder/layersOrder.ts
@@ -56,12 +56,10 @@ export class LayersOrderManager {
     );
     this._layersParentsIds = mapLibreParentsIds;
 
-    map.once('load', () => {
-      this._baseMapFirstLayerIdx = (map.getStyle().layers ?? []).length - 1;
-      this._awaitingTasks.forEach((task) => {
-        this._awaitingTasks.delete(task);
-        task(map);
-      });
+    this._baseMapFirstLayerIdx = (map.getStyle().layers ?? []).length - 1;
+    this._awaitingTasks.forEach((task) => {
+      this._awaitingTasks.delete(task);
+      task(map);
     });
   }
 


### PR DESCRIPTION


https://user-images.githubusercontent.com/6587585/213160036-b13594a8-82af-4447-94f9-8df0b2fa00ba.mp4


The reason of bug was in onInit hook setup process - there was a small time gap between map instance created and we pass link of instance to other places in our application where eventListener for 'load' event adds. If load event happens in this gap - subscribers that will be added after that just wait load event that not happens never again.