### PR TITLE
fix: 17740: select/deselect disaster after filters changes

### DIFF
--- a/src/core/shared_state/currentEvent.ts
+++ b/src/core/shared_state/currentEvent.ts
@@ -10,7 +10,7 @@ export type CurrentEventAtomState = {
 
 export const currentEventAtom = createAtom(
   {
-    setCurrentEventId: (eventId: string) => eventId,
+    setCurrentEventId: (eventId: string | null) => eventId,
     focusedGeometryAtom,
   },
   ({ onAction, onChange }, state: CurrentEventAtomState = null) => {

--- a/src/features/events_list/atoms/autoSelectEvent.ts
+++ b/src/features/events_list/atoms/autoSelectEvent.ts
@@ -29,13 +29,17 @@ export const autoSelectEvent = createAtom(
         if (currentEvent?.id) {
           // This case happens when call for event by provided eventId didn't return event
           schedule((dispatch) =>
-            dispatch(
+            dispatch([
               currentNotificationAtom.showNotification(
                 'warning',
                 { title: i18n.t('event_list.no_event_in_feed') },
                 5,
               ),
-            ),
+              // select top disaster from the list, if it's not empty
+              currentEventAtom.setCurrentEventId(
+                (eventListResource.data || [])[0]?.eventId || null,
+              ),
+            ]),
           );
         } else {
           const firstEventInList = eventListResource.data[0];


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Select-a-top-disaster-after-switching-feed-on-DN2-17741
https://kontur.fibery.io/Tasks/Task/Deselect-a-disaster-on-DN2-after-using-map-view-filter-17740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Enhanced flexibility in event selection by allowing the clearing of the current event selection.
	- Improved event list auto-selection logic to prioritize top disaster events.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->