### PR TITLE
feat(18182): Optional midpoints parameter for coloring MCDA legend

### DIFF
--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_GREEN = 'rgba(90, 200, 127, 0.5)';
 export const DEFAULT_RED = 'rgba(228, 26, 28, 0.5)';
+export const DEFAULT_YELLOW = 'rgba(251,237,170,0.5)';
 export const sentimentDefault: [string, string] = ['bad', 'good'];
 export const sentimentReversed: [string, string] = ['good', 'bad'];

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -71,6 +71,8 @@ function sentimentPaint({
   absoluteMax,
 }: PaintProps) {
   const { good = DEFAULT_GREEN, bad = DEFAULT_RED } = colorsConfig.parameters;
+  /* TODO: using midpoints for gradient customization is a temporary solution.
+  It will probably be removed in the future in favor of working with Color Manager */
   const midpoints = Array.isArray(colorsConfig.parameters.midpoints)
     ? colorsConfig.parameters.midpoints
     : [];

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -71,6 +71,14 @@ function sentimentPaint({
   absoluteMax,
 }: PaintProps) {
   const { good = DEFAULT_GREEN, bad = DEFAULT_RED } = colorsConfig.parameters;
+  const midpoints = Array.isArray(colorsConfig.parameters.midpoints)
+    ? colorsConfig.parameters.midpoints
+    : [];
+  const colorPoints = [
+    { value: absoluteMin, color: bad },
+    ...midpoints,
+    { value: absoluteMax, color: good },
+  ];
   return {
     'fill-color': [
       'let',
@@ -87,10 +95,7 @@ function sentimentPaint({
           'interpolate-hcl',
           ['linear'],
           ['var', 'mcdaResult'],
-          absoluteMin,
-          bad,
-          absoluteMax,
-          good,
+          ...colorPoints.flatMap((point) => [point.value, point.color]),
         ],
         // paint all values below absoluteMin (0 by default) same as absoluteMin
         ['<', ['var', 'mcdaResult'], absoluteMin],

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
@@ -8,6 +8,8 @@ export type ColorsBySentiments = {
   parameters: {
     good: string;
     bad: string;
+    /* TODO: using midpoints for gradient customization is a temporary solution.
+    It will probably be removed in the future in favor of working with Color Manager */
     midpoints?: { value: number; color: string }[];
   };
 };

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
@@ -8,6 +8,7 @@ export type ColorsBySentiments = {
   parameters: {
     good: string;
     bad: string;
+    midpoints?: { value: number; color: string }[];
   };
 };
 

--- a/src/features/mcda/atoms/mcdaLayer.ts
+++ b/src/features/mcda/atoms/mcdaLayer.ts
@@ -31,6 +31,8 @@ export const mcdaLayerAtom = createAtom(
       if (json.colors.type === 'sentiments') {
         const colorGood = json.colors.parameters?.good ?? DEFAULT_GREEN;
         const colorBad = json.colors.parameters?.bad ?? DEFAULT_RED;
+        /* TODO: using midpoints for gradient customization is a temporary solution.
+        It will probably be removed in the future in favor of working with Color Manager */
         const colorMidpoints =
           json.colors.parameters?.midpoints?.map(
             (point) => `${point.color} ${point.value * 100}%`,

--- a/src/features/mcda/atoms/mcdaLayer.ts
+++ b/src/features/mcda/atoms/mcdaLayer.ts
@@ -31,11 +31,19 @@ export const mcdaLayerAtom = createAtom(
       if (json.colors.type === 'sentiments') {
         const colorGood = json.colors.parameters?.good ?? DEFAULT_GREEN;
         const colorBad = json.colors.parameters?.bad ?? DEFAULT_RED;
-        legendColors = generateHclGradientColors(
-          colorBad.toString(),
-          colorGood.toString(),
-          5,
-        );
+        const colorMidpoints =
+          json.colors.parameters?.midpoints?.map(
+            (point) => `${point.color} ${point.value * 100}%`,
+          ) ?? null;
+        if (colorMidpoints?.length) {
+          legendColors = [colorBad.toString(), ...colorMidpoints, colorGood.toString()];
+        } else {
+          legendColors = generateHclGradientColors(
+            colorBad.toString(),
+            colorGood.toString(),
+            5,
+          );
+        }
       }
 
       const actions: Array<Action> = [

--- a/src/features/mcda/mcdaConfig.tsx
+++ b/src/features/mcda/mcdaConfig.tsx
@@ -76,6 +76,8 @@ function createDefaultMCDAConfig(overrides?: Partial<MCDAConfig>): MCDAConfig {
       parameters: {
         bad: DEFAULT_RED,
         good: DEFAULT_GREEN,
+        /* TODO: using midpoints for gradient customization is a temporary solution.
+        It will probably be removed in the future in favor of working with Color Manager */
         midpoints: [{ value: 0.5, color: DEFAULT_YELLOW }],
       },
     },

--- a/src/features/mcda/mcdaConfig.tsx
+++ b/src/features/mcda/mcdaConfig.tsx
@@ -6,6 +6,7 @@ import { formatBivariateAxisUnit, type Axis } from '~utils/bivariate';
 import {
   DEFAULT_GREEN,
   DEFAULT_RED,
+  DEFAULT_YELLOW,
   sentimentDefault,
 } from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants';
 import { MCDAForm } from './components/MCDAForm';
@@ -75,6 +76,7 @@ function createDefaultMCDAConfig(overrides?: Partial<MCDAConfig>): MCDAConfig {
       parameters: {
         bad: DEFAULT_RED,
         good: DEFAULT_GREEN,
+        midpoints: [{ value: 0.5, color: DEFAULT_YELLOW }],
       },
     },
     custom: true,


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Add-middle-color-for-good---bad-sentiment-in-MCDA-18182

Allows to create more complex linear gradients legend using an optional array of {mcdaValue, color} inside sentiments color parameters.

This is a temporary solution and will probably be replaced with using Color Manager in the future.

<img width="1390" alt="image" src="https://github.com/konturio/disaster-ninja-fe/assets/9570735/eac20303-6209-40fb-988f-49944f181509">
