### PR TITLE
feat(panel): 14327 - Arrow in the "Analytics" tab is in the incorrect…

### DIFF
--- a/src/utils/hooks/useShortPanelState.tsx
+++ b/src/utils/hooks/useShortPanelState.tsx
@@ -48,9 +48,11 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
   if (skipShortState) {
     const singleControl: PanelCustomControl[] = [
       {
-        icon: panelState === 'full' ? <ChevronUp24 /> : <ChevronDown24 />,
-        onWrapperClick: () =>
-          setPanelState((prevState) => (prevState === 'closed' ? 'full' : 'closed')),
+        icon: panelState === 'closed' ? <ChevronDown24 /> : <ChevronUp24 />,
+        onWrapperClick: () => {
+          const nextState = initialState === 'closed' ? 'full' : initialState;
+          setPanelState((prevState) => (prevState === 'closed' ? nextState : 'closed'));
+        },
       },
     ];
     // hooks must not be skipped - therefore it's late return


### PR DESCRIPTION
… position at the initiate state

https://kontur.fibery.io/Tasks/Task/Arrow-in-the-Analytics-tab-is-in-the-incorrect-position-at-the-initiate-state-14327


![image](https://user-images.githubusercontent.com/20676525/213989279-a28446eb-590b-4ced-b127-0b0d2b0f1ad8.png)
