### PR TITLE
MCDA edit layer: hide empty info buttons for parameters

### DIFF
--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameterRow/MCDALayerParameterRow.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameterRow/MCDALayerParameterRow.tsx
@@ -17,11 +17,12 @@ export function MCDALayerParameterRow({
     <div className={s.inputLine}>
       <span className={s.inputLinelabel}>
         {name}
-        <TooltipTrigger
+        {/* TODO: hidden temporarily until we add content for these popups */}
+        {/* <TooltipTrigger
           className={s.infoButton}
           tipText={tipText}
           tooltipId={LAYERS_PANEL_FEATURE_ID}
-        />
+        /> */}
       </span>
       <div className={s.inputContainer}>{children}</div>
     </div>


### PR DESCRIPTION
 Hides empty info buttons for MCDA layer edit parameters (they mess up the layout and have no content yet)