### PR TITLE
fix: 18065: correct bivariate legend style calculation rules

### DIFF
--- a/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixCell/BivariateMatrixCell.tsx
+++ b/src/features/bivariate_manager/components/BivariateMatrixControl/components/BivariateMatrixCell/BivariateMatrixCell.tsx
@@ -1,7 +1,7 @@
 import cn from 'clsx';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import styles from './BivariateMatrixCell.module.css';
-import type { MouseEvent } from 'react';
+import type { CSSProperties, MouseEvent } from 'react';
 
 interface CellProps {
   value?: number;
@@ -12,7 +12,7 @@ interface CellProps {
   onClick: (x: number, y: number, e: MouseEvent<Element>) => void;
   className?: string;
   disabled?: boolean;
-  style?: Record<string, any>;
+  style?: CSSProperties;
   firstRow?: boolean;
   firstCol?: boolean;
   lastRow?: boolean;

--- a/src/utils/bivariate/bivariateLegendUtils.test.ts
+++ b/src/utils/bivariate/bivariateLegendUtils.test.ts
@@ -43,5 +43,7 @@ describe('bivariateLegendUtils', () => {
     expect(getCellLabelByValue(xSteps, ySteps, 1, 1)).toEqual('A1');
     expect(getCellLabelByValue(xSteps, ySteps, 27, 154)).toEqual('C3');
     expect(getCellLabelByValue(xSteps, ySteps, 7, 23)).toEqual('B2');
+    expect(getCellLabelByValue(xSteps, ySteps, 0, 23)).toEqual('A2');
+    expect(getCellLabelByValue(xSteps, ySteps, 7, 0)).toEqual('B1');
   });
 });

--- a/src/utils/bivariate/bivariateLegendUtils.ts
+++ b/src/utils/bivariate/bivariateLegendUtils.ts
@@ -89,6 +89,15 @@ export function createBivariateMeta(
   };
 }
 
