### PR TITLE
feat(areaLayersDetails): 13354 - Calculate Urban Core and Settled Per…

### DIFF
--- a/src/core/bivariate/createBivariateGraphQLQuery.test.ts
+++ b/src/core/bivariate/createBivariateGraphQLQuery.test.ts
@@ -10,6 +10,7 @@ test('createBivariateQuery - cleans prefilled properties', () => {
   const geometry: FocusedGeometry = {
     geometry: {
       type: 'FeatureCollection',
+      hash: 'test_hash',
       features: [
         {
           type: 'Feature',

--- a/src/core/shared_state/focusedGeometry.ts
+++ b/src/core/shared_state/focusedGeometry.ts
@@ -38,9 +38,11 @@ export type GeometrySource =
   | GeometrySourceFromFile
   | GeometrySourceDrawn;
 
+export type GeometryWithHash = GeoJSON.GeoJSON & { hash: string };
+
 export interface FocusedGeometry {
   source: GeometrySource;
-  geometry: GeoJSON.GeoJSON;
+  geometry: GeometryWithHash;
 }
 
 export const focusedGeometryAtom = createAtom(

--- a/src/core/shared_state/focusedGeometry.ts
+++ b/src/core/shared_state/focusedGeometry.ts
@@ -65,7 +65,8 @@ export const focusedGeometryAtom = createAtom(
           // update only in case if geometry source or hash has changed
           if (!state || !ctx.hash || ctx.hash !== hash) {
             ctx.hash = hash;
-            dispatch(create('_update', { source, geometry }));
+            const geometryWithHash = { ...geometry, hash };
+            dispatch(create('_update', { source, geometry: geometryWithHash }));
           }
         });
       } else {

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
@@ -33,7 +33,7 @@ export const areaLayersDetailsParamsAtom = createAtom(
       if (!isEnabled) return false;
 
       if (layer.boundaryRequiredForRetrieval) {
-        const cacheKey: string | undefined = focusedGeometry?.geometry['hash'];
+        const cacheKey = focusedGeometry?.geometry.hash;
         const cached = cacheKey ? cache.get(cacheKey) : false;
         return !cached;
       }

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
@@ -3,18 +3,28 @@ import { currentUserAtom } from '~core/shared_state';
 import type { LayerInAreaDetails } from '../../types';
 import type { DetailsRequestParams } from './types';
 
+type EventId = string | null;
+type Hash = string;
+type LayerId = string;
+type AreaLayersDetailsResourceAtomCache = Map<
+  EventId | Hash,
+  Map<LayerId, LayerInAreaDetails> | boolean
+>;
+
 const createDefaultCacheState = (state?) => {
-  type EventId = string | null;
-  type LayerId = string;
-  type AreaLayersDetailsResourceAtomCache = Map<
-    EventId,
-    Map<LayerId, LayerInAreaDetails>
-  >;
   const cache: AreaLayersDetailsResourceAtomCache = state ? new Map(state) : new Map();
   return cache;
 };
 
-/* Store all prev request */
+/* 
+Store all prev request
+Cache structure: 
+  Map 
+  - key: focusedGeometry hash, value: true | For layer with boundaryRequiredForRetrieval=true flag
+  - key: eventId, value: Map | For layer with eventIdRequiredForRetrieval=true flag
+  - key: null, value: Map | For layer with eventIdRequiredForRetrieval=false flag
+*/
+
 export const areaLayersDetailsResourceAtomCache = createAtom(
   {
     user: currentUserAtom,
@@ -31,14 +41,29 @@ export const areaLayersDetailsResourceAtomCache = createAtom(
     onAction('update', ({ request, response }) => {
       state = createDefaultCacheState(state);
       const layersToRetrieveWithEventId = new Set(request.layersToRetrieveWithEventId);
+      const layersToRetrieveWithGeometryFilter = new Set(
+        request.layersToRetrieveWithGeometryFilter,
+      );
       response.forEach((layer) => {
+        if (layersToRetrieveWithGeometryFilter.has(layer.id)) {
+          const geometryHash: string | undefined = request?.geoJSON?.['hash'];
+          if (geometryHash && !state.get(geometryHash)) {
+            state.set(geometryHash, true);
+          }
+          return state;
+        }
+
         const eventId = layersToRetrieveWithEventId.has(layer.id)
           ? request.eventId ?? null
           : null;
         if (!state.get(eventId)) {
           state.set(eventId, new Map());
         }
-        state.get(eventId)!.set(layer.id, layer);
+
+        const cacheValue = state.get(eventId);
+        if (cacheValue instanceof Map) {
+          cacheValue.set(layer.id, layer);
+        }
       });
     });
     return state;

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
@@ -46,7 +46,7 @@ export const areaLayersDetailsResourceAtomCache = createAtom(
       );
       response.forEach((layer) => {
         if (layersToRetrieveWithGeometryFilter.has(layer.id)) {
-          const geometryHash: string | undefined = request?.geoJSON?.['hash'];
+          const geometryHash = request?.geoJSON?.hash;
           if (geometryHash && !state.get(geometryHash)) {
             state.set(geometryHash, true);
           }

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
@@ -8,7 +8,7 @@ type Hash = string;
 type LayerId = string;
 type AreaLayersDetailsResourceAtomCache = Map<
   EventId | Hash,
-  Map<LayerId, LayerInAreaDetails> | boolean
+  Map<LayerId, LayerInAreaDetails>
 >;
 
 const createDefaultCacheState = (state?) => {
@@ -20,7 +20,7 @@ const createDefaultCacheState = (state?) => {
 Store all prev request
 Cache structure: 
   Map 
-  - key: focusedGeometry hash, value: true | For layer with boundaryRequiredForRetrieval=true flag
+  - key: focusedGeometry hash, value: Map | For layer with boundaryRequiredForRetrieval=true flag
   - key: eventId, value: Map | For layer with eventIdRequiredForRetrieval=true flag
   - key: null, value: Map | For layer with eventIdRequiredForRetrieval=false flag
 */
@@ -45,28 +45,39 @@ export const areaLayersDetailsResourceAtomCache = createAtom(
         request.layersToRetrieveWithGeometryFilter,
       );
       response.forEach((layer) => {
-        if (layersToRetrieveWithGeometryFilter.has(layer.id)) {
-          const geometryHash = request?.geoJSON?.hash;
-          if (geometryHash && !state.get(geometryHash)) {
-            state.set(geometryHash, true);
-          }
-          return state;
-        }
+        const cacheKey: string | null = getLayersDetailsCacheKey({
+          boundaryRequiredForRetrieval: layersToRetrieveWithGeometryFilter.has(layer.id),
+          eventIdRequiredForRetrieval: layersToRetrieveWithEventId.has(layer.id),
+          eventId: request.eventId,
+          hash: request.geoJSON?.hash,
+        });
 
-        const eventId = layersToRetrieveWithEventId.has(layer.id)
-          ? request.eventId ?? null
-          : null;
-        if (!state.get(eventId)) {
-          state.set(eventId, new Map());
+        if (!state.get(cacheKey)) {
+          state.set(cacheKey, new Map());
         }
-
-        const cacheValue = state.get(eventId);
-        if (cacheValue instanceof Map) {
-          cacheValue.set(layer.id, layer);
-        }
+        state.get(cacheKey)!.set(layer.id, layer);
       });
     });
     return state;
   },
   'areaLayersDetailsResourceAtomCache',
 );
+
+export const getLayersDetailsCacheKey = ({
+  boundaryRequiredForRetrieval,
+  eventIdRequiredForRetrieval,
+  eventId,
+  hash,
+}: {
+  boundaryRequiredForRetrieval?: boolean;
+  eventIdRequiredForRetrieval?: boolean;
+  eventId?: string | null;
+  hash?: string;
+}): string | null => {
+  if (boundaryRequiredForRetrieval && hash) {
+    return hash;
+  } else if (eventIdRequiredForRetrieval && eventId) {
+    return eventId;
+  }
+  return null;
+};

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
@@ -1,3 +1,4 @@
+import type { GeometryWithHash } from '~core/shared_state/focusedGeometry';
 import type { LayerSource } from '~core/logical_layers/types/source';
 import type { LayerLegend } from '~core/logical_layers/types/legends';
 
@@ -5,7 +6,7 @@ export interface DetailsRequestParams {
   layersToRetrieveWithGeometryFilter?: string[];
   layersToRetrieveWithoutGeometryFilter?: string[];
   layersToRetrieveWithEventId?: string[];
-  geoJSON?: GeoJSON.GeoJSON;
+  geoJSON?: GeometryWithHash;
   eventId?: string;
   eventFeed?: string;
   skip?: true;

--- a/src/features/layers_in_area/atoms/areaLayersLegendsAndSources.ts
+++ b/src/features/layers_in_area/atoms/areaLayersLegendsAndSources.ts
@@ -74,7 +74,9 @@ export const areaLayersLegendsAndSources = createAtom(
         const cachedLayers = getUnlistedState(areaLayersDetailsResourceAtomCache).get(
           eventId,
         );
-        cachedLayers?.forEach((layer) => layersDetailsData.set(layer.id, layer));
+        if (cachedLayers instanceof Map) {
+          cachedLayers?.forEach((layer) => layersDetailsData.set(layer.id, layer));
+        }
       }
       // One error for all requested details
       const layersDetailsError = layersDetails.error ? Error(layersDetails.error) : null;

--- a/src/features/layers_in_area/atoms/areaLayersLegendsAndSources.ts
+++ b/src/features/layers_in_area/atoms/areaLayersLegendsAndSources.ts
@@ -66,16 +66,24 @@ export const areaLayersLegendsAndSources = createAtom(
         acc.set(layerDetails.id, layerDetails);
         return acc;
       }, new Map<string, LayerInAreaDetails>());
+      const boundaryRequiredLayersDetailsData = new Map<string, LayerInAreaDetails>();
 
       // apply cached layers if any are already stored for current eventId
       const focusedGeometry = get('focusedGeometryAtom');
       const eventId = getEventId(focusedGeometry);
       if (eventId) {
-        const cachedLayers = getUnlistedState(areaLayersDetailsResourceAtomCache).get(
-          eventId,
+        const cache = getUnlistedState(areaLayersDetailsResourceAtomCache);
+        const cachedEventIdRequiredLayers = cache.get(eventId);
+        cachedEventIdRequiredLayers?.forEach((layer) =>
+          layersDetailsData.set(layer.id, layer),
         );
-        if (cachedLayers instanceof Map) {
-          cachedLayers?.forEach((layer) => layersDetailsData.set(layer.id, layer));
+
+        const hash = focusedGeometry?.geometry.hash;
+        if (hash) {
+          const cachedBoundaryRequiredLayers = cache.get(hash);
+          cachedBoundaryRequiredLayers?.forEach((layer) => {
+            boundaryRequiredLayersDetailsData.set(layer.id, layer);
+          });
         }
       }
       // One error for all requested details
@@ -85,6 +93,14 @@ export const areaLayersLegendsAndSources = createAtom(
         const newState = new Map(state);
         requestedLayers.forEach((layerId) => {
           const layerDetails = layersDetailsData.get(layerId);
+          const layerSource = layerDetails ? convertDetailsToSource(layerDetails) : null;
+          newState.set(layerId, {
+            error: layersDetailsError,
+            data: layerSource,
+            isLoading: false,
+          });
+        });
+        boundaryRequiredLayersDetailsData.forEach((layerDetails, layerId) => {
           const layerSource = layerDetails ? convertDetailsToSource(layerDetails) : null;
           newState.set(layerId, {
             error: layersDetailsError,


### PR DESCRIPTION
…iphery for any focused area

https://kontur.fibery.io/Tasks/Task/Calculate-Urban-Core-and-Settled-Periphery-for-any-focused-area-13354

**Context:** 
Urban Core and Settled Periphery don't recalculate on new drawn geometry. 
But we want to have them recalculated every time we draw something. 
The reason was in cache invalidation. 
After request on api/layers/details we put results in cache. 

Before we had 2 type of record in cache: 
- eventId: Map
- null: Map

Now we extended it with 3rd type:
- hash: true

This is the hash of focusedGeometry, to invalidate layer with boundaryRequiredForRetrieval flag.
So if layer is boundaryRequiredForRetrieval and current focusedGeometry is already in cache - we don't need to request this layer again.

**Notes:**
```
if (layer.eventIdRequiredForRetrieval && !eventId) {
  console.warn(
    `Layer ${layer.id} request is skipped, as eventIdRequiredForRetrieval is true but evenntId is empty.`,
  );
  return false;
}
```
These lines fix a situation when in atom comes eventShape layer, that requires eventId, but eventId is already null.
This layer disappears next update, so this code just prevent invalid request. (check screenshot, 400 error)
<img width="613" alt="Screenshot 2023-01-31 at 11 59 00" src="https://user-images.githubusercontent.com/20676525/215715060-7e3f5c7c-bc48-4ba6-94dd-674222574e4f.png">


