### PR TITLE
fix(core): 14439 filter-out-layers-that-can't-be-shown

### DIFF
--- a/src/core/api_client/apiClient.ts
+++ b/src/core/api_client/apiClient.ts
@@ -444,10 +444,12 @@ export class ApiClient {
         );
       }
 
-      if (!requestConfig.headers || !requestConfig.headers.Authorization) {
-        requestConfig.headers = {
-          Authorization: `Bearer ${this.token}`,
-        };
+      if (!requestConfig.headers) {
+        requestConfig.headers = {};
+      }
+
+      if (!requestConfig.headers.Authorization) {
+        requestConfig.headers.Authorization = `Bearer ${this.token}`;
       }
     }
 

--- a/src/core/app/types.ts
+++ b/src/core/app/types.ts
@@ -1,5 +1,6 @@
 import type { UserProfileApi } from './user';
 import type { AppFeatureType } from '~core/auth/types';
+import type { LayerDetailsDto } from '~core/logical_layers/types/source';
 
 export interface AppConfig {
   API_GATEWAY: string;
@@ -76,24 +77,28 @@ export interface AppConfigGlobal {
 }
 
 // Unified config from /app/configuration
-export type AppConfiguration = {
+export interface AppDto {
   id: string;
   name: string;
   description: string;
   ownedByUser: boolean;
-  features?: AppConfigurationFeature[];
+  features?: FeatureDto[];
   sidebarIconUrl: string;
   faviconUrl: string;
   public: boolean;
   extent: [number, number, number, number];
   user?: UserProfileApi;
-};
+}
 
-export type AppConfigurationFeature = {
+export interface FeatureDto {
   name: string;
   description: string;
   type: string;
   configuration: object;
-};
+}
 
-export type AppConfigEffective = AppConfigGlobal & AppConfiguration;
+export interface AppConfigExtras {
+  defaultLayers: LayerDetailsDto[];
+}
+
+export type AppConfigEffective = AppConfigGlobal & AppDto & AppConfigExtras;

--- a/src/core/logical_layers/basemap.ts
+++ b/src/core/logical_layers/basemap.ts
@@ -1,0 +1,22 @@
+// temporary place for basemap-related stuff
+import type { LayerDetailsDto } from '~core/logical_layers/types/source';
+export const MAPBOX_EMPTY_STYLE = { version: 8, sources: {}, layers: [] };
+export const BASEMAPS_LIST = ['kontur_lines', 'kontur_zmrok'];
+export const BASEMAP_SOURCE_TYPE = 'maplibre-style-url';
+
+export function getBasemapFromDetails(layers: LayerDetailsDto[]) {
+  const basemapLayer = layers.find((d) => d.source?.type === BASEMAP_SOURCE_TYPE);
+  const basemapLayerUrl = basemapLayer?.source?.urls?.at(0);
+  console.assert(basemapLayer, 'No default basemap');
+  return {
+    basemapLayer,
+    basemapLayerId: basemapLayer?.id ?? BASEMAPS_LIST[0],
+    basemapLayerUrl,
+  };
+}
+
+export function findBasemapInLayersList(layers: string[]) {
+  for (const basemap of BASEMAPS_LIST) {
+    if (layers.includes(basemap)) return basemap;
+  }
+}

--- a/src/core/logical_layers/layerTypes.ts
+++ b/src/core/logical_layers/layerTypes.ts
@@ -1,0 +1,45 @@
+import type { LayerDetailsDto, LayerSummaryDto } from './types/source';
+
+export const SUPPORTED_LAYER_TYPE = {
+  //rasters - supported by FE
+  'raster-xyz': true, // xyz -  y goes down
+  'raster-tms': true, // tms - y goes up
+  'raster-quadkey': true, // quadkey - bing
+  'raster-wms': true, // wms
+  'raster-dem': true, // dem tiles
+  //vector
+  'vector-mvt': true, // mvt
+  'vector-geojson-url': true,
+  'vector-geojson': true, // geojson
+  //maplibre-style
+  'maplibre-style-url': true, // - planned to support - basemap type
+  'maplibre-style': true, // - (embedded in response)
+  //legend:
+  // simple legend
+  // bivariate legend
+  // (mcda legend)
+};
+
+export function isLayerSupported(layer: LayerSummaryDto) {
+  // FIXME: remove when BE will be returning correct type
+  if (layer.type && ['scanex', 'wms_endpoint', 'wmts'].includes(layer.type)) {
+    return false;
+  } else {
+    return true;
+  }
+
+  //// correct detection
+  // if (layer.type) {
+  //   return SUPPORTED_LAYER_TYPE[layer.type];
+  // }
+
+  // HACK: type for BIV layers should be provided by BE
+  if (layer?.group === 'bivariate') {
+    return true;
+  }
+  return false;
+}
+
+export function filterUnsupportedLayerTypes(layers: LayerSummaryDto[]) {
+  return layers.filter(isLayerSupported);
+}

--- a/src/core/logical_layers/types/source.ts
+++ b/src/core/logical_layers/types/source.ts
@@ -1,7 +1,7 @@
 import type { LayerDetailsLegend } from '~core/logical_layers/types/legends';
 
 export interface LayerSourceDto {
-  type: 'vector' | 'raster' | 'geojson';
+  type: 'vector' | 'raster' | 'geojson' | 'maplibre-style-url';
   urls?: string[];
   tileSize?: number;
   data?: unknown; // only for GeoJSON
@@ -12,7 +12,7 @@ export interface LayerDetailsDto {
   id: string;
   maxZoom?: number;
   minZoom?: number;
-  source: LayerSourceDto;
+  source?: LayerSourceDto;
   legend?: LayerDetailsLegend;
   ownedByUser?: boolean;
 }
@@ -50,5 +50,5 @@ export interface LayerSummaryDto {
   copyrights?: string[];
   ownedByUser: boolean;
   featureProperties?: object;
-  mapboxStyle?: string;
+  type?: string;
 }

--- a/src/features/analytics_panel/atoms/currentEventData.ts
+++ b/src/features/analytics_panel/atoms/currentEventData.ts
@@ -13,4 +13,5 @@ export const currentEventDataAtom = createAtom(
     }
     return null;
   },
+  'currentEventDataAtom',
 );

