### PR TITLE
fix(18080): Fix clearing layers selection in MCDA edit form. Other MCDA improvements and fixes

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -82,7 +82,7 @@
   "mcda": {
     "title": "Multi-criteria decision analysis",
     "name": "MCDA",
-    "modal_title": "Create analysis",
+    "modal_title": "Customize analysis",
     "modal_input_name": "Name",
     "modal_input_name_placeholder": "Set layer name",
     "modal_input_indicators": "List of layers",

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -90,6 +90,7 @@
     "modal_input_indicators_no_options": "No options",
     "btn_cancel": "Cancel",
     "btn_save": "Save analysis",
+    "error_analysis_name_cannot_be_empty": "Analysis name cannot be empty",
     "error_bad_layer_data": "Invalid MCDA layer data",
     "error_invalid_file": "Invalid MCDA file format",
     "legend_title": "Legend",

--- a/src/core/logical_layers/utils/applyNewLayerSource.ts
+++ b/src/core/logical_layers/utils/applyNewLayerSource.ts
@@ -1,20 +1,21 @@
 import { store } from '~core/store/store';
-import { enabledLayersAtom } from '../atoms/enabledLayers';
+import { layersRegistryAtom } from '../atoms/layersRegistry';
 import { createUpdateLayerActions } from './createUpdateActions';
 import type { LayerSource } from '../types/source';
-import type { Action } from '@reatom/core-v2';
 
-export function applyNewLayerSource(newSource: LayerSource) {
+export function applyNewSourceToExistingLayer(newSource: LayerSource) {
   const id = newSource.id;
-  const actions: Array<Action> = [
-    enabledLayersAtom.delete(id),
-    ...createUpdateLayerActions([
-      {
-        id,
-        source: newSource,
-      },
-    ]).flat(),
-  ];
-  store.dispatch(actions);
-  store.dispatch(enabledLayersAtom.set(id));
+  const layerAtom = store.getState(layersRegistryAtom).get(id);
+  if (layerAtom) {
+    store.dispatch([
+      layerAtom.disable(),
+      ...createUpdateLayerActions([
+        {
+          id,
+          source: newSource,
+        },
+      ]).flat(),
+    ]);
+    store.dispatch([layerAtom.enable()]);
+  }
 }

--- a/src/core/logical_layers/utils/applyNewLayerSource.ts
+++ b/src/core/logical_layers/utils/applyNewLayerSource.ts
@@ -3,7 +3,7 @@ import { layersRegistryAtom } from '../atoms/layersRegistry';
 import { createUpdateLayerActions } from './createUpdateActions';
 import type { LayerSource } from '../types/source';
 
-export function applyNewSourceToExistingLayer(newSource: LayerSource) {
+export function applyNewLayerSource(newSource: LayerSource) {
   const id = newSource.id;
   const layerAtom = store.getState(layersRegistryAtom).get(id);
   if (layerAtom) {
@@ -17,5 +17,9 @@ export function applyNewSourceToExistingLayer(newSource: LayerSource) {
       ]).flat(),
     ]);
     store.dispatch([layerAtom.enable()]);
+  } else {
+    console.error(
+      `Cannot apply new source for ${id}. The layer with the given id not found`,
+    );
   }
 }

