### PR TITLE
fix(auth): add logout if we have err with refresh token

### DIFF
--- a/src/core/apiClientInstance.ts
+++ b/src/core/apiClientInstance.ts
@@ -9,7 +9,7 @@ export const apiClient = withSetupCheck(ApiClient, {
       switch (error.problem.kind) {
         case 'unauthorized':
         case 'forbidden':
-          alert('Session expired. Please login again');
+          alert('Access denied or your session expired. Please login again');
           goTo('/profile');
           location.reload();
           break;

--- a/src/core/api_client/apiClient.ts
+++ b/src/core/api_client/apiClient.ts
@@ -198,7 +198,13 @@ export class ApiClient {
       refresh_token: this.refreshToken,
       grant_type: 'refresh_token',
     };
-    return await this.requestTokenOrThrow(this.refreshTokenApiPath, params);
+    try {
+      return await this.requestTokenOrThrow(this.refreshTokenApiPath, params);
+    } catch (error) {
+      // logout on refresh token error
+      await this.logout();
+      throw error;
+    }
   }
 
   /**

--- a/src/core/api_client/errors.ts
+++ b/src/core/api_client/errors.ts
@@ -66,9 +66,8 @@ export function createApiError(err: unknown) {
   }
   if (err instanceof wretch.WretchError) {
     status = err.status;
-    if (status === 400) {
-      problem = { kind: 'bad-request' };
-    } else if (status === 401) {
+    // In case of 400/401 error we need to parse error message from body and show it to user
+    if (status === 400 || status === 401) {
       errorMessage = err.json?.error_description ?? err?.message ?? 'Auth error';
       problem = { kind: 'unauthorized', data: err.json?.error };
     } else if (status === 403) {


### PR DESCRIPTION
If we have any problems with refresh token, add logout Improve auth alert error message
Improve auth error messages parsing

https://kontur.fibery.io/Tasks/Task/invalid_grant-shown-to-users-in-the-loop-for-users-with-wrong-invalid-refresh-token-17578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of unauthorized and forbidden errors, providing clearer messages to users when access is denied or sessions expire.
	- Enhanced error reporting for users, now displaying more informative messages when encountering specific request errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->