### PR TITLE
feat(toolbar): resize depends on screen width

### DIFF
--- a/src/features/toolbar/components/ToolbarButton/ToolbarButton.module.css
+++ b/src/features/toolbar/components/ToolbarButton/ToolbarButton.module.css
@@ -13,3 +13,20 @@
   white-space: pre-line;
   justify-content: center !important; /* TODO: fix in ui-kit */
 }
+
+@media screen and (max-width: 1024px) {
+  .toolbarButton_medium,
+  .toolbarButton_tiny {
+    & span {
+      display: none;
+    }
+  }
+}
+
+@media screen and (max-width: 550px) {
+  .toolbarButton_large {
+    & span {
+      display: none;
+    }
+  }
+}

--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
@@ -35,5 +35,5 @@
   display: grid;
   grid-template-rows: repeat(6, auto);
   grid-auto-flow: column;
-  grid-gap: 4px;
+  gap: 4px;
 }

--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
@@ -37,19 +37,3 @@
   grid-auto-flow: column;
   grid-gap: 4px;
 }
-
-.control-tiny {
-  align-items: flex-start;
-  grid-row: span 2;
-}
-
-.control-medium {
-  grid-row: span 3;
-  align-items: flex-start;
-}
-
-.control-large {
-  grid-row: span 6;
-  white-space: pre-line;
-  justify-content: center !important; /* TODO: fix in ui-kit */
-}

--- a/src/features/toolbar/components/ToolbarPanel/ToolbarPanel.module.css
+++ b/src/features/toolbar/components/ToolbarPanel/ToolbarPanel.module.css
@@ -1,0 +1,47 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 1;
+
+  &.collapse {
+    height: auto;
+    & div:not(:first-child) {
+      display: none;
+    }
+  }
+}
+
+.scrollable {
+  overflow-y: auto;
+  height: 100%;
+}
+
+.panelIcon.desktop {
+  display: none;
+}
+
+/* mobile */
+@media screen and (max-width: 960px) {
+  .panel.collapse {
+    display: none;
+  }
+
+  .scrollable {
+    width: 100%;
+  }
+
+  .panelIcon.mobile {
+    display: flex;
+    &.show {
+      transition: opacity 0.33s linear 0s;
+      visibility: visible;
+      opacity: 1;
+    }
+
+    &.hide {
+      visibility: hidden;
+      opacity: 0;
+    }
+  }
+}

--- a/src/features/toolbar/components/ToolbarPanel/ToolbarPanel.tsx
+++ b/src/features/toolbar/components/ToolbarPanel/ToolbarPanel.tsx
@@ -1,0 +1,125 @@
+import { Panel, PanelIcon } from '@konturio/ui-kit';
+import clsx from 'clsx';
+import { useCallback } from 'react';
+import { panelClasses as defaultPanelClasses } from '~components/Panel';
+import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
+import { useHeightResizer } from '~utils/hooks/useResizer';
+import { useShortPanelState } from '~utils/hooks/useShortPanelState';
+import { useAutoCollapsePanel } from '~utils/hooks/useAutoCollapsePanel';
+import s from './ToolbarPanel.module.css';
+import type { PanelState } from '~utils/hooks/useShortPanelState';
+import type { PanelFeatureInterface } from 'types/featuresTypes';
+
+type PanelProps = {
+  fullState?: PanelFeatureInterface | null;
+  shortState?: PanelFeatureInterface | null;
+  id?: string;
+  initialState?: PanelState | null;
+  header?: string;
+  panelIcon?: JSX.Element;
+  getPanelClasses?: ({
+    isOpen,
+    isShort,
+  }: {
+    isOpen: boolean;
+    isShort: boolean;
+  }) => typeof defaultPanelClasses;
+};
+
+export function ToolbarPanel({
+  fullState,
+  shortState,
+  id,
+  initialState,
+  header,
+  panelIcon,
+  getPanelClasses = () => defaultPanelClasses,
+}: PanelProps) {
+  const { panelState, panelControls, setPanelState } = useShortPanelState({
+    initialState,
+    skipShortState: Boolean(!fullState || !shortState),
+  });
+
+  const isOpen = panelState !== 'closed';
+  const isShort = panelState === 'short';
+  const isMobileQuery = `(max-width: 385px)`;
+  const isMobile = useMediaQuery(isMobileQuery);
+  const getProperty = useCallback(
+    function <K extends keyof PanelFeatureInterface>(property: K) {
+      return isShort ? shortState?.[property] : fullState?.[property];
+    },
+    [isShort, fullState, shortState],
+  );
+
+  const minHeight = getProperty('minHeight') || shortState?.minHeight || 0;
+  const maxHeight = getProperty('maxHeight');
+  const contentHeight = getProperty('contentheight');
+  const resize = isMobile ? 'none' : getProperty('resize');
+
+  const handleRefChange = useHeightResizer(
+    (isOpen) => !isOpen && setPanelState('closed'),
+    isOpen,
+    minHeight,
+    id || 'primary_and_secondary',
+    isShort ? shortState?.skipAutoResize : fullState?.skipAutoResize,
+  );
+
+  const onPanelIconClick = useCallback(() => {
+    setPanelState('full');
+  }, [setPanelState]);
+
+  const onPanelShort = useCallback(() => {
+    setPanelState('short');
+  }, [setPanelState]);
+
+  const togglePanelState = useCallback(() => {
+    setPanelState(isOpen ? 'closed' : 'full');
+  }, [isOpen, setPanelState]);
+
+  useAutoCollapsePanel(isOpen, onPanelShort, isMobileQuery);
+
+  if (!fullState && !shortState) return null;
+
+  const resultHeader = header || (!fullState ? shortState?.header : fullState.header);
+  const resultPanelIcon =
+    panelIcon || (!fullState ? shortState?.panelIcon : fullState.panelIcon);
+
+  const panelContent = {
+    full: fullState?.content || shortState?.content,
+    short: shortState?.content,
+    closed: <></>,
+  };
+
+  return (
+    <>
+      <Panel
+        header={resultHeader}
+        onHeaderClick={togglePanelState}
+        headerIcon={resultPanelIcon || undefined}
+        className={clsx(s.panel, isOpen ? s.show : s.collapse)}
+        classes={getPanelClasses({ isOpen, isShort })}
+        isOpen={isOpen}
+        resize={resize}
+        contentClassName={s.contentWrap}
+        contentContainerRef={handleRefChange}
+        customControls={panelControls}
+        contentHeight={contentHeight}
+        minContentHeight={minHeight}
+        maxContentHeight={maxHeight}
+      >
+        {panelContent[panelState]}
+      </Panel>
+
+      <PanelIcon
+        clickHandler={onPanelIconClick}
+        className={clsx(
+          s.panelIcon,
+          isOpen && s.hide,
+          !isOpen && s.show,
+          isMobile ? s.mobile : s.desktop,
+        )}
+        icon={resultPanelIcon || <></>}
+      />
+    </>
+  );
+}

