### PR TITLE
fix: 15027: save public feed after page reload

### DIFF
--- a/src/core/shared_state/currentEventFeed.ts
+++ b/src/core/shared_state/currentEventFeed.ts
@@ -32,8 +32,8 @@ export const currentEventFeedAtom = createAtom(
     });
 
     onChange('eventFeedsAtom', (eventFeeds) => {
-      if (eventFeeds && eventFeeds.length) {
-        const newFeed = checkFeed(eventFeeds, state?.id);
+      if (eventFeeds && eventFeeds.data.length && !eventFeeds.loading) {
+        const newFeed = checkFeed(eventFeeds.data, state?.id);
         if (newFeed !== undefined && newFeed !== state?.id) {
           state = { id: newFeed };
           const currentEvent = getUnlistedState(currentEventAtom);

--- a/src/core/shared_state/eventFeeds.ts
+++ b/src/core/shared_state/eventFeeds.ts
@@ -9,17 +9,18 @@ export const eventFeedsAtom = createAtom(
   {
     eventFeedsResourceAtom,
   },
-  ({ get }, state = defaultFeeds) => {
+  ({ get }, state = { data: defaultFeeds, loading: false }) => {
     const { data, error, loading } = get('eventFeedsResourceAtom');
+    state = { ...state, loading };
     if (!loading && !error) {
       if (data) {
         console.assert(
           data.map((d) => d.feed).includes(configRepo.get().defaultFeed),
           'default feed not included in response',
         );
-        return data;
+        return { data, loading };
       } else {
-        return [...defaultFeeds];
+        return { data: [...defaultFeeds], loading };
       }
     }
     return state;

--- a/src/features/events_list/components/FeedSelector/FeedSelector.tsx
+++ b/src/features/events_list/components/FeedSelector/FeedSelector.tsx
@@ -20,7 +20,7 @@ export function FeedSelector() {
     [setCurrentFeed, scheduleAutoSelect],
   );
 
-  if (eventFeeds?.length < 2) {
+  if (eventFeeds.data?.length < 2) {
     return null;
   }
 
@@ -33,7 +33,7 @@ export function FeedSelector() {
           value={currentFeed?.id || configRepo.get().defaultFeed}
           className={s.feedsSelect}
         >
-          {eventFeeds.map((fd) => (
+          {eventFeeds.data.map((fd) => (
             <option key={fd.feed} value={fd.feed}>
               {fd.name}
             </option>

--- a/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
+++ b/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
@@ -21,7 +21,7 @@ export function SettingsForm() {
 
   useEffect(() => {
     getUserProfile();
-  }, []);
+  }, [getUserProfile]);
 
   if (status === 'init')
     return (
@@ -53,7 +53,7 @@ function SettingsFormGen({ userProfile, updateUserProfile }) {
     } else if (localSettings && userProfile) {
       setPageStatus('ready');
     }
-  }, [localSettings, userProfile]);
+  }, [localSettings, setPageStatus, userProfile]);
 
   function onSave() {
     // do async put request
@@ -99,7 +99,7 @@ function SettingsFormGen({ userProfile, updateUserProfile }) {
 
   const OPTIONS_LANGUAGE = getLanguageOptions();
 
-  const OPTIONS_FEED = eventFeeds.map((o) => ({
+  const OPTIONS_FEED = eventFeeds.data.map((o) => ({
     title: o.name,
     value: o.feed,
   }));


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/always-public-feed-after-page-reload-15027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved shared state handling for event feeds, including better loading and error state management.
- **Bug Fixes**
	- Fixed an issue where the feed selector did not properly access event feeds data.
	- Corrected user profile settings form to accurately map event feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->