### PR TITLE
fix(18085): Fix 403 error on map for guest users

### DIFF
--- a/src/components/Layer/EditControl/EditControl.tsx
+++ b/src/components/Layer/EditControl/EditControl.tsx
@@ -1,9 +1,10 @@
 import { Edit16 } from '@konturio/default-icons';
+import { useAtom } from '@reatom/react-v2';
 import { store } from '~core/store/store';
 import { mcdaLayerAtom } from '~features/mcda/atoms/mcdaLayer';
-import { editMCDAConfig } from '~features/mcda/mcdaConfig';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { getMutualExcludedActions } from '~core/logical_layers/utils/getMutualExcludedActions';
+import { FeatureFlag, featureFlagsAtom } from '~core/shared_state';
 import style from './EditControl.module.css';
 import type {
   LogicalLayerActions,
@@ -17,17 +18,22 @@ export function EditControl({
   layerState: LogicalLayerState;
   layerActions: LogicalLayerActions;
 }) {
+  const [featureFlags] = useAtom(featureFlagsAtom);
   async function editLayer() {
-    if (layerState.style?.type === 'mcda') {
-      const config = await editMCDAConfig(layerState);
-      if (config?.id) {
-        layerActions.destroy();
-        store.dispatch([
-          mcdaLayerAtom.createMCDALayer({ ...config, id: config.id }),
-          enabledLayersAtom.set(config.id),
-          ...getMutualExcludedActions(layerState),
-        ]);
-      }
+    if (layerState.style?.type === 'mcda' && featureFlags[FeatureFlag.MCDA]) {
+      import('~features/mcda/mcdaConfig').then(async ({ editMCDAConfig }) => {
+        {
+          const config = await editMCDAConfig(layerState);
+          if (config?.id) {
+            layerActions.destroy();
+            store.dispatch([
+              mcdaLayerAtom.createMCDALayer({ ...config, id: config.id }),
+              enabledLayersAtom.set(config.id),
+              ...getMutualExcludedActions(layerState),
+            ]);
+          }
+        }
+      });
     }
   }
   return (

--- a/src/components/Layer/EditControl/EditControl.tsx
+++ b/src/components/Layer/EditControl/EditControl.tsx
@@ -1,9 +1,5 @@
 import { Edit16 } from '@konturio/default-icons';
 import { useAtom } from '@reatom/react-v2';
-import { store } from '~core/store/store';
-import { mcdaLayerAtom } from '~features/mcda/atoms/mcdaLayer';
-import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
-import { getMutualExcludedActions } from '~core/logical_layers/utils/getMutualExcludedActions';
 import { FeatureFlag, featureFlagsAtom } from '~core/shared_state';
 import style from './EditControl.module.css';
 import type {
@@ -21,18 +17,8 @@ export function EditControl({
   const [featureFlags] = useAtom(featureFlagsAtom);
   async function editLayer() {
     if (layerState.style?.type === 'mcda' && featureFlags[FeatureFlag.MCDA]) {
-      import('~features/mcda/mcdaConfig').then(async ({ editMCDAConfig }) => {
-        {
-          const config = await editMCDAConfig(layerState);
-          if (config?.id) {
-            layerActions.destroy();
-            store.dispatch([
-              mcdaLayerAtom.createMCDALayer({ ...config, id: config.id }),
-              enabledLayersAtom.set(config.id),
-              ...getMutualExcludedActions(layerState),
-            ]);
-          }
-        }
+      import('~features/mcda').then(async ({ editMCDA }) => {
+        editMCDA(layerState, layerActions);
       });
     }
   }

--- a/src/features/mcda/index.ts
+++ b/src/features/mcda/index.ts
@@ -1,10 +1,16 @@
 import { i18n } from '~core/localization';
 import { toolbar } from '~core/toolbar';
 import { store } from '~core/store/store';
+import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
+import { getMutualExcludedActions } from '~core/logical_layers/utils/getMutualExcludedActions';
 import { mcdaLayerAtom } from './atoms/mcdaLayer';
-import { createMCDAConfig } from './mcdaConfig';
+import { createMCDAConfig, editMCDAConfig } from './mcdaConfig';
 import { MCDA_CONTROL_ID, UPLOAD_MCDA_CONTROL_ID } from './constants';
 import { askMcdaJSONFile } from './openMcdaFile';
+import type {
+  LogicalLayerActions,
+  LogicalLayerState,
+} from '~core/logical_layers/types/logicalLayer';
 
 export const mcdaControl = toolbar.setupControl({
   id: MCDA_CONTROL_ID,
@@ -67,6 +73,22 @@ uploadMcdaControl.onStateChange((ctx, state) => {
     store.dispatch(uploadMcdaControl.setState('regular'));
   }
 });
+
+/** Edit MCDA */
+export async function editMCDA(
+  layerState: LogicalLayerState,
+  layerActions: LogicalLayerActions,
+) {
+  const config = await editMCDAConfig(layerState);
+  if (config?.id) {
+    layerActions.destroy();
+    store.dispatch([
+      mcdaLayerAtom.createMCDALayer({ ...config, id: config.id }),
+      enabledLayersAtom.set(config.id),
+      ...getMutualExcludedActions(layerState),
+    ]);
+  }
+}
 
 export function initMCDA() {
   mcdaControl.init();


### PR DESCRIPTION
 Imports `features/mcda/mcdaConfig` dynamically to avoid 403 errors on map for guest users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the `EditControl` component to support feature flags and dynamic imports for enhanced MCDA configuration editing.
	- Added imports and modified functions in the `mcda/index.ts` file for improved MCDA configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->