--- a/src/features/current_event/atoms/currentEventAutoFocus.ts
+++ b/src/features/current_event/atoms/currentEventAutoFocus.ts
@@ -33,5 +33,5 @@ export const currentEventAutoFocusAtom = createAtom(
       }
     });
   },
-  '[Shared state] currentEventAtom',
+  'currentEventAutoFocusAtom',
 );

--- a/src/features/current_event/atoms/currentEventRefresher.ts
+++ b/src/features/current_event/atoms/currentEventRefresher.ts
@@ -20,4 +20,5 @@ export const currentEventRefresherAtom = createAtom(
       }
     });
   },
+  'currentEventRefresherAtom',
 );

--- a/src/features/events_list/atoms/currentEventBbox.ts
+++ b/src/features/events_list/atoms/currentEventBbox.ts
@@ -56,4 +56,5 @@ export const currentEventBbox = createAtom(
 
     return bbox;
   },
+  'currentEventBboxAtom',
 );

--- a/src/features/events_list/atoms/eventListFilters.ts
+++ b/src/features/events_list/atoms/eventListFilters.ts
@@ -44,4 +44,5 @@ export const eventListFilters = createAtom(
 
     return state;
   },
+  'eventListFiltersAtom',
 );

--- a/src/features/focused_geometry_layer/atoms/focusedGeometrySourceAtom.ts
+++ b/src/features/focused_geometry_layer/atoms/focusedGeometrySourceAtom.ts
@@ -52,4 +52,5 @@ export const createFocusedGeometrySourceAtom = (sourceId: string) =>
         });
       }
     },
+    'focusedGeometrySourceAtom:' + sourceId,
   );

--- a/src/features/layers_in_area/atoms/layersGlobalResource.ts
+++ b/src/features/layers_in_area/atoms/layersGlobalResource.ts
@@ -1,6 +1,7 @@
 import { appConfig } from '~core/app_config';
 import { apiClient } from '~core/apiClientInstance';
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
+import { filterUnsupportedLayerTypes } from '~core/logical_layers/layerTypes';
 import { LAYERS_IN_AREA_API_ERROR } from '../constants';
 import type { LayerSummaryDto } from '~core/logical_layers/types/source';
 
