### PR TITLE
feat(toolbar): add cancel button

### DIFF
--- a/src/core/draw_tools/atoms/drawnGeometryAtom.ts
+++ b/src/core/draw_tools/atoms/drawnGeometryAtom.ts
@@ -13,6 +13,7 @@ export const drawnGeometryAtom = createAtom(
     setFeatures: (features: Feature[]) => features,
     updateByIndex: (feature: Feature, index: number) => ({ feature, index }),
     removeByIndexes: (indexes: number[]) => indexes,
+    resetToDefault: () => null,
     activeDrawModeAtom,
   },
   ({ onAction, schedule }, state: FeatureCollection = defaultState) => {
@@ -45,6 +46,10 @@ export const drawnGeometryAtom = createAtom(
         return !indexesToRemove.includes(featureIndex);
       });
       state = stateCopy;
+    });
+
+    onAction('resetToDefault', () => {
+      state = defaultState;
     });
 
     return state;

--- a/src/core/draw_tools/atoms/toolboxAtom.ts
+++ b/src/core/draw_tools/atoms/toolboxAtom.ts
@@ -31,6 +31,7 @@ export const toolboxAtom = createAtom(
     activeDrawModeAtom,
     toggleDrawMode: (mode: DrawModeType) => mode,
     finishDrawing: () => null,
+    cancelDrawing: () => null, // New action
     isDrawingStartedAtom,
     setSettings: (settings: DrawToolBoxSettings) => settings,
     downloadDrawGeometry: () => null,
@@ -69,7 +70,12 @@ export const toolboxAtom = createAtom(
       newState.settings?.finishButtonCallback?.();
     });
 
-    // I think we don't need to specify the need for ModifyMode
+    onAction('cancelDrawing', () => {
+      actions.push(activeDrawModeAtom.setDrawMode(null));
+      actions.push(drawnGeometryAtom.resetToDefault());
+      actions.push(temporaryGeometryAtom.resetToDefault());
+    });
+
     onAction('setSettings', (settings) => {
       newState = { ...newState, settings };
     });

--- a/src/core/draw_tools/index.ts
+++ b/src/core/draw_tools/index.ts
@@ -87,7 +87,13 @@ const modeToIcon = {
 export const useDrawTools: DrawToolsHook = () => {
   const [
     { mode: activeDrawMode, selectedIndexes, settings },
-    { deleteFeatures, toggleDrawMode, finishDrawing, downloadDrawGeometry },
+    {
+      deleteFeatures,
+      toggleDrawMode,
+      finishDrawing,
+      downloadDrawGeometry,
+      cancelDrawing,
+    },
   ] = useAtom(toolboxAtom);
 
   const controls = useMemo(() => {
@@ -129,7 +135,7 @@ export const useDrawTools: DrawToolsHook = () => {
     downloadDrawGeometry,
   ]);
 
-  return [controls, finishDrawing];
+  return [controls, { cancelDrawing, finishDrawing }];
 };
 
 export const drawTools: DrawToolsController = new DrawToolsControllerImpl();

--- a/src/core/draw_tools/types.ts
+++ b/src/core/draw_tools/types.ts
@@ -20,5 +20,8 @@ export interface DrawToolsController {
   geometry: GeoJSON.FeatureCollection;
 }
 
-type FinishDrawingAction = () => void;
-export type DrawToolsHook = () => [Array<DrawToolController>, FinishDrawingAction];
+interface Actions {
+  finishDrawing: () => void;
+  cancelDrawing: () => void;
+}
+export type DrawToolsHook = () => [Array<DrawToolController>, Actions];

--- a/src/widgets/FocusedGeometryEditor/DrawToolsWidget.tsx
+++ b/src/widgets/FocusedGeometryEditor/DrawToolsWidget.tsx
@@ -1,10 +1,8 @@
-import { EditGeometry16, Finish16 } from '@konturio/default-icons';
+import { Close16, EditGeometry16, Finish16 } from '@konturio/default-icons';
 import clsx from 'clsx';
 import { i18n } from '~core/localization';
 import { useDrawTools } from '~core/draw_tools';
-import { ToolbarButton } from '~features/toolbar/components/ToolbarButton/ToolbarButton';
 import { ToolbarIcon } from '~features/toolbar/components/ToolbarIcon';
-import { ShortToolbarButton } from '~features/toolbar/components/ShortToolbarButton/ShortToolbarButton';
 import { FOCUSED_GEOMETRY_EDITOR_CONTROL_NAME } from './constants';
 import s from './DrawToolsWidget.module.css';
 import type { WidgetProps } from '~core/toolbar/types';
@@ -14,7 +12,7 @@ export function DrawToolsWidget({
   onClick,
   controlComponent: ControlComponent,
 }: WidgetProps) {
-  const [tools, finishDrawing] = useDrawTools();
+  const [tools, { cancelDrawing, finishDrawing }] = useDrawTools();
 
   if (state === 'regular') {
     return (
@@ -42,6 +40,11 @@ export function DrawToolsWidget({
       onClick();
     };
 
+    const onCancel = () => {
+      cancelDrawing(); // order of callings is important!
+      onClick();
+    };
+
     return (
       <>
         {tools.map((tool) => {
@@ -58,6 +61,16 @@ export function DrawToolsWidget({
             </ControlComponent>
           );
         })}
+        {/* Cancel button */}
+        <ControlComponent
+          icon={<Close16 width={16} height={16} />}
+          size="medium"
+          className={clsx(s.cancelButton)}
+          onClick={onCancel}
+        >
+          {i18n.t('cancel')}
+        </ControlComponent>
+        {/* Finish button */}
         <ControlComponent
           variant="primary"
           icon={<Finish16 width={16} height={16} />}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Add-'Cancel'-button-to-the-Toolbar-13323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Cancel Drawing" action to allow users to easily discard their current drawing progress.
  - Added a "Reset to Default" option for clearing all drawing states and starting fresh.

- **Enhancements**
  - Updated the drawing tools interface to include a cancel button for improved user experience.
  - Enhanced the geometry editing capabilities with new actions for finishing and canceling edits.

- **User Interface**
  - Implemented a new cancel button with a clear icon to indicate the action visually.

- **Bug Fixes**
  - Fixed issues related to the persistence of drawing states when switching between tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->