### PR TITLE
Revert "feat(18342): replace bio placeholder with bio tooltip (#751)"

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -362,7 +362,7 @@
     "konturTheme": "Kontur",
     "HOTTheme": "HOT",
     "userBio(about)": "Bio",
-    "user_bio_tooltip": "Tell us a bit about yourself:\n  •  your current role\n  •  professional skills\n  •  interests\n  •  industry\n  •  objectives or challenges you tackle\nThis bio helps customize and personalize your experience.",
+    "user_bio_placeholder": "Tell us a bit about yourself:\n  •  your current role\n  •  professional skills\n  •  interests\n  •  industry\n  •  objectives or challenges you tackle\nThis bio helps customize and personalize your experience.",
     "defaultDisasterFeed": "Default disaster feed",
     "defaultOSMeditor": "Default OpenStreetMap editor (beta)",
     "successNotification": "All changes have been applied successfully",

--- a/src/features/user_profile/components/SettingsForm/SettingsForm.module.css
+++ b/src/features/user_profile/components/SettingsForm/SettingsForm.module.css
@@ -83,14 +83,13 @@
     resize: vertical;
   }
 }
+.textAreaPlaceholder {
+  white-space: pre-wrap;
+}
 
 /* Mobile view */
 @media screen and (max-width: 550px) {
   .divider {
     display: none;
   }
-}
-
-.bioTooltipContent {
-  white-space: pre-wrap;
 }

--- a/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
+++ b/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
@@ -1,16 +1,7 @@
-import {
-  Button,
-  Input,
-  Radio,
-  Select,
-  Text,
-  Heading,
-  Textarea,
-  Tooltip,
-} from '@konturio/ui-kit';
+import { Button, Input, Radio, Select, Text, Heading, Textarea } from '@konturio/ui-kit';
 import { useAtom } from '@reatom/react-v2';
 import clsx from 'clsx';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { KonturSpinner } from '~components/LoadingSpinner/KonturSpinner';
 import { authClientInstance } from '~core/authClientInstance';
 import { i18n } from '~core/localization';
@@ -20,7 +11,6 @@ import { flatObjectsAreEqual } from '~utils/common';
 import { currentProfileAtom, pageStatusAtom } from '../../atoms/userProfile';
 import s from './SettingsForm.module.css';
 import { ReferenceAreaInfo } from './ReferenceAreaInfo/ReferenceAreaInfo';
-import { MAX_BIO_HEIGHT, MIN_BIO_HEIGHT } from './constants';
 import type { UserDto } from '~core/app/user';
 import type { ChangeEvent } from 'react';
 
@@ -49,8 +39,6 @@ function SettingsFormGen({ userProfile, updateUserProfile }) {
   const [status, { set: setPageStatus }] = useAtom(pageStatusAtom);
   const [eventFeeds] = useAtom(eventFeedsAtom);
   const featureFlags = configRepo.get().features;
-  const bioTooltipTargetRef = useRef<HTMLDivElement>(null);
-  const [isBioTooltipOpen, setIsBioTooltipOpen] = useState(false);
 
   function logout() {
     authClientInstance.logout();
@@ -147,34 +135,16 @@ function SettingsFormGen({ userProfile, updateUserProfile }) {
                   placeholder={i18n.t('profile.email')}
                   disabled
                 />
-
-                <Tooltip
-                  placement="right-start"
-                  offset={15}
-                  open={isBioTooltipOpen}
-                  triggerRef={bioTooltipTargetRef}
-                  onClose={() => setIsBioTooltipOpen(false)}
-                >
-                  <div className={s.bioTooltipContent}>
-                    {i18n.t('profile.user_bio_tooltip')}
-                  </div>
-                </Tooltip>
-                <div
-                  className={s.biography}
-                  ref={bioTooltipTargetRef}
-                  onClick={() => setIsBioTooltipOpen((prev) => !prev)}
-                >
+                <div className={s.biography}>
                   <Textarea
-                    onFocus={() => setIsBioTooltipOpen(true)}
-                    onBlur={() => setIsBioTooltipOpen(false)}
-                    placeholder={i18n.t('profile.userBio(about)')}
-                    showTopPlaceholder
+                    placeholder={i18n.t('profile.user_bio_placeholder')}
                     value={localSettings.bio}
                     onChange={onBioChange}
                     className={s.textArea}
+                    classes={{ placeholder: s.textAreaPlaceholder }}
                     width="100%"
-                    minHeight={MIN_BIO_HEIGHT}
-                    maxHeight={MAX_BIO_HEIGHT}
+                    minHeight="200px"
+                    maxHeight="250px"
                   />
                 </div>
 

--- a/src/features/user_profile/components/SettingsForm/constants.ts
+++ b/src/features/user_profile/components/SettingsForm/constants.ts
@@ -1,2 +1,0 @@
-export const MAX_BIO_HEIGHT = '250px';
-export const MIN_BIO_HEIGHT = '80px';


### PR DESCRIPTION
This reverts commit 0d3a75317569b63eeb377021f6c107e008442a71.

Reverting back to bio tooltip, because it's displayed incorrectly in builds on Windows.
![image](https://github.com/konturio/disaster-ninja-fe/assets/9570735/65db1c87-5564-4556-bbcf-3adf204625cd)

Returning to placeholder for now:
<img width="820" alt="image" src="https://github.com/konturio/disaster-ninja-fe/assets/9570735/eb8cb8c0-7438-4938-991c-4886adc41dc0">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced user profile settings form with updated placeholder text for bio input.

- **Style**
  - Improved text area styling for better readability and mobile view compatibility.

- **Refactor**
  - Simplified bio input handling by removing the tooltip and related state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->