### PR TITLE
feat(toolbar): add toolbar short state

### DIFF
--- a/src/core/toolbar/example.tsx
+++ b/src/core/toolbar/example.tsx
@@ -64,7 +64,7 @@ function ExampleControl({
     case 'widget':
       return (
         <settings.typeSettings.component
-          controlClassName="someToolbarClass"
+          controlComponent={() => null}
           onClick={toggleState}
           state={state}
         />

--- a/src/core/toolbar/types.ts
+++ b/src/core/toolbar/types.ts
@@ -1,3 +1,4 @@
+import type { ButtonProps } from '@konturio/ui-kit/tslib/Button';
 import type { PrimitiveAtom } from '@reatom/core/primitives';
 
 export type ControlID = string;
@@ -25,11 +26,6 @@ interface CommonToolbarControlSettings {
   typeSettings: Record<string, unknown>;
 }
 
-interface ControlComponentProps {
-  state: ControlState;
-  onClick: () => void;
-}
-
 // Button
 interface ToolbarButtonSettings extends CommonToolbarControlSettings {
   type: 'button';
@@ -37,15 +33,27 @@ interface ToolbarButtonSettings extends CommonToolbarControlSettings {
     name: string | ValueForState<string>;
     hint: string | ValueForState<string>;
     icon: string | ValueForState<string>;
-    preferredSize: 'tiny' | 'large' | 'small' | 'medium';
+    preferredSize: ButtonProps['size'];
     /* Only for edge cases when you need direct access to element */
     onRef?: (el: HTMLElement) => void;
   };
 }
 
+// Control button component props
+export interface ControlComponentProps {
+  icon: React.ReactElement;
+  onClick: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+  active?: boolean;
+  size: ButtonProps['size'];
+  variant?: ButtonProps['variant'];
+  className?: string;
+}
+
 // Widget
 export interface WidgetProps {
-  controlClassName: string;
+  controlComponent: React.ComponentType<ControlComponentProps>;
   state: ControlState;
   onClick: () => void;
 }

--- a/src/features/toolbar/components/ShortToolbarButton/ShortToolbarButton.module.css
+++ b/src/features/toolbar/components/ShortToolbarButton/ShortToolbarButton.module.css
@@ -1,0 +1,15 @@
+.toolbarButton_tiny {
+  align-items: flex-start;
+  grid-row: span 2;
+}
+
+.toolbarButton_medium {
+  grid-row: span 3;
+  align-items: flex-start;
+}
+
+.toolbarButton_large {
+  grid-row: span 6;
+  white-space: pre-line;
+  justify-content: center !important; /* TODO: fix in ui-kit */
+}

--- a/src/features/toolbar/components/ShortToolbarButton/ShortToolbarButton.tsx
+++ b/src/features/toolbar/components/ShortToolbarButton/ShortToolbarButton.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@konturio/ui-kit';
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+import s from './ShortToolbarButton.module.css';
+import type { ButtonProps } from '@konturio/ui-kit/tslib/Button';
+import type { ControlButttonProps } from '../ToolbarButton/ToolbarButton';
+
+export const ShortToolbarButton = forwardRef(function ToolbarButton(
+  {
+    icon,
+    disabled,
+    onClick,
+    variant = 'invert',
+    className,
+    active,
+  }: React.PropsWithoutRef<ControlButttonProps>,
+  ref: React.Ref<HTMLButtonElement>,
+) {
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      iconBefore={icon}
+      size="tiny"
+      className={clsx(className)}
+      disabled={disabled}
+      active={active}
+      onClick={onClick}
+    />
+  );
+});

--- a/src/features/toolbar/components/ShortToolbarContent/ShortToolbarContent.module.scss
+++ b/src/features/toolbar/components/ShortToolbarContent/ShortToolbarContent.module.scss
@@ -1,0 +1,13 @@
+.toolbarContent {
+  padding: 16px;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 8px;
+}
+
+.section {
+  display: flex;
+  flex-flow: row nowrap;
+  border-radius: 4px;
+  border: 1px solid var(--faint-weak, #eceeef);
+}

--- a/src/features/toolbar/components/ShortToolbarContent/ShortToolbarContent.tsx
+++ b/src/features/toolbar/components/ShortToolbarContent/ShortToolbarContent.tsx
@@ -1,5 +1,36 @@
+import { Fragment } from 'react';
+import { useAtom } from '@reatom/react';
+import { toolbar } from '~core/toolbar';
+import { ToolbarControl } from '../ToolbarControl/ToolbarControl';
+import { ShortToolbarButton } from '../ShortToolbarButton/ShortToolbarButton';
 import s from './ShortToolbarContent.module.scss';
 
 export const ShortToolbarContent = () => {
-  return <div className={s.shortToolbarContent}>Short</div>;
+  const [controls] = useAtom(toolbar.controls);
+
+  return (
+    <div className={s.toolbarContent}>
+      {toolbar.toolbarSettings.sections.map((section, index) => (
+        <div key={section.name} className={s.section}>
+          <div className={s.sectionContent}>
+            {section.controls.map((id) => {
+              const settings = controls.get(id);
+              const stateAtom = toolbar.getControlState(id);
+
+              if (!settings || !stateAtom) return null;
+              return (
+                <ToolbarControl
+                  id={id}
+                  key={id}
+                  settings={settings}
+                  stateAtom={stateAtom}
+                  controlComponent={ShortToolbarButton}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 };

--- a/src/features/toolbar/components/ToolbarButton/ToolbarButton.module.css
+++ b/src/features/toolbar/components/ToolbarButton/ToolbarButton.module.css
@@ -1,0 +1,15 @@
+.toolbarButton_tiny {
+  align-items: flex-start;
+  grid-row: span 2;
+}
+
+.toolbarButton_medium {
+  grid-row: span 3;
+  align-items: flex-start;
+}
+
+.toolbarButton_large {
+  grid-row: span 6;
+  white-space: pre-line;
+  justify-content: center !important; /* TODO: fix in ui-kit */
+}

--- a/src/features/toolbar/components/ToolbarButton/ToolbarButton.tsx
+++ b/src/features/toolbar/components/ToolbarButton/ToolbarButton.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@konturio/ui-kit';
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+import s from './ToolbarButton.module.css';
+import type { ButtonProps } from '@konturio/ui-kit/tslib/Button';
+
+// Control button component props
+export interface ControlButttonProps {
+  size: ButtonProps['size'];
+  icon: React.ReactElement;
+  onClick: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+  active?: boolean;
+  variant?: ButtonProps['variant'];
+  className?: string;
+}
+
+export const ToolbarButton = forwardRef(function ToolbarButton(
+  {
+    icon,
+    size,
+    disabled,
+    active,
+    onClick,
+    children,
+    variant = 'invert-outline',
+    className,
+  }: React.PropsWithChildren<ControlButttonProps>,
+  ref: React.Ref<HTMLButtonElement>,
+) {
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      iconBefore={icon}
+      size={size}
+      className={clsx(s[`toolbarButton_${size}`], className)}
+      disabled={disabled}
+      active={active}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+});

--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.tsx
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.tsx
@@ -3,6 +3,7 @@ import { Fragment } from 'react';
 import { useAtom } from '@reatom/react';
 import { toolbar } from '~core/toolbar';
 import { ToolbarControl } from '../ToolbarControl/ToolbarControl';
+import { ToolbarButton } from '../ToolbarButton/ToolbarButton';
 import s from './ToolbarContent.module.css';
 
 export const ToolbarContent = () => {
@@ -26,6 +27,7 @@ export const ToolbarContent = () => {
                     key={id}
                     settings={settings}
                     stateAtom={stateAtom}
+                    controlComponent={ToolbarButton}
                   />
                 );
               })}

--- a/src/features/toolbar/components/ToolbarControl/ToolbarControl.tsx
+++ b/src/features/toolbar/components/ToolbarControl/ToolbarControl.tsx
@@ -1,24 +1,26 @@
-import { Button } from '@konturio/ui-kit';
 import { useCallback } from 'react';
-import * as icons from '@konturio/default-icons';
-import clsx from 'clsx';
 import { useAtom } from '@reatom/react';
 import { passRefToSettings, resolveValue } from '~core/toolbar/utils';
-import s from '../ToolbarContent/ToolbarContent.module.css';
+import { ToolbarIcon } from '../ToolbarIcon';
 import type {
   ControlID,
   ToolbarControlSettings,
   ToolbarControlStateAtom,
 } from '~core/toolbar/types';
+import type { ControlButttonProps } from '../ToolbarButton/ToolbarButton';
 
 export function ToolbarControl({
   id,
   settings,
   stateAtom,
+  controlComponent: ControlComponent,
 }: {
   id: ControlID;
   settings: ToolbarControlSettings;
   stateAtom: ToolbarControlStateAtom;
+  controlComponent: React.ComponentType<
+    ControlButttonProps & React.RefAttributes<HTMLButtonElement>
+  >;
 }) {
   /* Implement "onRef" toolbar setting */
   const refChangeCallback = useCallback(
@@ -40,27 +42,26 @@ export function ToolbarControl({
 
   switch (settings.type) {
     case 'button':
-      const Icon = icons[resolveValue(settings.typeSettings.icon, state)];
+      const icon = resolveValue(settings.typeSettings.icon, state);
       return (
-        <Button
+        <ControlComponent
           key={id}
           ref={refChangeCallback}
-          variant="invert-outline"
-          iconBefore={<Icon width={16} height={16} />}
+          icon={<ToolbarIcon icon={icon} width={16} height={16} />}
           size={settings.typeSettings.preferredSize}
-          className={clsx(s[`control-${settings.typeSettings.preferredSize}`])}
+          active={state === 'active'}
           disabled={state === 'disabled'}
           onClick={toggleState}
         >
           {resolveValue(settings.typeSettings.name, state)}
-        </Button>
+        </ControlComponent>
       );
 
     case 'widget':
       return (
         <settings.typeSettings.component
           key={id}
-          controlClassName=""
+          controlComponent={ControlComponent}
           onClick={toggleState}
           state={state}
         />

--- a/src/features/toolbar/components/ToolbarIcon.tsx
+++ b/src/features/toolbar/components/ToolbarIcon.tsx
@@ -1,0 +1,14 @@
+import * as icons from '@konturio/default-icons';
+
+export function ToolbarIcon({
+  width,
+  height,
+  icon,
+}: {
+  width: number;
+  height: number;
+  icon: string;
+}) {
+  const Icon = icons[icon];
+  return <Icon width={width} height={height} />;
+}

--- a/src/views/Map/Map.module.css
+++ b/src/views/Map/Map.module.css
@@ -84,3 +84,8 @@
     background-color: rgba(255, 255, 255, 0.7);
   }
 }
+
+.toolbarHeaderTitle {
+  min-width: unset;
+  max-width: 260px;
+}

--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -12,6 +12,7 @@ import { IntercomBTN } from '~features/intercom/IntercomBTN';
 import { ScaleControl } from '~components/ConnectedMap/ScaleControl/ScaleControl';
 import { Copyrights } from '~components/Copyrights/Copyrights';
 import { shortToolbar, toolbar } from '~features/toolbar';
+import { panelClasses } from '~components/Panel';
 import s from './Map.module.css';
 import { Layout } from './Layouts/Layout';
 
@@ -135,6 +136,7 @@ export function MapPage() {
 }
 
 const Toolbar = () => {
+  const getPanelClasses = () => ({ ...panelClasses, headerTitle: s.toolbarHeaderTitle });
   return (
     <div style={{ display: 'flex' }}>
       <FullAndShortStatesPanelWidget
@@ -144,6 +146,7 @@ const Toolbar = () => {
         shortState={shortToolbar()}
         panelIcon={toolbar().panelIcon}
         header={toolbar().header}
+        getPanelClasses={getPanelClasses}
       />
     </div>
   );

--- a/src/widgets/FocusedGeometryEditor/DrawToolsWidget.tsx
+++ b/src/widgets/FocusedGeometryEditor/DrawToolsWidget.tsx
@@ -1,53 +1,63 @@
+import { EditGeometry16, Finish16 } from '@konturio/default-icons';
+import clsx from 'clsx';
 import { i18n } from '~core/localization';
 import { useDrawTools } from '~core/draw_tools';
+import { ToolbarButton } from '~features/toolbar/components/ToolbarButton/ToolbarButton';
+import { ToolbarIcon } from '~features/toolbar/components/ToolbarIcon';
+import { ShortToolbarButton } from '~features/toolbar/components/ShortToolbarButton/ShortToolbarButton';
 import { FOCUSED_GEOMETRY_EDITOR_CONTROL_NAME } from './constants';
-import { DrawToolsButton } from './DrawToolsButton';
 import s from './DrawToolsWidget.module.css';
 import type { WidgetProps } from '~core/toolbar/types';
 
-export function DrawToolsWidget({ state, onClick, controlClassName }: WidgetProps) {
+export function DrawToolsWidget({
+  state,
+  onClick,
+  controlComponent: ControlComponent,
+}: WidgetProps) {
   const [tools, finishDrawing] = useDrawTools();
 
   if (state === 'regular') {
     return (
-      <DrawToolsButton
-        name={FOCUSED_GEOMETRY_EDITOR_CONTROL_NAME}
-        hint={i18n.t('focus_geometry.title')}
-        icon={'EditGeometry16'}
-        preferredSize={'large'}
-        state={state}
+      <ControlComponent
+        icon={<EditGeometry16 width={16} height={16} />}
+        size="large"
         onClick={onClick}
-      />
+      >
+        {FOCUSED_GEOMETRY_EDITOR_CONTROL_NAME}
+      </ControlComponent>
     );
   } else {
     const onFinish = () => {
-      finishDrawing(); // order jf callings is important!
+      finishDrawing(); // order of callings is important!
       onClick();
     };
 
     return (
       <>
-        {tools.map((tool) => (
-          <DrawToolsButton
-            key={tool.name}
-            name={tool.name}
-            hint={tool.hint}
-            icon={tool.icon}
-            preferredSize={tool.prefferedSize || 'tiny'}
-            state={tool.state}
-            onClick={tool.action}
-          />
-        ))}
-        <DrawToolsButton
-          name={'Save'}
-          hint={i18n.t('save')}
-          icon="Finish16"
-          preferredSize="medium"
-          state={state}
-          onClick={onFinish}
-          className={s.finishButton}
+        {tools.map((tool) => {
+          return (
+            <ControlComponent
+              key={tool.name}
+              icon={<ToolbarIcon width={16} height={16} icon={tool.icon} />}
+              size={tool.prefferedSize || 'tiny'}
+              onClick={tool.action}
+              active={tool.state === 'active'}
+              disabled={tool.state === 'disabled'}
+            >
+              {tool.name}
+            </ControlComponent>
+          );
+        })}
+        <ControlComponent
           variant="primary"
-        />
+          icon={<Finish16 width={16} height={16} />}
+          size="medium"
+          className={clsx(s.finishButton)}
+          disabled={state === 'disabled'}
+          onClick={onFinish}
+        >
+          {i18n.t('save')}
+        </ControlComponent>
       </>
     );
   }

--- a/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
@@ -1,7 +1,7 @@
 import { Panel, PanelIcon } from '@konturio/ui-kit';
 import clsx from 'clsx';
 import { useCallback } from 'react';
-import { panelClasses } from '~components/Panel';
+import { panelClasses as defaultPanelClasses } from '~components/Panel';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import { useHeightResizer } from '~utils/hooks/useResizer';
 import { useShortPanelState } from '~utils/hooks/useShortPanelState';
@@ -17,6 +17,13 @@ type PanelProps = {
   initialState?: PanelState | null;
   header?: string;
   panelIcon?: JSX.Element;
+  getPanelClasses?: ({
+    isOpen,
+    isShort,
+  }: {
+    isOpen: boolean;
+    isShort: boolean;
+  }) => typeof defaultPanelClasses;
 };
 
 export function FullAndShortStatesPanelWidget({
@@ -26,6 +33,7 @@ export function FullAndShortStatesPanelWidget({
   initialState,
   header,
   panelIcon,
+  getPanelClasses = () => defaultPanelClasses,
 }: PanelProps) {
   const { panelState, panelControls, setPanelState } = useShortPanelState({
     initialState,
@@ -88,7 +96,7 @@ export function FullAndShortStatesPanelWidget({
         onHeaderClick={togglePanelState}
         headerIcon={resultPanelIcon || undefined}
         className={clsx(s.panel, isOpen ? s.show : s.collapse)}
-        classes={panelClasses}
+        classes={getPanelClasses({ isOpen, isShort })}
         isOpen={isOpen}
         modal={{ onModalClick: onPanelClose, showInModal: isMobile }}
         resize={resize}


### PR DESCRIPTION
add get-panel-classes prop to full-short-state-panel

https://kontur.fibery.io/Tasks/Task/Implement-short-state-for-Toolbar-layout-17114