### PR TITLE
15292-ukrainian-language-is-not-written-in-ukrainian-in-language-menu

### DIFF
--- a/src/core/localization/gettext/uk/common.po
+++ b/src/core/localization/gettext/uk/common.po
@@ -942,7 +942,7 @@ msgstr "Німецька"
 
 #: profile##languageOption##uk
 msgid "Ukrainian"
-msgstr ""
+msgstr "Українська"
 
 #: locate_me##get_location_error
 msgid "Error while getting location"


### PR DESCRIPTION
adding missed translation