### PR TITLE
Refactor e2e test configuration and environment setup

### DIFF
--- a/.env.playwright
+++ b/.env.playwright
@@ -1,2 +1,2 @@
-TEST_EMAIL=test_email
-TEST_PASSWORD=test_password
+EMAIL=test_email
+PASSWORD=test_password

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -9,20 +9,16 @@ on:
           - dev
           - test
           - prod
-
-env:
-  test_atlas_url: 'https://test-apps-ninja01.konturlabs.com/'
-  dev_atlas_url: 'https://test-apps-ninja02.konturlabs.com/'
-  prod_atlas_url: 'https://atlas.kontur.io/'
-  test_disaster_ninja_url: 'https://test-apps-ninja01.konturlabs.com/'
-  dev_disaster_ninja_url: 'https://test-apps-ninja02.konturlabs.com/'
-  prod_disaster_ninja_url: 'https://disaster.ninja/'
-  test_smart_city_url: 'https://test-apps-ninja01.konturlabs.com/'
-  dev_smart_city_url: 'https://test-apps-ninja02.konturlabs.com/'
-  prod_smart_city_url: 'https://maps.kontur.io/'
-  test_oam_url: 'https://test-apps-ninja01.konturlabs.com/'
-  dev_oam_url: 'https://test-apps-ninja02.konturlabs.com/'
-  prod_oam_url: 'https://new.openaerialmap.org/'
+      app:
+        type: choice
+        required: true
+        default: all
+        options:
+          - atlas
+          - disaster-ninja
+          - smart-city
+          - oam
+          - all
 
 jobs:
   run_tests:
