### PR TITLE
fix(core):13708 layersInAreaAndEventLayerResource metric is sent only after refresh the page

### DIFF
--- a/src/core/app/features.ts
+++ b/src/core/app/features.ts
@@ -25,6 +25,5 @@ export function setFeatures(value: BackendFeature[] | null) {
   value?.forEach((ft) => {
     newFeatures[ft.name] = true;
   });
-  featureFlagsAtom.set.dispatch(newFeatures);
   store.dispatch([featureFlagsAtom.set(newFeatures), featuresWereSetAtom.setTrue()]);
 }

--- a/src/core/app/init.ts
+++ b/src/core/app/init.ts
@@ -3,7 +3,6 @@ import { appConfig, updateAppConfig } from '~core/app_config';
 import { apiClient } from '~core/apiClientInstance';
 import { urlEncoder, urlStoreAtom } from '~core/url_store';
 import { authClientInstance } from '~core/authClientInstance';
-import { currentApplicationAtom } from '~core/shared_state';
 import { onLogin, onLogout, onPublicLogin } from './authHooks';
 import { runAtom } from './index';
 import type { UrlData } from '~core/url_store';
@@ -40,9 +39,6 @@ export async function appInit() {
   }
 
   updateAppConfig(appInfo);
-
-  // FIXME: refactor remove currentApplicationAtom dependency in other atoms
-  currentApplicationAtom.set.dispatch(initialState.app);
 
   postAppInit(initialState);
 }

--- a/src/core/logical_layers/atoms/layersRegistry.ts
+++ b/src/core/logical_layers/atoms/layersRegistry.ts
@@ -15,11 +15,10 @@ type UnsubscribeFn = () => void;
 const cleanUpActionsMap = new WeakMap<LayerAtom, Action[]>();
 const unsubscribes = new WeakMap<LayerAtom, UnsubscribeFn>();
 
-export const createLayersRegistryAtom = () => {
+export const createLayersRegistryAtom = (id: string) => {
   const atom = createAtom(
     {
-      register: (r: RegisterRequest | RegisterRequest[]) =>
-        Array.isArray(r) ? r : [r],
+      register: (r: RegisterRequest | RegisterRequest[]) => (Array.isArray(r) ? r : [r]),
       unregister: (
         id: string | string[],
         { notifyLayerAboutDestroy }: { notifyLayerAboutDestroy?: boolean } = {},
@@ -80,9 +79,7 @@ export const createLayersRegistryAtom = () => {
               dispatch(actions);
             });
           } else {
-            console.error(
-              `Attempt unregister not existing layer with id: ${id}`,
-            );
+            console.error(`Attempt unregister not existing layer with id: ${id}`);
           }
         });
       });
@@ -97,10 +94,11 @@ export const createLayersRegistryAtom = () => {
 
       return state;
     },
-    'layersRegistry',
+    id,
   );
 
   return atom;
 };
 
-export const layersRegistryAtom: LayerRegistryAtom = createLayersRegistryAtom();
+export const layersRegistryAtom: LayerRegistryAtom =
+  createLayersRegistryAtom('layersRegistryAtom');

