### PR TITLE
fix(14214): Shift blue stroke of selected area outline to outside of the area shape

### DIFF
--- a/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
+++ b/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
@@ -32,6 +32,7 @@ const getLayersConfig = (
       paint: {
         'line-width': 8,
         'line-color': FOCUSED_GEOMETRY_COLOR,
+        'line-offset': -2,
       },
       layout: {
         'line-join': 'round',
@@ -45,6 +46,7 @@ const getLayersConfig = (
         'line-width': 10,
         'line-color': '#FFF',
         'line-opacity': 0.5,
+        'line-offset': -2,
       },
       layout: {
         'line-join': 'round',

--- a/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
+++ b/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
@@ -46,7 +46,7 @@ const getLayersConfig = (
         'line-width': 10,
         'line-color': '#FFF',
         'line-opacity': 0.5,
-        'line-offset': -3,
+        'line-offset': -4,
       },
       layout: {
         'line-join': 'round',

--- a/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
+++ b/src/features/focused_geometry_layer/renderers/FocusedGeometryRenderer.ts
@@ -32,7 +32,7 @@ const getLayersConfig = (
       paint: {
         'line-width': 8,
         'line-color': FOCUSED_GEOMETRY_COLOR,
-        'line-offset': -2,
+        'line-offset': -3,
       },
       layout: {
         'line-join': 'round',
@@ -46,7 +46,7 @@ const getLayersConfig = (
         'line-width': 10,
         'line-color': '#FFF',
         'line-opacity': 0.5,
-        'line-offset': -2,
+        'line-offset': -3,
       },
       layout: {
         'line-join': 'round',


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Blue-stroke-of-Selected-area-should-be-only-outside-of-event-shape-14214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **New Features**
  - Updated the geometry rendering to include a new line offset, enhancing the visual clarity of layered elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->