### PR TITLE
fix(layers_in_area): 13152 selected area differs from event shape

### DIFF
--- a/src/core/shared_state/focusedGeometry.ts
+++ b/src/core/shared_state/focusedGeometry.ts
@@ -86,7 +86,7 @@ export const focusedGeometryAtom = createAtom(
   '[Shared state] focusedGeometryAtom',
 );
 
-export function getEvendId(focusedGeometry: FocusedGeometry | null) {
+export function getEventId(focusedGeometry: FocusedGeometry | null) {
   return focusedGeometry?.source?.type === 'event'
     ? focusedGeometry.source.meta.eventId
     : null;

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
@@ -6,7 +6,6 @@ import { layersGlobalResource } from '../layersGlobalResource';
 import { layersInAreaAndEventLayerResource } from '../layersInAreaAndEventLayerResource';
 import { areaLayersDetailsResourceAtomCache } from './areaLayersDetailsResourceAtomCache';
 import type { DetailsRequestParams } from './types';
-import type { LayerInArea, LayerInAreaDetails } from '~features/layers_in_area/types';
 
 export const areaLayersDetailsParamsAtom = createAtom(
   {

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtom.ts
@@ -7,7 +7,6 @@ import type { LayerInAreaDetails } from '../../types';
 export const areaLayersDetailsResourceAtom = createAsyncAtom(
   areaLayersDetailsParamsAtom,
   async (params, abortController) => {
-    if (params === null) return null;
     if (params.skip) return []; // When all 100% layers in cache we still need to trigger ResourceAtomState to run listeners
     // exclude layersToRetrieveWithEventId from body - in needed just for cache invalidation
     const { layersToRetrieveWithEventId, ...body } = params;

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtom.ts
@@ -8,6 +8,7 @@ export const areaLayersDetailsResourceAtom = createAsyncAtom(
   areaLayersDetailsParamsAtom,
   async (params, abortController) => {
     if (params === null) return null;
+    if (params.skip) return []; // When all 100% layers in cache we still need to trigger ResourceAtomState to run listeners
     // exclude layersToRetrieveWithEventId from body - in needed just for cache invalidation
     const { layersToRetrieveWithEventId, ...body } = params;
     const request = await apiClient.post<LayerInAreaDetails[]>(

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtom.ts
@@ -25,6 +25,7 @@ export const areaLayersDetailsResourceAtom = createAsyncAtom(
     onSuccess: (dispatch, request, response) => {
       if (response === null) return;
       if (request === null) return;
+      if (response.length === 0) return;
       dispatch(areaLayersDetailsResourceAtomCache.update(request, response));
     },
   },

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
@@ -1,15 +1,14 @@
 import type { LayerSource } from '~core/logical_layers/types/source';
 import type { LayerLegend } from '~core/logical_layers/types/legends';
-import type { LayerInAreaDetails } from '../../types';
 
 export interface DetailsRequestParams {
-  layersToRetrieveWithGeometryFilter: string[];
-  layersToRetrieveWithoutGeometryFilter: string[];
-  layersToRetrieveWithEventId: string[];
+  layersToRetrieveWithGeometryFilter?: string[];
+  layersToRetrieveWithoutGeometryFilter?: string[];
+  layersToRetrieveWithEventId?: string[];
   geoJSON?: GeoJSON.GeoJSON;
   eventId?: string;
   eventFeed?: string;
-  cached: LayerInAreaDetails[];
+  skip?: true;
 }
 
 export interface LayerData {

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
@@ -1,3 +1,7 @@
+import type { LayerSource } from '~core/logical_layers/types/source';
+import type { LayerLegend } from '~core/logical_layers/types/legends';
+import type { LayerInAreaDetails } from '../../types';
+
 export interface DetailsRequestParams {
   layersToRetrieveWithGeometryFilter: string[];
   layersToRetrieveWithoutGeometryFilter: string[];
@@ -5,4 +9,10 @@ export interface DetailsRequestParams {
   geoJSON?: GeoJSON.GeoJSON;
   eventId?: string;
   eventFeed?: string;
+  cached: LayerInAreaDetails[];
+}
+
+export interface LayerData {
+  source: LayerSource;
+  legend: LayerLegend | null;
 }

--- a/src/features/layers_in_area/atoms/areaLayersLegendsAndSources.ts
+++ b/src/features/layers_in_area/atoms/areaLayersLegendsAndSources.ts
@@ -3,9 +3,8 @@ import { layersSourcesAtom } from '~core/logical_layers/atoms/layersSources';
 import { layersLegendsAtom } from '~core/logical_layers/atoms/layersLegends';
 import { legendFormatter } from '~features/layers_in_area/utils/legendFormatter';
 import { focusedGeometryAtom } from '~core/shared_state';
-import { getEvendId } from '~core/shared_state/focusedGeometry';
+import { getEventId } from '~core/shared_state/focusedGeometry';
 import { areaLayersDetailsResourceAtom } from './areaLayersDetailsResource';
-import { areaLayersDetailsResourceAtomCache } from './areaLayersDetailsResource/areaLayersDetailsResourceAtomCache';
 import type { LayerInAreaDetails } from '../types';
 import type { LayerSource } from '~core/logical_layers/types/source';
 import type { LayerLegend } from '~core/logical_layers/types/legends';
@@ -44,6 +43,7 @@ export const areaLayersLegendsAndSources = createAtom(
       ...(layersDetails.lastParams?.layersToRetrieveWithGeometryFilter ?? []),
       ...(layersDetails.lastParams?.layersToRetrieveWithoutGeometryFilter ?? []),
     ];
+    // const layersFromCache = layersDetails.lastParams?.cached ?? [];
 
     // Loading started
     if (layersDetails.loading) {
@@ -67,16 +67,6 @@ export const areaLayersLegendsAndSources = createAtom(
         return acc;
       }, new Map<string, LayerInAreaDetails>());
 
-      // apply cached layers if any are already stored for current eventId
-      const focusedGeometry = get('focusedGeometryAtom');
-      const eventId = getEvendId(focusedGeometry);
-      if (eventId) {
-        const cachedLayers = getUnlistedState(areaLayersDetailsResourceAtomCache).get(
-          eventId,
-        );
-        cachedLayers?.forEach((layer) => layersDetailsData.set(layer.id, layer));
-      }
-
       // One error for all requested details
       const layersDetailsError = layersDetails.error ? Error(layersDetails.error) : null;
 
@@ -91,6 +81,16 @@ export const areaLayersLegendsAndSources = createAtom(
             isLoading: false,
           });
         });
+
+        // layersFromCache.forEach((layerDetails) => {
+        //   const layerSource = layerDetails ? convertDetailsToSource(layerDetails) : null;
+        //   newState.set(layerDetails.id, {
+        //     error: layersDetailsError,
+        //     data: layerSource,
+        //     isLoading: false,
+        //   });
+        // });
+
         return newState;
       });
 
@@ -105,6 +105,16 @@ export const areaLayersLegendsAndSources = createAtom(
             isLoading: false,
           });
         });
+
+        // layersFromCache.forEach((layerDetails) => {
+        //   const layerLegend = layerDetails ? convertDetailsToLegends(layerDetails) : null;
+        //   newState.set(layerDetails.id, {
+        //     error: layersDetailsError,
+        //     data: layerLegend,
+        //     isLoading: false,
+        //   });
+        // });
+
         return newState;
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "importsNotUsedAsValues": "error",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "importsNotUsedAsValues": "error",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",


### PR DESCRIPTION
When use change selected event in order:
1. Select event that was never selected before
2. Select previously active event 

This creates a situation in which all the necessary layers are already in the cache so we don't need to trigger api request (areaLayersDetailsResourceAtom). But we have an old fix in areaLayersLegendsAndSources that listen resource atom changes, and then run imperative update of eventShape layers with new geometry (this workaround was created because eventShape always have same id, but in fact different geometry depending from event in request)
I create task for refactoring that will allow us remove this workaround (14387), and as temporary solution I trigger resource atom with skip 'true` flag - it still not send request to backend, but at the same time trigger listeners of resource atom.

Additional small changes
- ~~improvements in ts config that fixes auto imports of type definitions~~ - blocked by [reatom](https://t.me/reatom_ru/24832) bug
- function name misspelling fixed