### PR TITLE
fix(18581): [HOTFIX] Add null check to findBaseMap()

### DIFF
--- a/src/boot.ts
+++ b/src/boot.ts
@@ -109,7 +109,7 @@ async function getBaseMapUrl(
 ) {
   /* Find base map by source type */
   const findBaseMap = <T extends { source?: { type: string } }>(layers: Array<T>) =>
-    layers.find((l) => l.source?.type === 'maplibre-style-url');
+    layers.find((l) => l?.source?.type === 'maplibre-style-url');
 
   let baseMapUrl: string | undefined;
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Add-null-check-inside-getBaseMapUrl()-18581