### PR TITLE
fix(layers_in_area): 14318 - don't update layers in area for /details while loading or on error

### DIFF
--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
@@ -18,11 +18,9 @@ export const areaLayersDetailsParamsAtom = createAtom(
     state: DetailsRequestParams | null = null,
   ): DetailsRequestParams | null => {
     const layersGlobal = get('layersGlobalResource');
-    const layersInAreaAndEventLayer = get('layersInAreaAndEventLayerResource');
-    const allLayers = [
-      ...(layersGlobal.data ?? []),
-      ...(layersInAreaAndEventLayer.data ?? []),
-    ];
+    const { loading, error, data } = get('layersInAreaAndEventLayerResource');
+    const layersInAreaAndEventLayer = loading || error || !data ? [] : data;
+    const allLayers = [...(layersGlobal.data ?? []), ...layersInAreaAndEventLayer];
     const enabledLayers = get('enabledLayersAtom');
     const focusedGeometry = getUnlistedState(focusedGeometryAtom);
     const eventId = getEventId(focusedGeometry);


### PR DESCRIPTION
fixes error when user had event shape layer turned on and switched to non-event geometry
![image](https://user-images.githubusercontent.com/50058726/216393348-9a8f7854-ff69-45ab-afb7-7070fb4e8d8d.png)
