### PR TITLE
fix: hide unrouded corners from inner components

### DIFF
--- a/src/features/events_list/components/EventsPanel/EventsPanel.module.css
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.module.css
@@ -36,6 +36,7 @@
 .eventsPanel {
   position: relative;
   border-radius: var(--border-radius-unit);
+  overflow: hidden;
   flex: 1;
 
   &.show > .contentWrap {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Bottom-corners-are-not-rounded-on-short-Disasters-panel-13689