### PR TITLE
feat(17481): Download button added in layers panel for MCDA layer

### DIFF
--- a/src/core/logical_layers/utils/logicalLayerFabric.ts
+++ b/src/core/logical_layers/utils/logicalLayerFabric.ts
@@ -125,7 +125,9 @@ export function createLogicalLayerAtom(
         isEnabled: get('enabledLayersAtom').has(id),
         isMounted: mounted.has(id),
         isVisible: !get('hiddenLayersAtom').has(id),
-        isDownloadable: asyncLayerSource.data?.source.type === 'geojson', // details.data.source.type === 'geojson'
+        isDownloadable:
+          asyncLayerSource.data?.source.type === 'geojson' || // details.data.source.type === 'geojson'
+          asyncLayerSource.data?.style?.type === 'mcda',
         settings: deepFreeze(asyncLayerSettings.data),
         meta: deepFreeze(asyncLayerMeta.data),
         legend: deepFreeze(asyncLayerLegend.data),
@@ -200,8 +202,15 @@ export function createLogicalLayerAtom(
                 state.settings?.name || state.id || 'Disaster Ninja map layer'
               }-${new Date().toISOString()}.json`,
             );
+          } else if (state.source.style?.type === 'mcda') {
+            downloadObject(
+              state.source.style.config,
+              `${
+                state.settings?.name || state.id || 'Disaster Ninja MCDA'
+              }-${new Date().toISOString()}.json`,
+            );
           } else {
-            logError('Only geojson layers can be downloaded');
+            logError('Only geojson layers or MCDA can be downloaded');
           }
         } catch (e) {
           logError(e);

--- a/src/core/logical_layers/utils/logicalLayerFabric.ts
+++ b/src/core/logical_layers/utils/logicalLayerFabric.ts
@@ -199,14 +199,14 @@ export function createLogicalLayerAtom(
             downloadObject(
               state.source.source.data,
               `${
-                state.settings?.name || state.id || 'Disaster Ninja map layer'
+                state.settings?.name || state.id || 'map layer'
               }-${new Date().toISOString()}.json`,
             );
           } else if (state.source.style?.type === 'mcda') {
             downloadObject(
               state.source.style.config,
               `${
-                state.settings?.name || state.id || 'Disaster Ninja MCDA'
+                state.settings?.name || state.id || 'MCDA'
               }-${new Date().toISOString()}.json`,
             );
           } else {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Add-Download-MCDA-flow-17481

https://www.figma.com/file/cFmWZmGioB52BDMoCofzpY/MCDA?type=design&node-id=12026-171898&mode=design&t=t7EABNwtf8umJwG9-0

- Download button added in layers panel for MCDA layer
<img width="300" alt="image" src="https://github.com/konturio/disaster-ninja-fe/assets/9570735/37f33697-44cb-4e64-9500-664f1fd4d065">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced download functionality to support layers with the 'mcda' style type.
	- Improved logic to determine downloadable layers based on new conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->