### PR TITLE
fix(analytics-panel) - 14292: panel name and icon should stick to sho…

### DIFF
--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -135,6 +135,8 @@ const Analytics = ({ featureFlags }: { featureFlags: Record<string, boolean> }) 
       initialState={featureFlags[FeatureFlag.ANALYTICS_PANEL] ? 'short' : null}
       key="analytics"
       id="analytics"
+      panelIcon={analyticsPanel.panelIcon}
+      header={analyticsPanel.header}
     />
   );
 };

--- a/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
@@ -15,6 +15,8 @@ type PanelProps = {
   shortState?: PanelFeatureInterface | null;
   id?: string;
   initialState?: PanelState | null;
+  header?: string;
+  panelIcon?: JSX.Element;
 };
 
 export function FullAndShortStatesPanelWidget({
@@ -22,6 +24,8 @@ export function FullAndShortStatesPanelWidget({
   shortState,
   id,
   initialState,
+  header,
+  panelIcon,
 }: PanelProps) {
   const { panelState, panelControls, setPanelState } = useShortPanelState({
     initialState,
@@ -63,8 +67,9 @@ export function FullAndShortStatesPanelWidget({
 
   if (!fullState && !shortState) return null;
 
-  const header = !fullState ? shortState?.header : fullState.header;
-  const panelIcon = !fullState ? shortState?.panelIcon : fullState.panelIcon;
+  const resultHeader = header || (!fullState ? shortState?.header : fullState.header);
+  const resultPanelIcon =
+    panelIcon || (!fullState ? shortState?.panelIcon : fullState.panelIcon);
 
   const panelContent = {
     full: fullState?.content || shortState?.content,
@@ -75,8 +80,8 @@ export function FullAndShortStatesPanelWidget({
   return (
     <>
       <Panel
-        header={header}
-        headerIcon={panelIcon || undefined}
+        header={resultHeader}
+        headerIcon={resultPanelIcon || undefined}
         className={clsx(s.panel, isOpen ? s.show : s.collapse)}
         classes={panelClasses}
         isOpen={isOpen}
@@ -100,7 +105,7 @@ export function FullAndShortStatesPanelWidget({
           !isOpen && s.show,
           isMobile ? s.mobile : s.desktop,
         )}
-        icon={panelIcon || <></>}
+        icon={resultPanelIcon || <></>}
       />
     </>
   );


### PR DESCRIPTION
…rt state

https://kontur.fibery.io/Tasks/Task/The-name-of-the-Analytics-panel-is-changed-to-Advanced-analytics-while-choosing-the-states-of-the-pa-14292

<img width="324" alt="Screenshot 2023-01-18 at 15 45 35" src="https://user-images.githubusercontent.com/20676525/213175036-770ee9ef-8757-40f6-9d19-2e3582fa5951.png">
