### PR TITLE
fix(18180): add Record Sensors button to Toolbar

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -26,7 +26,7 @@
     "geometry_uploader": "Upload\nGeoJSON",
     "focused_geometry_editor": "Draw or edit\ngeometry",
     "edit_in_osm": "Edit map in OSM",
-    "start_sensor_recording": "Start Sensor Recording",
+    "record_sensors": "Record sensors",
     "tools_label": "Tools",
     "selected_area_label": "Selected area",
     "upload_mcda": "Upload\nMCDA"

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -26,6 +26,7 @@
     "geometry_uploader": "Upload\nGeoJSON",
     "focused_geometry_editor": "Draw or edit\ngeometry",
     "edit_in_osm": "Edit map in OSM",
+    "start_sensor_recording": "Start Sensor Recording",
     "tools_label": "Tools",
     "selected_area_label": "Selected area",
     "upload_mcda": "Upload\nMCDA"

--- a/src/core/toolbar/index.ts
+++ b/src/core/toolbar/index.ts
@@ -2,6 +2,7 @@ import { createMapAtom, createPrimitiveAtom } from '~utils/atoms/createPrimitive
 import { store } from '~core/store/store';
 import { i18n } from '~core/localization';
 import { MCDA_CONTROL_ID, UPLOAD_MCDA_CONTROL_ID } from '~features/mcda/constants';
+import { SENSOR_CONTROL_ID } from '~features/live_sensor/constants';
 import type {
   ControlID,
   ControlState,
@@ -47,6 +48,7 @@ class ToolbarImpl implements Toolbar {
           'MapRuler',
           'EditInOsm',
           'BivariateMatrix',
+          SENSOR_CONTROL_ID,
           MCDA_CONTROL_ID,
           UPLOAD_MCDA_CONTROL_ID,
           'EditableLayer',

--- a/src/features/live_sensor/constants.ts
+++ b/src/features/live_sensor/constants.ts
@@ -1,3 +1,2 @@
-export const SENSOR_CONTROL = 'sensorControl';
-export const SENSOR_CONTROL_NAME = 'Live sensor control';
+export const SENSOR_CONTROL_ID = 'sensorControl';
 export const SENSOR_PRECISION = 6;

--- a/src/features/live_sensor/index.ts
+++ b/src/features/live_sensor/index.ts
@@ -11,7 +11,7 @@ export const liveSensorsControl = toolbar.setupControl<{
   id: SENSOR_CONTROL_ID,
   type: 'button',
   typeSettings: {
-    name: i18n.t('toolbar.start_sensor_recording'),
+    name: i18n.t('toolbar.record_sensors'),
     hint: {
       regular: i18n.t('live_sensor.start'),
       active: i18n.t('live_sensor.finish'),

--- a/src/features/live_sensor/index.ts
+++ b/src/features/live_sensor/index.ts
@@ -2,23 +2,23 @@ import { notificationServiceInstance } from '~core/notificationServiceInstance';
 import { toolbar } from '~core/toolbar';
 import { i18n } from '~core/localization';
 import { store } from '~core/store/store';
-import { SENSOR_CONTROL, SENSOR_CONTROL_NAME } from './constants';
+import { SENSOR_CONTROL_ID } from './constants';
 import { LiveSensor } from './LiveSensor';
 
 export const liveSensorsControl = toolbar.setupControl<{
   liveSensor?: LiveSensor;
 }>({
-  id: SENSOR_CONTROL,
+  id: SENSOR_CONTROL_ID,
   type: 'button',
   typeSettings: {
-    name: SENSOR_CONTROL_NAME,
+    name: i18n.t('toolbar.start_sensor_recording'),
     hint: {
       regular: i18n.t('live_sensor.start'),
       active: i18n.t('live_sensor.finish'),
       disabled: i18n.t('live_sensor.start'),
     },
     icon: 'Car24',
-    preferredSize: 'small',
+    preferredSize: 'large',
   },
 });
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Live-sensor-button-is-not-present-on-Smart-City-app-18180