### PR TITLE
doc(toolbar, core): 13746 - add doc and fix core a tiny bit

### DIFF
--- a/src/core/shared_state/toolbarControls.ts
+++ b/src/core/shared_state/toolbarControls.ts
@@ -2,17 +2,20 @@ import { createAtom } from '~utils/atoms';
 import { currentUserAtom } from '~core/shared_state/currentUser';
 import type { Action } from '@reatom/core';
 
-export interface SideControl {
+type SideControl = {
   id: string;
   name: string;
   icon: JSX.Element | null;
   active: boolean;
   title: string;
+  // only one control of a given group can be enabled.
+  // Enabling 2nd control from the same group will run `disable` action for the first enabled control
   exclusiveGroup?: string;
-  visualGroup: string;
+  // allows toolbar component to group controls into sections
+  visualGroup?: string;
   onClick?: (isActive: boolean) => void;
   onChange?: (isActive: boolean) => void;
-}
+};
 
 export const controlGroup = {
   mapTools: 'mapTools',

--- a/src/features/toolbar/readme.md
+++ b/src/features/toolbar/readme.md
@@ -1,3 +1,11 @@
-<h2>Toolbar</h2>
+## Toolbar
 
 This feature combines registered controls of other features and puts them in predefined order as buttons inside panel component
+
+### How to use
+
+Just import <Toolbar /> component from root directory
+
+### How it works
+
+It simply maps over `toolbarControlsAtom`. Controls ([see SideControl type](https://github.com/konturio/disaster-ninja-fe/blob/main/src/core/shared_state/toolbarControls.ts)) of this atom describe buttons appearance and the logic on click, on becoming active/inactive and belonging to mutually exclusive controls


### PR DESCRIPTION
there was no need for exporting interface and for the `interface` instead of `type`