### PR TITLE
Version 2.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "disaster-ninja-fe",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "disaster-ninja-fe",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "disaster-ninja-fe",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "private": true,
   "homepage": "/active/",
   "type": "module",


### PR DESCRIPTION
fix: 16393-center-disaster-geometry-by-map-without-panels-on-mobile-devices-2
15507 add log endpoint in front go server 
15507 Better critical error message