@@ -30,7 +26,14 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
-      INPUT_ENV: ${{ github.event.inputs.env }}
+      ENVIRONMENT: ${{ github.event.inputs.env }}
+      APP_NAME: ${{ github.event.inputs.app }}
+      TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+      DEV_EMAIL: ${{ secrets.DEV_EMAIL }}
+      DEV_PASSWORD: ${{ secrets.DEV_PASSWORD }}
+      PROD_EMAIL: ${{ secrets.PROD_EMAIL }}
+      PROD_PASSWORD: ${{ secrets.PROD_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -38,9 +41,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '20'
-      - name: Install dependencies
-        working-directory: .
-        run: npm ci
       - name: Update playwright and install dependencies
         shell: bash
         run: |
@@ -50,30 +50,16 @@ jobs:
       - name: Create .env file
         shell: bash
         run: |
-          if [[ "$INPUT_ENV" == "test" ]]; then
-            echo "TEST_EMAIL=${{ secrets.TEST_EMAIL }}" >> .env.playwright.local
-            echo "TEST_PASSWORD=${{ secrets.TEST_PASSWORD }}" >> .env.playwright.local
-          elif [[ "$INPUT_ENV" == "dev" ]]; then
-            echo "TEST_EMAIL=${{ secrets.DEV_EMAIL }}" >> .env.playwright.local
-            echo "TEST_PASSWORD=${{ secrets.DEV_PASSWORD }}" >> .env.playwright.local
-          elif [[ "$INPUT_ENV" == "prod" ]]; then
-            echo "TEST_EMAIL=${{ secrets.PROD_EMAIL }}" >> .env.playwright.local
-            echo "TEST_PASSWORD=${{ secrets.PROD_PASSWORD }}" >> .env.playwright.local
-          fi
-      - name: Adjust project URLs
-        shell: bash
-        run: |
-          if [[ "$INPUT_ENV" == "test" ]]; then
-            sed -i "s|\"url\": \"$prod_atlas_url\"|\"url\": \"$test_atlas_url\"|g" e2e/projects-config.json
-            sed -i "s|\"url\": \"$prod_disaster_ninja_url\"|\"url\": \"$test_disaster_ninja_url\"|g" e2e/projects-config.json
-            sed -i "s|\"url\": \"$prod_smart_city_url\"|\"url\": \"$test_smart_city_url\"|g" e2e/projects-config.json
-            sed -i "s|\"url\": \"$prod_oam_url\"|\"url\": \"$test_oam_url\"|g" e2e/projects-config.json
-          elif [[ "$INPUT_ENV" == "dev" ]]; then
-            sed -i "s|\"url\": \"$prod_atlas_url\"|\"url\": \"$dev_atlas_url\"|g" e2e/projects-config.json
-            sed -i "s|\"url\": \"$prod_disaster_ninja_url\"|\"url\": \"$dev_disaster_ninja_url\"|g" e2e/projects-config.json
-            sed -i "s|\"url\": \"$prod_smart_city_url\"|\"url\": \"$dev_smart_city_url\"|g" e2e/projects-config.json
-            sed -i "s|\"url\": \"$prod_oam_url\"|\"url\": \"$dev_oam_url\"|g" e2e/projects-config.json
-          fi
+          ENV_PREFIX="${ENVIRONMENT^^}" # Convert to uppercase
+          EMAIL_VAR_NAME="${ENV_PREFIX}_EMAIL"
+          PASSWORD_VAR_NAME="${ENV_PREFIX}_PASSWORD"
+
+          EMAIL="${!EMAIL_VAR_NAME}"
+          PASSWORD="${!PASSWORD_VAR_NAME}"
+
+          echo "EMAIL=$EMAIL" >> .env.playwright.production
+          echo "PASSWORD=$PASSWORD" >> .env.playwright.production
+
       - name: Move to e2e directory and run tests
         working-directory: ./e2e
         run: npx playwright test

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ To view the app, visit https://localhost:3000 in your browser.
 Create a `.env.playwright.local` file in the root of the project with the following content:
 
 ```bash
-TEST_EMAIL=test_email
-TEST_PASSWORD=test_password
+EMAIL=test_email
+PASSWORD=test_password
 ```
 
 Set your projects environment at projects-config.json file

--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,8 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('has title', async ({ page }) => {
-  await page.goto('https://localhost:3000/');
-
-  // Expect a title "to contain" a substring.
-  await expect(page).toHaveTitle(/Disaster Ninja/);
-});

--- a/e2e/projects-config.json
+++ b/e2e/projects-config.json
@@ -1,22 +1,86 @@
-{
-  "atlas": {
-    "url": "https://atlas.kontur.io/",
-    "app": "9043acf9-2cf3-48ac-9656-a5d7c4b7593d",
-    "title": "Kontur Atlas"
+[
+  {
+    "env": "prod",
+    "name": "atlas",
+    "url": "https://atlas.kontur.io",
+    "title": "Kontur Atlas",
+    "hasCookieBanner": true
   },
-  "disaster_ninja": {
-    "url": "https://disaster.ninja/",
-    "app": "58851b50-9574-4aec-a3a6-425fa18dcb54",
-    "title": "Disaster Ninja"
+  {
+    "env": "dev",
+    "name": "atlas",
+    "url": "https://test-apps-ninja02.konturlabs.com/active?app=9043acf9-2cf3-48ac-9656-a5d7c4b7593d",
+    "title": "Kontur Atlas",
+    "hasCookieBanner": true
   },
-  "smart_city": {
-    "url": "https://maps.kontur.io/",
-    "app": "634f23f5-f898-4098-a8bd-09eb7c1e1ae5",
-    "title": "Smart City"
+  {
+    "env": "test",
+    "name": "atlas",
+    "url": "https://test-apps-ninja01.konturlabs.com/active?app=9043acf9-2cf3-48ac-9656-a5d7c4b7593d",
+    "title": "Kontur Atlas",
+    "hasCookieBanner": true
   },
-  "oam": {
-    "url": "https://new.openaerialmap.org/",
-    "app": "1dc6fe68-8802-4672-868d-7f17943bf1c8",
-    "title": "OpenAerialMap"
+  {
+    "env": "prod",
+    "name": "disaster-ninja",
+    "url": "https://disaster.ninja",
+    "title": "Disaster Ninja",
+    "hasCookieBanner": true
+  },
+  {
+    "env": "dev",
+    "name": "disaster-ninja",
+    "url": "https://test-apps-ninja02.konturlabs.com/active?app=58851b50-9574-4aec-a3a6-425fa18dcb54",
+    "title": "Disaster Ninja",
+    "hasCookieBanner": true
+  },
+  {
+    "env": "test",
+    "name": "disaster-ninja",
+    "url": "https://test-apps-ninja01.konturlabs.com/active?app=58851b50-9574-4aec-a3a6-425fa18dcb54",
+    "title": "Disaster Ninja",
+    "hasCookieBanner": true
+  },
+  {
+    "env": "prod",
+    "name": "smart-city",
+    "url": "https://maps.kontur.io",
+    "title": "Smart City",
+    "hasCookieBanner": true
+  },
+  {
+    "env": "dev",
+    "name": "smart-city",
+    "url": "https://test-apps-ninja02.konturlabs.com/active?app=634f23f5-f898-4098-a8bd-09eb7c1e1ae5",
+    "title": "Smart City",
+    "hasCookieBanner": true
+  },
+  {
+    "env": "test",
+    "name": "smart-city",
+    "url": "https://test-apps-ninja01.konturlabs.com/active?app=634f23f5-f898-4098-a8bd-09eb7c1e1ae5",
+    "title": "Smart City",
+    "hasCookieBanner": true
+  },
+  {
+    "env": "prod",
+    "name": "oam",
+    "url": "https://new.openaerialmap.org",
+    "title": "OpenAerialMap",
+    "hasCookieBanner": false
+  },
+  {
+    "env": "dev",
+    "name": "oam",
+    "url": "https://test-apps-ninja02.konturlabs.com/active?app=1dc6fe68-8802-4672-868d-7f17943bf1c8",
+    "title": "OpenAerialMap",
+    "hasCookieBanner": false
+  },
+  {
+    "env": "test",
+    "name": "oam",
+    "url": "https://test-apps-ninja01.konturlabs.com/active?app=1dc6fe68-8802-4672-868d-7f17943bf1c8",
+    "title": "OpenAerialMap",
+    "hasCookieBanner": false
   }
-}
+]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,9 @@ import * as dotenv from 'dotenv';
  * https://github.com/motdotla/dotenv
  */
 
-dotenv.config({ path: ['.env.playwright.local', '.env.playwright'] });
+dotenv.config({
+  path: ['.env.playwright.production', '.env.playwright.local', '.env.playwright'],
+});
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
This commit introduces several changes to the end-to-end (e2e) testing setup and configuration. The primary changes include:

- Standardization of environment variable names across different files, replacing `TEST_EMAIL` and `TEST_PASSWORD` with `EMAIL` and `PASSWORD`.
- Removal of hardcoded environment URLs in the GitHub Actions workflow file, replacing them with a dynamic setup that adjusts based on the input environment.
- Deletion of an example test file that was no longer needed.
- Update of the login test specification to accommodate changes in the environment setup and to remove hardcoded values.
- Refactoring of the projects configuration JSON to include environment-specific URLs and additional properties such as `hasCookieBanner`.
- Adjustment of the Playwright configuration to prioritize the production environment file.

These changes aim to simplify the configuration process, reduce duplication, and make the e2e testing framework more flexible and maintainable.