### PR TITLE
feat(18518): Display admin boundaries based on user preferred languages

### DIFF
--- a/src/utils/map/boundaries.test.ts
+++ b/src/utils/map/boundaries.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, describe, it } from 'vitest';
+import { getLocalizedFeatureName } from './boundaries';
+
+const FEATURE: GeoJSON.Feature = {
+  id: '913067_ID',
+  properties: {
+    name: 'NAME',
+    tags: {
+      int_name: 'Shanghai:INT',
+      'name:en': 'Shanghai:EN',
+      'name:uk': 'Шанхай:UK',
+      'name:zh': '上海市:ZH',
+      'name:es': 'Shanghái:ES',
+    },
+  },
+  geometry: {
+    type: 'MultiPolygon',
+    coordinates: [],
+  },
+  type: 'Feature',
+};
+
+describe('getLocalizedFeatureName', () => {
+  it('should return the first available localized name from the list of preferred languages', () => {
+    expect(getLocalizedFeatureName(FEATURE, ['fr', 'uk', 'en', 'es'])).toEqual(
+      FEATURE.properties!.tags['name:uk'],
+    );
+    expect(
+      getLocalizedFeatureName(FEATURE as GeoJSON.Feature, ['zh', 'fr', 'uk', 'en']),
+    ).toEqual(FEATURE.properties!.tags['name:zh']);
+  });
+
+  it('should return international name if none of the preferred languages is available', () => {
+    expect(
+      getLocalizedFeatureName(FEATURE as GeoJSON.Feature, ['fr', 'by', 'fi']),
+    ).toEqual(FEATURE.properties!.tags.int_name);
+  });
+
+  it('should return standard feature name if neither localized nor international name is available', () => {
+    const featureWithoutIntName = structuredClone(FEATURE);
+    featureWithoutIntName.properties!.tags.int_name = '';
+    expect(
+      getLocalizedFeatureName(featureWithoutIntName as GeoJSON.Feature, [
+        'fr',
+        'by',
+        'fi',
+      ]),
+    ).toEqual(FEATURE.properties!.name);
+  });
+});

--- a/src/utils/map/boundaries.ts
+++ b/src/utils/map/boundaries.ts
@@ -8,8 +8,7 @@ export function getLocalizedFeatureName(
 ): string {
   if (feature.properties?.tags) {
     const tags = feature.properties.tags;
-    // check language from the app config first,
-    // then the list of browser's preferred languages
+    // check names in preferred languages first
     for (let i = 0; i < preferredLanguages.length; i++) {
       if (tags[`name:${preferredLanguages[i]}`]) {
         return tags[`name:${preferredLanguages[i]}`];

--- a/src/utils/map/boundaries.ts
+++ b/src/utils/map/boundaries.ts
@@ -2,16 +2,15 @@ import { configRepo } from '~core/config';
 
 export type BoundaryOption = { label: string; value: string | number };
 
-function getLocalizedFeatureName(
+export function getLocalizedFeatureName(
   feature: GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>,
+  preferredLanguages: string[],
 ): string {
-  const configLang = configRepo.get().user?.language;
   if (feature.properties?.tags) {
     const tags = feature.properties.tags;
     // check language from the app config first,
     // then the list of browser's preferred languages
-    const preferredLanguages = [configLang, ...navigator.languages];
-    for (let i = 0; i < navigator.languages.length; i++) {
+    for (let i = 0; i < preferredLanguages.length; i++) {
       if (tags[`name:${preferredLanguages[i]}`]) {
         return tags[`name:${preferredLanguages[i]}`];
       }
@@ -33,12 +32,17 @@ export function constructOptionsFromBoundaries(
   const sortedFeatures = features.sort(
     (f1, f2) => f2.properties?.admin_level - f1.properties?.admin_level,
   );
+
+  const preferredLanguages = [
+    configRepo.get().user?.language,
+    ...navigator.languages,
+  ].filter(Boolean) as string[];
   const options: BoundaryOption[] = [];
   for (const feat of sortedFeatures) {
     const id = feat.id;
     if (id !== undefined) {
       options.push({
-        label: getLocalizedFeatureName(feat),
+        label: getLocalizedFeatureName(feat, preferredLanguages),
         value: id,
       });
     }


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Display-admin-boundaries-based-on-interface-language-on-Kontur-apps-18518

<img width="327" alt="image" src="https://github.com/konturio/disaster-ninja-fe/assets/9570735/dc835937-e63a-4298-8bbd-89871653431b">
