### PR TITLE
feat(timeline): show timeline toggle if event episode count > 1

### DIFF
--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -54,6 +54,8 @@ export interface Event {
   description?: string;
   /** Event geometry bbox */
   bbox: [number, number, number, number];
+  /** Event epsode count */
+  episodeCount: number;
 }
 
 export interface AnalyticsData {
@@ -94,6 +96,7 @@ export type EventWithGeometry = {
   osmGaps: number | null;
   updatedAt: string;
   bbox: [number, number, number, number];
+  episodeCount: number;
 };
 
 export type LegendStepStyle = {

--- a/src/features/events_list/components/CurrentEvent/CurrentEvent.tsx
+++ b/src/features/events_list/components/CurrentEvent/CurrentEvent.tsx
@@ -31,7 +31,9 @@ export function CurrentEvent({
         event={event}
         isActive={true}
         alternativeActionControl={
-          hasTimeline ? <EpisodeTimelineToggle isActive={true} /> : null
+          hasTimeline && event.episodeCount > 1 ? (
+            <EpisodeTimelineToggle isActive={true} />
+          ) : null
         }
         externalUrls={event.externalUrls}
         showDescription={showDescription}

--- a/src/features/events_list/components/FullState/FullState.tsx
+++ b/src/features/events_list/components/FullState/FullState.tsx
@@ -82,7 +82,7 @@ export function FullState({
                     isActive={event.eventId === currentEventId}
                     onClick={eventClickHandler}
                     alternativeActionControl={
-                      hasTimeline ? (
+                      hasTimeline && event.episodeCount > 1 ? (
                         <EpisodeTimelineToggle
                           isActive={event.eventId === currentEventId}
                         />


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Hide-play-button-if-a-disaster-has-less-than-2-episodes-15274