@@ -16,7 +17,7 @@ export const layersGlobalResource = createAsyncAtom(
         signal: abortController.signal,
       },
     );
-    return layers;
+    return filterUnsupportedLayerTypes(layers || []);
   },
   'layersGlobalResource',
 );

--- a/src/features/layers_in_area/atoms/layersInAreaAndEventLayerResource.ts
+++ b/src/features/layers_in_area/atoms/layersInAreaAndEventLayerResource.ts
@@ -5,6 +5,7 @@ import { focusedGeometryAtom } from '~core/focused_geometry/model';
 import { createAtom } from '~utils/atoms';
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
 import { removeEmpty } from '~utils/common';
+import { filterUnsupportedLayerTypes } from '~core/logical_layers/layerTypes';
 import { LAYERS_IN_AREA_API_ERROR } from '../constants';
 import type { LayerSummaryDto } from '~core/logical_layers/types/source';
 import type { FocusedGeometry } from '~core/focused_geometry/types';
@@ -65,7 +66,7 @@ export const layersInAreaAndEventLayerResource = createAsyncAtom(
         signal: abortController.signal,
       },
     );
-    return layers;
+    return filterUnsupportedLayerTypes(layers || []);
   },
   'layersInAreaAndEventLayerResource',
 );

--- a/src/features/layers_panel/atoms/categoryDeselection.ts
+++ b/src/features/layers_panel/atoms/categoryDeselection.ts
@@ -10,16 +10,13 @@ export const categoryDeselection = createAtom(
     onAction('deselect', (categoryId) => {
       const enabledLayers = getUnlistedState(enabledLayersAtom);
       const layersSettings = getUnlistedState(layersSettingsAtom);
-      const enabledLayersInGroup = Array.from(enabledLayers).reduce(
-        (acc, id) => {
-          const settings = layersSettings.get(id);
-          if (settings?.data?.category === categoryId) {
-            acc.push(id);
-          }
-          return acc;
-        },
-        [] as string[],
-      );
+      const enabledLayersInGroup = Array.from(enabledLayers).reduce((acc, id) => {
+        const settings = layersSettings.get(id);
+        if (settings?.data?.category === categoryId) {
+          acc.push(id);
+        }
+        return acc;
+      }, [] as string[]);
       if (enabledLayersInGroup.length === 0) return;
 
       const disableActions = enabledLayersInGroup.map((layerId) =>
@@ -28,4 +25,5 @@ export const categoryDeselection = createAtom(
       schedule((dispatch) => dispatch(disableActions));
     });
   },
+  'categoryDeselectionAtom',
 );

--- a/src/features/layers_panel/atoms/groupDeselection.ts
+++ b/src/features/layers_panel/atoms/groupDeselection.ts
@@ -10,16 +10,13 @@ export const groupDeselection = createAtom(
     onAction('deselect', (groupId) => {
       const enabledLayers = getUnlistedState(enabledLayersAtom);
       const layersSettings = getUnlistedState(layersSettingsAtom);
-      const enabledLayersInGroup = Array.from(enabledLayers).reduce(
-        (acc, id) => {
-          const settings = layersSettings.get(id);
-          if (settings?.data?.group === groupId) {
-            acc.push(id);
-          }
-          return acc;
-        },
-        [] as string[],
-      );
+      const enabledLayersInGroup = Array.from(enabledLayers).reduce((acc, id) => {
+        const settings = layersSettings.get(id);
+        if (settings?.data?.group === groupId) {
+          acc.push(id);
+        }
+        return acc;
+      }, [] as string[]);
       if (enabledLayersInGroup.length === 0) return;
 
       const disableActions = enabledLayersInGroup.map((layerId) =>
@@ -28,4 +25,5 @@ export const groupDeselection = createAtom(
       schedule((dispatch) => dispatch(disableActions));
     });
   },
+  'groupDeselectionAtom',
 );


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/DN2-FE.-Utilize-layer-type-property-to-filter-out-layers-that-can't-be-shown-14439

filter unsupported layers (hardcoded list till BE return correct type)
apiClient fix
add missing atom names
get default basemap from api