--- a/src/core/logical_layers/utils/logicalLayerFabric.ts
+++ b/src/core/logical_layers/utils/logicalLayerFabric.ts
@@ -212,6 +212,7 @@ export function createLogicalLayerAtom(
               `${
                 state.settings?.name || state.id || 'MCDA'
               }-${new Date().toISOString()}.json`,
+              2,
             );
           } else {
             logError('Only geojson layers or MCDA can be downloaded');

--- a/src/features/mcda/components/MCDAForm/index.tsx
+++ b/src/features/mcda/components/MCDAForm/index.tsx
@@ -56,10 +56,14 @@ export function MCDAForm({
   const [axisesResource] = useAtom(availableBivariateAxisesAtom);
   const inputItems = useMemo(
     () =>
-      (axisesResource.data ?? []).map((d) => ({
-        title: d.label,
-        value: d.id,
-      })) ?? [],
+      (axisesResource.data ?? [])
+        .sort((axis1, axis2) =>
+          axis1.label?.localeCompare(axis2.label, undefined, { sensitivity: 'base' }),
+        )
+        .map((d) => ({
+          title: d.label,
+          value: d.id,
+        })) ?? [],
     [axisesResource],
   );
 

--- a/src/features/mcda/components/MCDAForm/index.tsx
+++ b/src/features/mcda/components/MCDAForm/index.tsx
@@ -33,10 +33,15 @@ export function MCDAForm({
 }) {
   // Layer name input
   const [name, setName] = useState(initialState.name);
-  const onNameChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value),
-    [],
-  );
+  const [nameError, setNameError] = useState<string>('');
+  const onNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+    if (!e.target.value) {
+      setNameError(i18n.t('mcda.error_analysis_name_cannot_be_empty'));
+    } else {
+      setNameError('');
+    }
+  }, []);
 
   // Indicators input
   const [selectedIndicators, selectIndicators] = useState<SelectableItem[]>([]);