+// need to ignore first range to avoid getting @ and 0 chars
+const indexTestFunc = <T extends { value: number }>(
+  el: T,
+  i: number,
+  arr: T[],
+  value: number,
+): boolean =>
+  (i !== 0 && value < el.value) || (i === arr.length - 1 && value <= el.value);
+
 // same logic as in classResolver method in styleGen.ts, but here we do it manually
 export function getCellLabelByValue(
   xSteps: Step[],
@@ -96,12 +105,12 @@ export function getCellLabelByValue(
   xValue: number,
   yValue: number,
 ) {
-  const charIndex = xSteps.findIndex((xStep) => {
-    if (xValue < xStep.value) return true;
-  });
+  const charIndex = xSteps.findIndex((xStep, i, arr) =>
+    indexTestFunc(xStep, i, arr, xValue),
+  );
   const char = getCharByIndex(charIndex);
-  const number = ySteps.findIndex((yStep) => {
-    if (yValue < yStep.value) return true;
-  });
+  const number = ySteps.findIndex((yStep, i, arr) =>
+    indexTestFunc(yStep, i, arr, yValue),
+  );
   return char + number;
 }

--- a/src/utils/bivariate/bivariateLegendUtils.ts
+++ b/src/utils/bivariate/bivariateLegendUtils.ts
@@ -90,13 +90,14 @@ export function createBivariateMeta(
 }
 
 // need to ignore first range to avoid getting @ and 0 chars
-const indexTestFunc = <T extends { value: number }>(
-  el: T,
-  i: number,
-  arr: T[],
-  value: number,
+const fitsLegendCriteria = <T extends { value: number }>(
+  step: T,
+  index: number,
+  totalSteps: number,
+  targetValue: number,
 ): boolean =>
-  (i !== 0 && value < el.value) || (i === arr.length - 1 && value <= el.value);
+  (index !== 0 && targetValue < step.value) ||
+  (index === totalSteps - 1 && targetValue <= step.value);
 
 // same logic as in classResolver method in styleGen.ts, but here we do it manually
 export function getCellLabelByValue(
@@ -106,11 +107,11 @@ export function getCellLabelByValue(
   yValue: number,
 ) {
   const charIndex = xSteps.findIndex((xStep, i, arr) =>
-    indexTestFunc(xStep, i, arr, xValue),
+    fitsLegendCriteria(xStep, i, arr.length, xValue),
   );
   const char = getCharByIndex(charIndex);
   const number = ySteps.findIndex((yStep, i, arr) =>
-    indexTestFunc(yStep, i, arr, yValue),
+    fitsLegendCriteria(yStep, i, arr.length, yValue),
   );
   return char + number;
 }

--- a/src/utils/bivariate/bivariate_style/index.ts
+++ b/src/utils/bivariate/bivariate_style/index.ts
@@ -9,24 +9,18 @@ import {
 import type { Stat, Axis, OverlayColor } from '../types/stat.types';
 import type { BivariateLayerStyle } from '~utils/bivariate/bivariateColorThemeUtils';
 
-function colorsMap(colors) {
-  return Object.fromEntries(colors.map(Object.values));
+function colorsMap(colors: Array<OverlayColor>): Record<string, string> {
+  return Object.fromEntries(colors.map(({ id, color }) => [id, color]));
 }
 
 function filterSetup(xAxis: Axis, yAxis: Axis) {
   return anyCondition(
-    notEqual(
-      ['/', featureProp(xAxis.quotient[0]), featureProp(xAxis.quotient[1])],
-      0,
-    ),
-    notEqual(
-      ['/', featureProp(yAxis.quotient[0]), featureProp(yAxis.quotient[1])],
-      0,
-    ),
+    notEqual(['/', featureProp(xAxis.quotient[0]), featureProp(xAxis.quotient[1])], 0),
+    notEqual(['/', featureProp(yAxis.quotient[0]), featureProp(yAxis.quotient[1])], 0),
   );
 }
 
-function colorSetup(xAxis: Axis, yAxis: Axis, colors) {
+function colorSetup(xAxis: Axis, yAxis: Axis, colors: Record<string, string>) {
   return addVariable(
     'class',
     classResolver(

--- a/src/utils/bivariate/bivariate_style/styleGen.ts
+++ b/src/utils/bivariate/bivariate_style/styleGen.ts
@@ -1,41 +1,40 @@
-export function featureProp(name) {
+export function featureProp<T>(name: T) {
   return ['get', name];
 }
 
-export function getVariable(name) {
+export function getVariable<T>(name: T) {
   return ['var', name];
 }
 
-export function less(first, second) {
+export function less<T, R>(first: T, second: R) {
   return ['<', first, second];
 }
 
-export function lessOrEqual(first, second) {
+export function lessOrEqual<T, R>(first: T, second: R) {
   return ['<=', first, second];
 }
 
-export function notEqual(first, second) {
+export function notEqual<T, R>(first: T, second: R) {
   return ['!=', first, second];
 }
 
-export function equal(first, second) {
+export function equal<T, R>(first: T, second: R) {
   return ['==', first, second];
 }
 
-export function caseFn(condition, output) {
+export function caseFn<T, R>(condition: T, output: R) {
   return [condition, output];
 }
 
-export function switchFn(...conditions) {
-  const defaultCase = conditions.pop();
+export function switchFn<T>(defaultCase: number | string, conditions: Array<T>) {
   return ['case', ...conditions.flat(2), defaultCase];
 }
 
-export function concat(...values) {
-  return ['concat', ...values];
+export function concat<T, R>(first: T, second: R) {
+  return ['concat', first, second];
 }
 
-export function addVariable(name, binding, expression) {
+export function addVariable<T, R>(name: string, binding: T, expression: R) {
   return ['let', name, binding, expression];
 }
 
@@ -51,16 +50,15 @@ export function anyCondition(...conditionInputs) {
   return ['any', ...conditionInputs];
 }
 
-function stringsToFeatureProp(expression) {
+type FeaturePropReturn = number | string | Array<FeaturePropReturn>;
+
+function stringsToFeatureProp(expression: Array<string> | string): FeaturePropReturn {
   if (typeof expression === 'string') {
     return expression === '1' ? 1 : featureProp(expression);
-  }
-  if (Array.isArray(expression)) {
+  } else {
     // ignore first item in array - it's operator
     return expression.map((exp, i) => (i === 0 ? exp : stringsToFeatureProp(exp)));
   }
-
-  return expression;
 }
 
 const AT_CHAR_CODE = 64; // '@'.charCodeAt(0);
@@ -70,38 +68,43 @@ export const getCharByIndex = (i: number) => String.fromCharCode(AT_CHAR_CODE + 
  * Return condition based on border range
  * all ranges - <
  * last range - <=
- * @param {number} i - index of current range
- * @param {number} bL - length of borders array
+ * @param {number} currentIndex - index of current range
+ * @param {number} totalBorders - length of borders array
  */
-const getConditionFunc = (i: number, bL: number) => (i === bL - 1 ? lessOrEqual : less);
+const getConditionFunc = (currentIndex: number, totalBorders: number) =>
+  currentIndex === totalBorders - 1 ? lessOrEqual : less;
 
+export type AxisValue = {
+  propName: Array<string>;
+  borders: Array<number>;
+};
 /**
  * Generate class A1 - C3 resolver based on borders in mapbox style resolver
- * @param {string} xValue.propName - name of prop in feature properties for x axis
- * @param {Array}  xValue.borders  - xValue class borders
- * @param {string} yValue.propName - name of prop in feature properties for y axis
- * @param {Array}  yValue.borders  - yValue class borders
+ * @param xValue.propName - name of prop in feature properties for x axis
+ * @param xValue.borders  - xValue class borders
+ * @param yValue.propName - name of prop in feature properties for y axis
+ * @param yValue.borders  - yValue class borders
  */
-export function classResolver(xValue, yValue) {
+export function classResolver(xValue: AxisValue, yValue: AxisValue) {
   const xAxisValue = stringsToFeatureProp(xValue.propName);
   const yAxisValue = stringsToFeatureProp(yValue.propName);
 
   return concat(
     switchFn(
+      // default case required
+      getCharByIndex(xValue.borders.length),
       // cases for a, b, c ...
       xValue.borders.map((border, i, arr) =>
         caseFn(getConditionFunc(i, arr.length)(xAxisValue, border), getCharByIndex(i)),
       ),
-      // default case required
-      getCharByIndex(xValue.borders.length),
     ),
     switchFn(
+      // default case required
+      yValue.borders.length,
       // cases for 1, 2, 3 ...
       yValue.borders.map((border, i, arr) =>
         caseFn(getConditionFunc(i, arr.length)(yAxisValue, border), i),
       ),
-      // default case required
-      yValue.borders.length,
     ),
   );
 }
@@ -112,12 +115,16 @@ export function classResolver(xValue, yValue) {
  * @param {Object} colorMap     - { class: color } map
  * @param {String} color        - color for classes missed in color map
  */
-export function colorResolver(variableName, colorMap, fallbackColor) {
+export function colorResolver(
+  variableName: string,
+  colorMap: Record<string, string>,
+  fallbackColor: string,
+) {
   return switchFn(
+    fallbackColor,
     Object.entries(colorMap).map(([cls, color]) =>
       // color cases
       caseFn(equal(getVariable(variableName), cls), color),
     ),
-    fallbackColor,
   );
 }

--- a/src/utils/bivariate/bivariate_style/styleGen.ts
+++ b/src/utils/bivariate/bivariate_style/styleGen.ts
@@ -67,6 +67,15 @@ const AT_CHAR_CODE = 64; // '@'.charCodeAt(0);
 export const getCharByIndex = (i: number) => String.fromCharCode(AT_CHAR_CODE + i); //get A - C by index
 
 /**
+ * Return condition based on border range
+ * all ranges - <
+ * last range - <=
+ * @param {number} i - index of current range
+ * @param {number} bL - length of borders array
+ */
+const getConditionFunc = (i: number, bL: number) => (i === bL - 1 ? lessOrEqual : less);
+
+/**
  * Generate class A1 - C3 resolver based on borders in mapbox style resolver
  * @param {string} xValue.propName - name of prop in feature properties for x axis
  * @param {Array}  xValue.borders  - xValue class borders
@@ -80,15 +89,17 @@ export function classResolver(xValue, yValue) {
   return concat(
     switchFn(
       // cases for a, b, c ...
-      xValue.borders.map((border, i) =>
-        caseFn(less(xAxisValue, border), getCharByIndex(i)),
+      xValue.borders.map((border, i, arr) =>
+        caseFn(getConditionFunc(i, arr.length)(xAxisValue, border), getCharByIndex(i)),
       ),
       // default case required
       getCharByIndex(xValue.borders.length),
     ),
     switchFn(
       // cases for 1, 2, 3 ...
-      yValue.borders.map((border, i) => caseFn(less(yAxisValue, border), i)),
+      yValue.borders.map((border, i, arr) =>
+        caseFn(getConditionFunc(i, arr.length)(yAxisValue, border), i),
+      ),
       // default case required
       yValue.borders.length,
     ),


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Some-hexagons-from-the-building-completeness-layer-are-not-displayed-18065
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- Improved logic for retrieving character and number data in bivariate legends.
	- Enhanced condition handling in bivariate style generation for better performance and accuracy.
	- Updated import statements and refined property types in the BivariateMatrixCell component for improved styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->