--- a/src/utils/hooks/useAutoCollapsePanel.tsx
+++ b/src/utils/hooks/useAutoCollapsePanel.tsx
@@ -1,8 +1,12 @@
 import { useState, useEffect } from 'react';
 import { COLLAPSE_PANEL_QUERY, useMediaQuery } from './useMediaQuery';
 
-export const useAutoCollapsePanel = (isOpen: boolean, onPanelClose: () => void) => {
-  const shouldCollapse = useMediaQuery(COLLAPSE_PANEL_QUERY);
+export const useAutoCollapsePanel = (
+  isOpen: boolean,
+  onPanelClose: () => void,
+  collapseQuery?: string,
+) => {
+  const shouldCollapse = useMediaQuery(collapseQuery ?? COLLAPSE_PANEL_QUERY);
   const [wasCollapsed, setWasCollapsed] = useState(false);
 
   useEffect(() => {

--- a/src/views/Map/Layouts/Layout.tsx
+++ b/src/views/Map/Layouts/Layout.tsx
@@ -40,7 +40,7 @@ export function Layout({
             {matrix}
           </>
         }
-        mapColumnTop={toolbar}
+        topColumn={toolbar}
         mapColumnBottom={timeline}
         footer={footer}
       />

--- a/src/views/Map/Layouts/Mobile/Mobile.module.css
+++ b/src/views/Map/Layouts/Mobile/Mobile.module.css
@@ -45,3 +45,9 @@
   grid-row: -1;
   height: var(--unit);
 }
+
+.topColumn {
+  grid-row: 1;
+  grid-column: 1/-1;
+  padding: var(--unit);
+}

--- a/src/views/Map/Layouts/Mobile/Mobile.tsx
+++ b/src/views/Map/Layouts/Mobile/Mobile.tsx
@@ -3,21 +3,21 @@ import s from './Mobile.module.css';
 
 export function MobileLayout({
   firstColumn,
-  mapColumnTop,
+  topColumn,
   mapColumnBottom,
   footer,
 }: {
   firstColumn: JSX.Element;
-  mapColumnTop: JSX.Element;
+  topColumn: JSX.Element;
   mapColumnBottom: JSX.Element;
   footer: JSX.Element;
 }) {
   return (
     <div className={s.contentWrap}>
       <div className={s.panelsColumn}>{firstColumn}</div>
+      <div className={s.topColumn}>{topColumn}</div>
       <div className={s.mapWrap}>
         <div className={s.mapSpaceRight} id={configRepo.get().mapBlankSpaceId}>
-          {mapColumnTop}
           {mapColumnBottom}
         </div>
       </div>

--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -13,6 +13,7 @@ import { ScaleControl } from '~components/ConnectedMap/ScaleControl/ScaleControl
 import { Copyrights } from '~components/Copyrights/Copyrights';
 import { shortToolbar, toolbar } from '~features/toolbar';
 import { panelClasses } from '~components/Panel';
+import { ToolbarPanel } from '~features/toolbar/components/ToolbarPanel/ToolbarPanel';
 import s from './Map.module.css';
 import { Layout } from './Layouts/Layout';
 
@@ -139,7 +140,7 @@ const Toolbar = () => {
   const getPanelClasses = () => ({ ...panelClasses, headerTitle: s.toolbarHeaderTitle });
   return (
     <div style={{ display: 'flex' }}>
-      <FullAndShortStatesPanelWidget
+      <ToolbarPanel
         id="toolbar"
         key="toolbar"
         fullState={toolbar()}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Resize-Toolbar-on-laptop-13318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a responsive `ToolbarPanel` component with collapsible behavior for smaller screens.
  - Implemented a new top column layout for mobile views.

- **Style**
  - Updated toolbar button styles to adapt to various screen widths.
  - Removed specific grid layout classes in favor of a more unified styling approach.
  - Added new styles for scrollable elements and panel icons across devices.

- **Refactor**
  - Renamed `mapColumnTop` prop to `topColumn` for consistency in layout components.
  - Enhanced the `useAutoCollapsePanel` hook to accept a custom media query for auto-collapse behavior.

- **Documentation**
  - No visible changes to end-user documentation in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->