@@ -116,7 +121,9 @@ export function MCDAForm({
             {i18n.t('mcda.btn_cancel')}
           </Button>
           <Button
-            disabled={!axisesResource.data || selectedIndicators.length === 0}
+            disabled={
+              !axisesResource.data || selectedIndicators.length === 0 || !name?.length
+            }
             type="submit"
             onClick={saveAction}
           >
@@ -129,6 +136,7 @@ export function MCDAForm({
         <Input
           type="text"
           value={name}
+          error={nameError}
           onChange={onNameChange}
           renderLabel={<Text type="label">{i18n.t('mcda.modal_input_name')}</Text>}
           placeholder={i18n.t('mcda.modal_input_name_placeholder')}

--- a/src/features/mcda/components/MCDAForm/index.tsx
+++ b/src/features/mcda/components/MCDAForm/index.tsx
@@ -40,8 +40,12 @@ export function MCDAForm({
 
   // Indicators input
   const [selectedIndicators, selectIndicators] = useState<SelectableItem[]>([]);
+  const [selectionInitialized, setSelectionInitialized] = useState(false);
+
   const onSelectedIndicatorsChange = useCallback(
-    (e: { selectedItems: SelectableItem[] }) => selectIndicators(e.selectedItems),
+    (e: { selectedItems: SelectableItem[] }) => {
+      selectIndicators(e.selectedItems);
+    },
     [],
   );
   const [axisesResource] = useAtom(availableBivariateAxisesAtom);
@@ -54,18 +58,18 @@ export function MCDAForm({
     [axisesResource],
   );
 
-  const indicatorSelectorEmpty = selectedIndicators.length === 0;
   useEffect(() => {
     // Setup indicators input initial state after we get available indicators
     const preselected = new Set(initialState.axises.map((a) => a.id));
-    if (axisesResource.data && indicatorSelectorEmpty) {
+    if (axisesResource.data && !selectionInitialized && preselected.size > 0) {
       selectIndicators(
         axisesResource.data
           .filter((a) => preselected.has(a.id))
           .map((ind) => ({ value: ind.id, title: ind.label })),
       );
+      setSelectionInitialized(true);
     }
-  }, [initialState.axises, axisesResource, indicatorSelectorEmpty]);
+  }, [initialState.axises, axisesResource, selectionInitialized]);
 
   // Possible exits
   const cancelAction = useCallback(() => onConfirm(null), [onConfirm]);
@@ -111,7 +115,11 @@ export function MCDAForm({
           <Button type="reset" onClick={cancelAction} variant="invert-outline">
             {i18n.t('mcda.btn_cancel')}
           </Button>
-          <Button disabled={!axisesResource.data} type="submit" onClick={saveAction}>
+          <Button
+            disabled={!axisesResource.data || selectedIndicators.length === 0}
+            type="submit"
+            onClick={saveAction}
+          >
             {i18n.t('mcda.btn_save')}
           </Button>
         </div>

--- a/src/features/mcda/index.ts
+++ b/src/features/mcda/index.ts
@@ -78,15 +78,18 @@ export async function editMCDA(
   layerState: LogicalLayerState,
   layerActions: LogicalLayerActions,
 ) {
-  const config = await editMCDAConfig(layerState);
-  if (config?.id) {
-    // TODO: use applyNewMCDAConfig() instead of the following lines. This whole function and editMCDAConfig() should be refactored
-    layerActions.destroy();
-    store.dispatch([
-      mcdaLayerAtom.createMCDALayer({ ...config, id: config.id }),
-      enabledLayersAtom.set(config.id),
-      ...getMutualExcludedActions(layerState),
-    ]);
+  const oldConfig = layerState.style?.config;
+  if (oldConfig) {
+    const config = await editMCDAConfig(layerState?.style?.config);
+    if (config?.id) {
+      // TODO: use applyNewMCDAConfig() instead of the following lines. This whole function and editMCDAConfig() should be refactored
+      layerActions.destroy();
+      store.dispatch([
+        mcdaLayerAtom.createMCDALayer({ ...config, id: config.id }),
+        enabledLayersAtom.set(config.id),
+        ...getMutualExcludedActions(layerState),
+      ]);
+    }
   }
 }
 

--- a/src/features/mcda/index.ts
+++ b/src/features/mcda/index.ts
@@ -7,6 +7,7 @@ import { mcdaLayerAtom } from './atoms/mcdaLayer';
 import { createMCDAConfig, editMCDAConfig } from './mcdaConfig';
 import { MCDA_CONTROL_ID, UPLOAD_MCDA_CONTROL_ID } from './constants';
 import { askMcdaJSONFile } from './utils/openMcdaFile';
+import { applyNewMCDAConfig } from './utils/applyNewMCDAConfig';
 import type {
   LogicalLayerActions,
   LogicalLayerState,
@@ -82,13 +83,14 @@ export async function editMCDA(
   if (oldConfig) {
     const config = await editMCDAConfig(layerState?.style?.config);
     if (config?.id) {
-      // TODO: use applyNewMCDAConfig() instead of the following lines. This whole function and editMCDAConfig() should be refactored
-      layerActions.destroy();
-      store.dispatch([
-        mcdaLayerAtom.createMCDALayer({ ...config, id: config.id }),
-        enabledLayersAtom.set(config.id),
-        ...getMutualExcludedActions(layerState),
-      ]);
+      if (config.id === oldConfig.id) {
+        // update existing MCDA
+        applyNewMCDAConfig(config);
+      } else {
+        // recreate MCDA with a new id
+        layerActions.destroy();
+        store.dispatch([mcdaLayerAtom.createMCDALayer({ ...config, id: config.id })]);
+      }
     }
   }
 }

--- a/src/features/mcda/index.ts
+++ b/src/features/mcda/index.ts
@@ -81,7 +81,7 @@ export async function editMCDA(
 ) {
   const oldConfig = layerState.style?.config;
   if (oldConfig) {
-    const config = await editMCDAConfig(layerState?.style?.config);
+    const config = await editMCDAConfig(oldConfig);
     if (config?.id) {
       if (config.id === oldConfig.id) {
         // update existing MCDA

--- a/src/features/mcda/mcdaConfig.tsx
+++ b/src/features/mcda/mcdaConfig.tsx
@@ -15,37 +15,30 @@ import type {
   MCDALayer,
 } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 
-export async function editMCDAConfig(
-  layerState: LogicalLayerState,
-): Promise<MCDAConfig | null> {
-  const name = layerState.id;
-  const axises =
-    layerState.style?.config?.layers?.map((layer) => ({
-      id: layer.id,
-      label: layer.name,
-    })) ?? [];
+export async function editMCDAConfig(oldConfig: MCDAConfig): Promise<MCDAConfig | null> {
+  const name = oldConfig.id;
+  const oldLayers = oldConfig.layers ?? [];
+  const axises = oldLayers.map((layer) => ({
+    id: layer.id,
+    label: layer.name,
+  }));
   const input = await showModal(MCDAForm, {
     initialState: {
       name,
       axises,
     },
   });
-
   if (input === null) return null;
 
   const newLayers = createMCDALayersFromBivariateAxises(input.axises);
-  const oldLayers = layerState.style?.config?.layers ?? [];
   const resultLayers = newLayers.reduce<MCDALayer[]>((acc, layer) => {
+    // if there already was a layer with this id, reuse it
     const oldLayer = oldLayers.find((old) => old.id === layer.id);
     acc.push(oldLayer ?? layer);
     return acc;
   }, []);
 
-  const config = createDefaultMCDAConfig({
-    id: input.name,
-    layers: resultLayers,
-  });
-  return { ...config };
+  return { ...oldConfig, layers: resultLayers, id: input.name };
 }
 
 export async function createMCDAConfig() {

--- a/src/features/mcda/utils/applyNewMCDAConfig.ts
+++ b/src/features/mcda/utils/applyNewMCDAConfig.ts
@@ -1,5 +1,5 @@
 import { layersSourcesAtom } from '~core/logical_layers/atoms/layersSources';
-import { applyNewLayerSource } from '~core/logical_layers/utils/applyNewLayerSource';
+import { applyNewSourceToExistingLayer } from '~core/logical_layers/utils/applyNewLayerSource';
 import { deepCopy } from '~core/logical_layers/utils/deepCopy';
 import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 
@@ -11,6 +11,6 @@ export function applyNewMCDAConfig(config: MCDAConfig) {
     if (newSource?.style?.config) {
       newSource.style.config = { ...config };
     }
-    applyNewLayerSource(newSource);
+    applyNewSourceToExistingLayer(newSource);
   }
 }

--- a/src/features/mcda/utils/applyNewMCDAConfig.ts
+++ b/src/features/mcda/utils/applyNewMCDAConfig.ts
@@ -1,5 +1,5 @@
 import { layersSourcesAtom } from '~core/logical_layers/atoms/layersSources';
-import { applyNewSourceToExistingLayer } from '~core/logical_layers/utils/applyNewLayerSource';
+import { applyNewLayerSource } from '~core/logical_layers/utils/applyNewLayerSource';
 import { deepCopy } from '~core/logical_layers/utils/deepCopy';
 import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 
@@ -11,6 +11,6 @@ export function applyNewMCDAConfig(config: MCDAConfig) {
     if (newSource?.style?.config) {
       newSource.style.config = { ...config };
     }
-    applyNewSourceToExistingLayer(newSource);
+    applyNewLayerSource(newSource);
   }
 }

--- a/src/utils/file/download.ts
+++ b/src/utils/file/download.ts
@@ -1,5 +1,9 @@
-export function downloadObject(data: unknown, fileName: string) {
-  const file = new Blob([JSON.stringify(data)], { type: 'json' });
+export function downloadObject(
+  data: unknown,
+  fileName: string,
+  indentation?: string | number,
+) {
+  const file = new Blob([JSON.stringify(data, null, indentation)], { type: 'json' });
   const a = document.createElement('a');
   const url = URL.createObjectURL(file);
   a.href = url;


### PR DESCRIPTION
Fixes and changes:
- https://kontur.fibery.io/Tasks/Task/FE-Cross-near-layers-at-Edit-analysis-sets-default-value-instead-of-deletion-18080
- https://kontur.fibery.io/Tasks/Task/FE-Disable-Save-analysis-button-if-MCDA-name-or-Layer-list-is-empty-17909
- Prevents auto renaming and unnecessary creation/deletion of logical layers when editing MCDA
- Refactors applyNewLayerSource for using layerAtom actions (helps properly applying mutually excluded actions)
- add name sorting to Create MCDA form dropdown
- changed MCDA edit/creation modal title to "Customize analysis"
- format MCDA JSON when dowloading it as file