### PR TITLE
fix(18310): add Outlier to short summary of changed mcda layer parameters

### DIFF
--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
@@ -96,6 +96,12 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
         value: layer.normalization,
       });
     }
+    if (layer.outliers !== DEFAULTS.outliers) {
+      result.push({
+        paramName: i18n.t('mcda.layer_editor.outliers'),
+        value: layer.outliers,
+      });
+    }
     return result;
   }, [layer]);
 


### PR DESCRIPTION
https://kontur.fibery.io/favorites/Tasks/My-tasks-3575#Tasks/Task/FE-Modified-Outliers-value-isn't-shown-in-MCDA-layer-summary-18310

<img width="269" alt="image" src="https://github.com/konturio/disaster-ninja-fe/assets/9570735/10fab0d0-fd84-4291-a6c3-4eb2d206b9e4">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the layer editor to include an `outliers` parameter when it deviates from the default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->