### PR TITLE
feat: disable unused params from location url

### DIFF
--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -115,7 +115,8 @@ export const urlStoreAtom = createAtom(
     newState.event = currentEvent?.id ? currentEvent.id : undefined;
 
     const currentFeed = get('currentEventFeedAtom');
-    newState.feed = currentFeed && isFeedSelectorEnabled ? currentFeed.id : undefined;
+    const feedId = currentFeed && isFeedSelectorEnabled ? currentFeed.id : undefined;
+    newState.feed = feedId;
 
     const enabledLayers = get('enabledLayersAtom');
     newState.layers = Array.from(enabledLayers ?? []);

--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -38,8 +38,8 @@ export const urlStoreAtom = createAtom(
   ) => {
     const isFeedSelectorEnabled =
       typeof (
-        getUnlistedState(featureFlagsAtom)[FeatureFlag.EVENTS_LIST__FEED_SELECTOR] ||
-        getUnlistedState(featureFlagsAtom)[FeatureFlag.FEED_SELECTOR]
+        configRepo.get().features[FeatureFlag.EVENTS_LIST__FEED_SELECTOR] ||
+        configRepo.get().features[FeatureFlag.FEED_SELECTOR]
       ) !== 'undefined';
 
     onAction('init', (initialState) => {

--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -5,7 +5,7 @@ import {
   currentMapPositionAtom,
   currentEventFeedAtom,
 } from '~core/shared_state';
-import { featureFlagsAtom, FeatureFlag } from '~core/shared_state';
+import { FeatureFlag } from '~core/shared_state';
 import { scheduledAutoSelect, scheduledAutoFocus } from '~core/shared_state/currentEvent';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { createStringAtom } from '~utils/atoms/createPrimitives';

--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -36,11 +36,10 @@ export const urlStoreAtom = createAtom(
     { get, schedule, onAction, onInit, create, getUnlistedState },
     state: UrlData | null = null,
   ) => {
-    const isFeedSelectorEnabled =
-      typeof (
-        configRepo.get().features[FeatureFlag.EVENTS_LIST__FEED_SELECTOR] ||
-        configRepo.get().features[FeatureFlag.FEED_SELECTOR]
-      ) !== 'undefined';
+    const isFeedSelectorEnabled = [
+      FeatureFlag.EVENTS_LIST__FEED_SELECTOR,
+      FeatureFlag.FEED_SELECTOR,
+    ].some((flag) => typeof configRepo.get().features[flag] !== 'undefined');
 
     onAction('init', (initialState) => {
       schedule(async (dispatch) => {

--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -5,6 +5,7 @@ import {
   currentMapPositionAtom,
   currentEventFeedAtom,
 } from '~core/shared_state';
+import { featureFlagsAtom, FeatureFlag } from '~core/shared_state';
 import { scheduledAutoSelect, scheduledAutoFocus } from '~core/shared_state/currentEvent';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { createStringAtom } from '~utils/atoms/createPrimitives';
@@ -31,7 +32,16 @@ export const urlStoreAtom = createAtom(
     _setState: (state: UrlData | null) => state,
     init: (initialState: UrlData) => initialState,
   },
-  ({ get, schedule, onAction, onInit, create }, state: UrlData | null = null) => {
+  (
+    { get, schedule, onAction, onInit, create, getUnlistedState },
+    state: UrlData | null = null,
+  ) => {
+    const isFeedSelectorEnabled =
+      typeof (
+        getUnlistedState(featureFlagsAtom)[FeatureFlag.EVENTS_LIST__FEED_SELECTOR] ||
+        getUnlistedState(featureFlagsAtom)[FeatureFlag.FEED_SELECTOR]
+      ) !== 'undefined';
+
     onAction('init', (initialState) => {
       schedule(async (dispatch) => {
         const actions: Action[] = [create('_setState', initialState)];
@@ -71,7 +81,7 @@ export const urlStoreAtom = createAtom(
         }
 
         // Apply feed
-        if (initialState.feed) {
+        if (initialState.feed && isFeedSelectorEnabled) {
           actions.push(currentEventFeedAtom.setCurrentFeed(initialState.feed));
         }
 
@@ -105,12 +115,15 @@ export const urlStoreAtom = createAtom(
     newState.event = currentEvent?.id ? currentEvent.id : undefined;
 
     const currentFeed = get('currentEventFeedAtom');
-    newState.feed = currentFeed ? currentFeed.id : undefined;
+    newState.feed = currentFeed && isFeedSelectorEnabled ? currentFeed.id : undefined;
 
     const enabledLayers = get('enabledLayersAtom');
     newState.layers = Array.from(enabledLayers ?? []);
 
-    newState.app = configRepo.get().id;
+    const addAppIdToUrl = ['test-apps-ninja', 'localhost'].some((host) =>
+      window.location.host.includes(host),
+    );
+    if (addAppIdToUrl) newState.app = configRepo.get().id;
 
     state = newState;
     const currentVersion = ++lastVersion;


### PR DESCRIPTION
hide the `feed` param if the app won't use it
hide the `app` param for the urls with custom domain