### PR TITLE
fix(18774): Fix crash when opening MCDA file without indicators array

### DIFF
--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
@@ -78,7 +78,7 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
   }, [axes?.data?.axis, axes?.loading, layer.id]);
 
   const mcdaLayerHint: LayerInfo[] = useMemo(() => {
-    const description = layer.indicators[0]?.description;
+    const description = layer.indicators?.[0]?.description;
     const copyrightsCombined: string[] = [];
     layer?.indicators?.forEach((indicator) => {
       if (indicator.copyrights) {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/My-tasks-3575#Task/Upload-MCDA-crashes-if-the-file-doesn't-contain-indicators-array-18744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by ensuring safe access to the `description` property in the MCDA Layer Parameters, preventing potential errors when the property is undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->