### PR TITLE
fix(analytics): 14294 - prevent init of analytics with empty features

### DIFF
--- a/src/core/app/features.ts
+++ b/src/core/app/features.ts
@@ -25,6 +25,5 @@ export function setFeatures(value: BackendFeature[] | null) {
   value?.forEach((ft) => {
     newFeatures[ft.name] = true;
   });
-  featureFlagsAtom.set.dispatch(newFeatures);
   store.dispatch([featureFlagsAtom.set(newFeatures), featuresWereSetAtom.setTrue()]);
 }

--- a/src/core/shared_state/featureFlags.ts
+++ b/src/core/shared_state/featureFlags.ts
@@ -5,14 +5,14 @@ import { AppFeature } from '~core/auth/types';
 export const FeatureFlag = AppFeature;
 
 export const featureFlagsAtom = createAtom(
-  { set: (state = appConfig.effectiveFeatures) => state },
+  { set: (state = { ...appConfig.effectiveFeatures }) => state },
   ({ onAction }, state = {}) => {
     onAction('set', (f) => {
       if (f) {
         state = f;
       } else {
         // reset to defaults
-        state = appConfig.effectiveFeatures;
+        state = { ...appConfig.effectiveFeatures };
       }
     });
 

--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -99,7 +99,7 @@ export function MapPage() {
           <ConnectedMap className={s.Map} />
         </Suspense>
       </div>
-      {featureFlags && (
+      {Object.keys(featureFlags).length > 0 && (
         <Layout
           analytics={<Analytics featureFlags={featureFlags} />}
           // if EVENTS_LIST is enabled, we always have default feed


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/After-several-updates-the-initial-state-of-the-analytics-panel-becomes-advanced-analytics-14294

Context:
Reason of a bug being created - sometimes Analytics initial state is full though it's short set.
After investigation with @Akiyamka  we found that the reason is featureFlags being {} at the moment of defining initialState prop:
`initialState={featureFlags[FeatureFlag.ANALYTICS_PANEL] ? 'short' : null}`
When initialState prop is null, in useShortPanelState it's 'full'.
`const initialState = props?.initialState ?? 'full';`
So main line here in fix is 
```
    {Object.keys(featureFlags).length > 0 && (
        <Layout
```
just to render layout after we have features filled. 

- Line in src/core/app/features.ts is just redundant, appeared after merge, so remove it. 
- fixes in src/core/shared_state/featureFlags.ts don't make a bug, but still incorrect as value out of atom can be mutated, that can lead to bugs

