### PR TITLE
feat(i18n): 14293 - panel config created on the go

### DIFF
--- a/src/features/advanced_analytics_panel/index.tsx
+++ b/src/features/advanced_analytics_panel/index.tsx
@@ -6,7 +6,7 @@ import type { PanelFeatureInterface } from 'types/featuresTypes';
 
 const { PanelContent } = lazily(() => import('./components/PanelContent/PanelContent'));
 
-export const advancedAnalyticsPanel: PanelFeatureInterface = {
+export const advancedAnalyticsPanel: () => PanelFeatureInterface = () => ({
   content: (
     <Suspense>
       <PanelContent />
@@ -15,4 +15,4 @@ export const advancedAnalyticsPanel: PanelFeatureInterface = {
   header: i18n.t('advanced_analytics_panel.header_title'),
   minHeight: MIN_HEIGHT,
   resize: 'vertical',
-};
+});

--- a/src/features/analytics_panel/index.tsx
+++ b/src/features/analytics_panel/index.tsx
@@ -7,7 +7,7 @@ import type { PanelFeatureInterface } from 'types/featuresTypes';
 
 const { PanelContent } = lazily(() => import('./components/PanelContent/PanelContent'));
 
-export const analyticsPanel: PanelFeatureInterface = {
+export const analyticsPanel: () => PanelFeatureInterface = () => ({
   content: (
     <Suspense>
       <PanelContent />
@@ -19,4 +19,4 @@ export const analyticsPanel: PanelFeatureInterface = {
   maxHeight: MAX_HEIGHT,
   skipAutoResize: true,
   resize: 'vertical',
-};
+});

--- a/src/features/layers_panel/index.tsx
+++ b/src/features/layers_panel/index.tsx
@@ -7,7 +7,7 @@ import type { PanelFeatureInterface } from 'types/featuresTypes';
 
 const { PanelContent } = lazily(() => import('./components'));
 
-export const layersPanel: PanelFeatureInterface = {
+export const layersPanel: () => PanelFeatureInterface = () => ({
   content: (
     <Suspense>
       <PanelContent />
@@ -17,4 +17,4 @@ export const layersPanel: PanelFeatureInterface = {
   header: i18n.t('layers'),
   minHeight: MIN_HEIGHT,
   resize: 'vertical',
-};
+});

--- a/src/features/legend_panel/index.tsx
+++ b/src/features/legend_panel/index.tsx
@@ -7,7 +7,7 @@ import type { PanelFeatureInterface } from 'types/featuresTypes';
 
 const { PanelContent } = lazily(() => import('./components/PanelContent/PanelContent'));
 
-export const legendPanel: PanelFeatureInterface = {
+export const legendPanel: () => PanelFeatureInterface = () => ({
   content: (
     <Suspense>
       <PanelContent />
@@ -17,4 +17,4 @@ export const legendPanel: PanelFeatureInterface = {
   header: i18n.t('legend'),
   minHeight: MIN_HEIGHT,
   contentheight: 'min-content',
-};
+});

--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -125,8 +125,8 @@ export function MapPage() {
 
 const Analytics = ({ featureFlags }: { featureFlags: Record<string, boolean> }) => {
   const [fullState, shortState] = [
-    featureFlags[FeatureFlag.ADVANCED_ANALYTICS_PANEL] ? advancedAnalyticsPanel : null,
-    featureFlags[FeatureFlag.ANALYTICS_PANEL] ? analyticsPanel : null,
+    featureFlags[FeatureFlag.ADVANCED_ANALYTICS_PANEL] ? advancedAnalyticsPanel() : null,
+    featureFlags[FeatureFlag.ANALYTICS_PANEL] ? analyticsPanel() : null,
   ];
   return (
     <FullAndShortStatesPanelWidget
@@ -145,8 +145,8 @@ const LayersAndLegends = ({
   featureFlags: Record<string, boolean>;
 }) => {
   const [fullState, shortState] = [
-    featureFlags[FeatureFlag.MAP_LAYERS_PANEL] ? layersPanel : null,
-    featureFlags[FeatureFlag.LEGEND_PANEL] ? legendPanel : null,
+    featureFlags[FeatureFlag.MAP_LAYERS_PANEL] ? layersPanel() : null,
+    featureFlags[FeatureFlag.LEGEND_PANEL] ? legendPanel() : null,
   ];
   return (
     <FullAndShortStatesPanelWidget


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/The-translated-names-of-the-panels-are-switched-back-to-the-English-version-after-page-refreshment-14293

The problem is next (some panel titles aren't translated): 
<img width="342" alt="Screenshot 2023-01-20 at 10 34 34" src="https://user-images.githubusercontent.com/20676525/213641689-5c8caef4-01b5-4ca4-96f6-2e8479441229.png">

The reason is that all PanelFeatureInterface objects created on app start, but language comes async later from user profile request, that's why lang was outdated.
I've decided to create these objects on react render, as i18n expected scenario. 