### PR TITLE
fix(18075): Don't show out-of range MCDA results as transparent tiles

### DIFF
--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -64,8 +64,23 @@ function sentimentPaint({
           ['>=', ['var', 'mcdaResult'], absoluteMin],
           ['<=', ['var', 'mcdaResult'], absoluteMax],
         ],
-        ['interpolate-hcl', ['linear'], ['var', 'mcdaResult'], 0, bad, 1, good],
-        'transparent', // all values outside of range [0,1] will be painted as transparent
+        [
+          'interpolate-hcl',
+          ['linear'],
+          ['var', 'mcdaResult'],
+          absoluteMin,
+          bad,
+          absoluteMax,
+          good,
+        ],
+        // paint all values below absoluteMin (0 by default) same as absoluteMin
+        ['<', ['var', 'mcdaResult'], absoluteMin],
+        bad,
+        // paint all values above absoluteMax (1 by default) same as absoluteMax
+        ['>', ['var', 'mcdaResult'], absoluteMax],
+        good,
+        // default color value. We shouldn't get it, because all cases are covered
+        'transparent',
       ],
     ],
     'fill-opacity': 1,
@@ -111,14 +126,17 @@ function generateLayerPaint(props: PaintProps) {
 }
 
 export function createMCDAStyle(config: MCDAConfig) {
-  const [absoluteMin = 0, absoluteMax = 1] = config.layers.reduce((acc, l) => {
-    // Show full range of values between min max if normalization not enabled
-    const range: [number, number] = l.normalization === 'no' ? l.range : [0, 1];
-    if (acc.length === 0) return range;
-    acc[0] = Math.min(acc[0], range[0]);
-    acc[1] = Math.min(acc[1], range[1]);
-    return acc;
-  }, [] as [number, number] | []);
+  const [absoluteMin = 0, absoluteMax = 1] = config.layers.reduce(
+    (acc, l) => {
+      // Show full range of values between min max if normalization not enabled
+      const range: [number, number] = l.normalization === 'no' ? l.range : [0, 1];
+      if (acc.length === 0) return range;
+      acc[0] = Math.min(acc[0], range[0]);
+      acc[1] = Math.min(acc[1], range[1]);
+      return acc;
+    },
+    [] as [number, number] | [],
+  );
 
   const mcdaResult = linearNormalization(config.layers);
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Hexes-with-MCDA-score-out-of-0-1-range-aren't-shown-18075