--- a/src/core/metrics/app-metrics.ts
+++ b/src/core/metrics/app-metrics.ts
@@ -77,6 +77,11 @@ export class AppMetrics implements Metric {
 
     globalThis.addEventListener(METRICS_EVENT, this.listener.bind(this) as EventListener);
 
+    globalThis.addEventListener(
+      'visibilitychange',
+      this.visibilityListener.bind(this) as EventListener,
+    );
+
     if (KONTUR_METRICS_DEBUG) {
       console.info(`appMetrics.init route:${route}`, this.reportTemplate, this.watchList);
     }
@@ -87,7 +92,18 @@ export class AppMetrics implements Metric {
   // remove listeners and unsubscribe from atoms
   cleanup() {
     globalThis.removeEventListener(METRICS_EVENT, this.listener as EventListener);
+    globalThis.removeEventListener(
+      'visibilitychange',
+      this.visibilityListener.bind(this) as EventListener,
+    );
     this.watch = () => null;
+  }
+
+  visibilityListener() {
+    if (globalThis.document.visibilityState === 'hidden') {
+      // stop metrics processing when page is hidden because of irrelevant timing
+      this.cleanup();
+    }
   }
 
   exposeMetrics() {

--- a/src/core/shared_state/currentApplication.ts
+++ b/src/core/shared_state/currentApplication.ts
@@ -1,7 +1,0 @@
-import { createPrimitiveAtom } from '~utils/atoms/createPrimitives';
-
-export const currentApplicationAtom = createPrimitiveAtom<null | string>(
-  '',
-  null,
-  '[Shared state] currentApplicationAtom',
-);

--- a/src/core/shared_state/index.ts
+++ b/src/core/shared_state/index.ts
@@ -10,7 +10,6 @@ export { mapListenersAtom } from './mapListeners';
 export { currentNotificationAtom } from './currentNotifications';
 export { toolbarControlsAtom } from './toolbarControls';
 export { currentMapAtom } from './currentMap';
-export { currentApplicationAtom } from './currentApplication';
 export { episodesPanelState } from './episodesPanelState';
 export * from './toolbarControls';
 export * from './featureFlags';

--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -4,7 +4,6 @@ import { appConfig } from '~core/app_config';
 import {
   currentEventAtom,
   currentMapPositionAtom,
-  currentApplicationAtom,
   currentEventFeedAtom,
 } from '~core/shared_state';
 import { scheduledAutoSelect, scheduledAutoFocus } from '~core/shared_state/currentEvent';
@@ -29,7 +28,6 @@ export const urlStoreAtom = createAtom(
     currentMapPositionAtom,
     currentEventAtom,
     enabledLayersAtom,
-    currentApplicationAtom,
     currentEventFeedAtom,
     _setState: (state: UrlData | null) => state,
     init: (initialState: UrlData) => initialState,

--- a/src/features/bivariate_color_manager/atoms/bivariateColorManagerSamleMap.ts
+++ b/src/features/bivariate_color_manager/atoms/bivariateColorManagerSamleMap.ts
@@ -11,7 +11,7 @@ import type { BivariateLayerStyle } from '~utils/bivariate/bivariateColorThemeUt
 import type maplibregl from 'maplibre-gl';
 
 export const bivariateSampleMapLayersOrderManager = new LayersOrderManager();
-export const bivariateregistry = createLayersRegistryAtom();
+export const bivariateregistry = createLayersRegistryAtom('bivariateregistry');
 
 export type BivariateColorManagerAtomState = {
   map: maplibregl.Map | null;

--- a/src/features/create_layer/atoms/editableLayerController.ts
+++ b/src/features/create_layer/atoms/editableLayerController.ts
@@ -1,7 +1,7 @@
+import { appConfig } from '~core/app_config';
 import { apiClient } from '~core/apiClientInstance';
 import { createAtom } from '~utils/atoms';
 import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
-import { currentApplicationAtom } from '~core/shared_state';
 import { EditTargets, TEMPORARY_USER_LAYER_LEGEND } from '../constants';
 import { createLayerEditorFormAtom } from './layerEditorForm';
 import { createLayerEditorFormFieldAtom } from './layerEditorFormField';
@@ -57,8 +57,8 @@ export const editableLayerControllerAtom = createAtom(
             id: layerId,
             name: layerUserData.name ?? '',
             marker: 'default' as const,
-            fields: Object.entries(layerUserData.featureProperties).map(
-              ([name, type]) => createLayerEditorFormFieldAtom({ name, type }),
+            fields: Object.entries(layerUserData.featureProperties).map(([name, type]) =>
+              createLayerEditorFormFieldAtom({ name, type }),
             ),
           };
           dispatch([
@@ -107,7 +107,7 @@ export const editableLayerControllerAtom = createAtom(
         };
 
         // @ts-expect-error temporary code
-        data.appId = getUnlistedState(currentApplicationAtom);
+        data.appId = appConfig.id;
 
         schedule(async (dispatch) => {
           try {
@@ -119,11 +119,7 @@ export const editableLayerControllerAtom = createAtom(
                 true,
               );
             } else {
-              responseData = await apiClient.post<EditableLayers>(
-                `/layers`,
-                data,
-                true,
-              );
+              responseData = await apiClient.post<EditableLayers>(`/layers`, data, true);
             }
 
             if (responseData) {

--- a/src/features/create_layer/atoms/editableLayersListResource.ts
+++ b/src/features/create_layer/atoms/editableLayersListResource.ts
@@ -1,42 +1,15 @@
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
-import { createAtom } from '~utils/atoms/createPrimitives';
+import { appConfig } from '~core/app_config';
 import { apiClient } from '~core/apiClientInstance';
-import { currentApplicationAtom } from '~core/shared_state';
 import { EDITABLE_LAYERS_GROUP } from '~core/constants';
 import type { EditableLayers } from '../types';
 
-/**
- * This resource atom get editable user layers
- */
-const editableLayersListDependencyAtom = createAtom(
-  {
-    currentApplicationAtom,
-  },
-  (
-    { onChange },
-    state: {
-      appId: string | null;
-    } = {
-      appId: null,
-    },
-  ) => {
-    onChange('currentApplicationAtom', (currentApplication) => {
-      state = { appId: currentApplication };
-    });
-
-    return state;
-  },
-  'editableLayersListDependencyAtom',
-);
-
 export const editableLayersListResource = createAsyncAtom(
-  editableLayersListDependencyAtom,
-  async (params, abortController) => {
-    if (!params?.appId) return null;
-
+  null,
+  async (_, abortController) => {
     const responseData = await apiClient.post<EditableLayers[]>(
       '/layers/search/user',
-      { appId: params.appId },
+      { appId: appConfig.id },
       true,
       { signal: abortController.signal },
     );

--- a/src/features/create_layer/readme.md
+++ b/src/features/create_layer/readme.md
@@ -40,7 +40,6 @@ This feature uses next core modules:
 
 - logical_layers
 - draw_tools
-- currentApplicationAtom
 - userResourceAtom
 - notificationsService
 - translationService
@@ -81,7 +80,6 @@ flowchart TD
   editableLayersControlsAtom ---> logical_layers:::coreAtom
   editableLayersLegendsAndSources ---> logical_layers:::coreAtom
   editableLayersLegendsAndSources --> editableLayersDetailsResourceAtom
-  editableLayersListResource ---> currentApplicationAtom:::coreAtom
   editableLayersDetailsResourceAtom ---> enabledLayersAtom:::coreAtom
   openDrawToolsInFeatureEditMode ---> editTargetAtom
   openDrawToolsInFeatureEditMode ---> draw_tools:::coreAtom

--- a/src/features/focused_geometry_editor/atoms/isEditorActive.ts
+++ b/src/features/focused_geometry_editor/atoms/isEditorActive.ts
@@ -1,3 +1,3 @@
 import { createBooleanAtom } from '~utils/atoms/createPrimitives';
 
-export const isEditorActiveAtom = createBooleanAtom(false);
+export const isEditorActiveAtom = createBooleanAtom(false, 'isEditorActiveAtom');

--- a/src/features/layers_in_area/atoms/areaLayersControls.ts
+++ b/src/features/layers_in_area/atoms/areaLayersControls.ts
@@ -18,6 +18,7 @@ const allLayers = createAtom(
       ...(get('layersInAreaAndEventLayerResource').data ?? []),
     ];
   },
+  'allLayers',
 );
 
 /**

--- a/src/features/layers_in_area/atoms/layersGlobalResource.ts
+++ b/src/features/layers_in_area/atoms/layersGlobalResource.ts
@@ -1,39 +1,17 @@
+import { appConfig } from '~core/app_config';
 import { apiClient } from '~core/apiClientInstance';
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
-import { createAtom } from '~utils/atoms';
-import { currentApplicationAtom } from '~core/shared_state';
 import { LAYERS_IN_AREA_API_ERROR } from '../constants';
 import type { LayerInArea } from '../types';
 
-const layersGlobalResourceParametersAtom = createAtom(
-  {
-    currentApplicationAtom,
-  },
-  (
-    { onChange },
-    state: {
-      appId: string | null;
-    } = {
-      appId: null,
-    },
-  ) => {
-    onChange('currentApplicationAtom', (currentApplication) => {
-      state = { appId: currentApplication };
-    });
-
-    return state;
-  },
-  'layersGlobalResourceParametersAtom',
-);
-
 export const layersGlobalResource = createAsyncAtom(
-  layersGlobalResourceParametersAtom,
-  async (params, abortController) => {
-    if (!params?.appId) return null;
+  null,
+  async (_, abortController) => {
+    if (!appConfig.id) return null;
 
     const layers = await apiClient.post<LayerInArea[]>(
       '/layers/search/global',
-      { appId: params.appId },
+      { appId: appConfig.id },
       true,
       {
         errorsConfig: { messages: LAYERS_IN_AREA_API_ERROR },

--- a/src/features/layers_in_area/atoms/layersGlobalResource.ts
+++ b/src/features/layers_in_area/atoms/layersGlobalResource.ts
@@ -7,8 +7,6 @@ import type { LayerInArea } from '../types';
 export const layersGlobalResource = createAsyncAtom(
   null,
   async (_, abortController) => {
-    if (!appConfig.id) return null;
-
     const layers = await apiClient.post<LayerInArea[]>(
       '/layers/search/global',
       { appId: appConfig.id },


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/layersInAreaAndEventLayerResource-metric-is-sent-only-after-refresh-the-page-13708

metrics is stopped when page is hidden

additional improvements:
removed currentApplicationAtom and it usages (we have appId in appConfig)
added more missing names for atoms
