### PR TITLE
fix(18366): left align app logo on sidebar

### DIFF
--- a/src/features/side_bar/components/AppLogo/AppLogo.module.css
+++ b/src/features/side_bar/components/AppLogo/AppLogo.module.css
@@ -3,7 +3,7 @@
   pointer-events: none;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: left;
 
   color: var(--faint-weak-up, #d2d5d8);
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/My-tasks-3575#Task/App-logo-on-sidebar-is-not-left-aligned-18366