### PR TITLE
fix(layers_in_area) - 14418 cached layers deleted from map

### DIFF
--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
@@ -42,7 +42,7 @@ export const areaLayersDetailsParamsAtom = createAtom(
     if (mustBeRequested.length === 0) {
       // in we return null - resource atom will not updated.
       // But we need it
-      return state ? { ...state, skip: true } : { skip: true };
+      return { skip: true };
     }
 
     const [


### PR DESCRIPTION
lastParams was not reset when request skiped by mistake.
Because of this areaLayersLegendsAndSources delete mounted layers comparing request with response (It looked like the request was made and no response came)