### PR TITLE
fix(18079): Add name parameter to MCDA configuration. Refactor opening mcda json file

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -103,6 +103,7 @@
     "error_analysis_name_cannot_be_empty": "Analysis name cannot be empty",
     "error_bad_layer_data": "Invalid MCDA layer data",
     "error_invalid_file": "Invalid MCDA file format",
+    "error_wrong_mcda_version": "Wrong MCDA version",
     "legend_title": "Legend",
     "legend_subtitle": "Hexagons are colored based on analysis layer settings. Click a hexagon to see its values.",
     "layer_editor": {

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
@@ -37,6 +37,7 @@ export interface MCDALayer {
 
 export interface MCDAConfig {
   id: string;
+  name: string;
   version: 4;
   layers: Array<MCDALayer>;
   colors: ColorsBySentiments | ColorsByMapLibreExpression;

--- a/src/features/mcda/atoms/mcdaLayer.ts
+++ b/src/features/mcda/atoms/mcdaLayer.ts
@@ -27,6 +27,7 @@ export const mcdaLayerAtom = createAtom(
   ({ onAction, schedule, getUnlistedState, create }) => {
     onAction('createMCDALayer', (json) => {
       const id = json.id;
+      const name = json.name;
       let legendColors: string[] | undefined;
       if (json.colors.type === 'sentiments') {
         const colorGood = json.colors.parameters?.good ?? DEFAULT_GREEN;
@@ -53,7 +54,7 @@ export const mcdaLayerAtom = createAtom(
         layersSettingsAtom.set(
           id,
           createAsyncWrapper({
-            name: id,
+            name,
             id,
             category: 'overlay' as const,
             group: 'bivariate',

--- a/src/features/mcda/constants.ts
+++ b/src/features/mcda/constants.ts
@@ -1,2 +1,3 @@
 export const MCDA_CONTROL_ID = 'MCDA';
 export const UPLOAD_MCDA_CONTROL_ID = 'UploadMCDA';
+export const DEFAULT_MCDA_NAME = 'MCDA layer';

--- a/src/features/mcda/mcdaConfig.tsx
+++ b/src/features/mcda/mcdaConfig.tsx
@@ -10,14 +10,13 @@ import {
   sentimentDefault,
 } from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants';
 import { MCDAForm } from './components/MCDAForm';
-import type { LogicalLayerState } from '~core/logical_layers/types/logicalLayer';
 import type {
   MCDAConfig,
   MCDALayer,
 } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 
 export async function editMCDAConfig(oldConfig: MCDAConfig): Promise<MCDAConfig | null> {
-  const name = oldConfig.id;
+  const name = oldConfig.name;
   const oldLayers = oldConfig.layers ?? [];
   const axises = oldLayers.map((layer) => ({
     id: layer.id,
@@ -39,7 +38,12 @@ export async function editMCDAConfig(oldConfig: MCDAConfig): Promise<MCDAConfig 
     return acc;
   }, []);
 
-  return { ...oldConfig, layers: resultLayers, id: input.name };
+  return {
+    ...oldConfig,
+    layers: resultLayers,
+    name: input.name,
+    id: generateMCDAId(input.name),
+  };
 }
 
 export async function createMCDAConfig() {
@@ -53,16 +57,19 @@ export async function createMCDAConfig() {
   if (input === null) return null;
 
   const config = createDefaultMCDAConfig({
-    id: input.name,
+    name: input.name,
     layers: createMCDALayersFromBivariateAxises(input.axises),
   });
   return config;
 }
 
 function createDefaultMCDAConfig(overrides?: Partial<MCDAConfig>): MCDAConfig {
+  const name = overrides?.name ?? 'MCDA layer';
+
   return {
     version: 4,
-    id: `${overrides?.id ?? 'mcda-layer'}_${nanoid(4)}`,
+    id: generateMCDAId(name),
+    name,
     layers: overrides?.layers ?? [],
     colors: {
       type: 'sentiments',
@@ -113,6 +120,10 @@ function createMCDALayersFromBivariateAxises(axises: Axis[]): MCDALayer[] {
     }
     return acc;
   }, []);
+}
+
+function generateMCDAId(mcdaName: string) {
+  return `${mcdaName ?? 'mcda-layer'}_${nanoid(4)}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/features/mcda/mcdaConfig.tsx
+++ b/src/features/mcda/mcdaConfig.tsx
@@ -10,6 +10,8 @@ import {
   sentimentDefault,
 } from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants';
 import { MCDAForm } from './components/MCDAForm';
+import { generateMCDAId } from './utils/generateMCDAId';
+import { DEFAULT_MCDA_NAME } from './constants';
 import type {
   MCDAConfig,
   MCDALayer,
@@ -64,7 +66,7 @@ export async function createMCDAConfig() {
 }
 
 function createDefaultMCDAConfig(overrides?: Partial<MCDAConfig>): MCDAConfig {
-  const name = overrides?.name ?? 'MCDA layer';
+  const name = overrides?.name ?? DEFAULT_MCDA_NAME;
 
   return {
     version: 4,
@@ -120,19 +122,4 @@ function createMCDALayersFromBivariateAxises(axises: Axis[]): MCDALayer[] {
     }
     return acc;
   }, []);
-}
-
-function generateMCDAId(mcdaName: string) {
-  return `${mcdaName ?? 'mcda-layer'}_${nanoid(4)}`;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isMCDAConfig(json: any): json is MCDAConfig {
-  // TODO: full check using ajv
-  return (
-    json.id &&
-    json?.layers?.length &&
-    json?.version >= 4 &&
-    (json?.colors?.type === 'sentiments' || json?.colors?.type === 'mapLibreExpression')
-  );
 }

--- a/src/features/mcda/utils/generateMCDAId.ts
+++ b/src/features/mcda/utils/generateMCDAId.ts
@@ -1,0 +1,5 @@
+import { nanoid } from 'nanoid';
+
+export function generateMCDAId(mcdaName?: string) {
+  return `${mcdaName ?? 'mcda-layer'}_${nanoid(4)}`;
+}

--- a/src/features/mcda/utils/openMcdaFile.ts
+++ b/src/features/mcda/utils/openMcdaFile.ts
@@ -1,6 +1,7 @@
 import { i18n } from '~core/localization';
 import { currentNotificationAtom } from '~core/shared_state';
-import { isMCDAConfig } from '../mcdaConfig';
+import { DEFAULT_MCDA_NAME } from '../constants';
+import { generateMCDAId } from './generateMCDAId';
 import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 
 const input = (() => {
@@ -9,6 +10,29 @@ const input = (() => {
   input.multiple = false;
   return input;
 })();
+
+function createMCDAConfigFromJSON(json: Partial<MCDAConfig>): MCDAConfig {
+  const result: Partial<MCDAConfig> = { ...json };
+  if (!result.version || result.version < 4) {
+    throw new Error(i18n.t('mcda.error_wrong_mcda_version'));
+  }
+  if (
+    !result?.layers?.length ||
+    !(
+      result?.colors?.type === 'sentiments' ||
+      result?.colors?.type === 'mapLibreExpression'
+    )
+  ) {
+    throw new Error(i18n.t('mcda.error_invalid_file'));
+  }
+  if (!result.id) {
+    result.id = generateMCDAId(result.name);
+  }
+  if (!result.name) {
+    result.name = result.id ?? DEFAULT_MCDA_NAME;
+  }
+  return result as MCDAConfig;
+}
 
 function readMcdaJSONFile(file): Promise<MCDAConfig> {
   return new Promise((res, rej) => {
@@ -19,11 +43,8 @@ function readMcdaJSONFile(file): Promise<MCDAConfig> {
       if (!s) return;
       try {
         const json = JSON.parse(s);
-        if (isMCDAConfig(json)) {
-          return res({ ...json, custom: true } as MCDAConfig);
-        } else {
-          throw new Error('Not an MCDA JSON format');
-        }
+        const mcdaConfig = createMCDAConfigFromJSON(json);
+        res({ ...mcdaConfig, custom: true } as MCDAConfig);
       } catch (error) {
         rej(error);
       }
@@ -38,12 +59,12 @@ export function askMcdaJSONFile(onSuccess: (mcdaConfig: MCDAConfig) => void) {
     if ('files' in input && input.files !== null) {
       const files = Array.from(input.files);
       try {
-        const json = await readMcdaJSONFile(files[0]);
-        onSuccess(json);
+        const mcdaConfig = await readMcdaJSONFile(files[0]);
+        onSuccess(mcdaConfig);
       } catch (error) {
         currentNotificationAtom.showNotification.dispatch(
           'error',
-          { title: i18n.t('mcda.error_invalid_file') },
+          { title: (error as Error).message ?? i18n.t('mcda.error_invalid_file') },
           5,
         );
       } finally {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Refactor-new-MCDA-name-and-id-creation-18079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new error message for incorrect MCDA version.
  - Introduced a `name` property for MCDA configurations.
  - Added a default MCDA name constant: 'MCDA layer'.
  - Implemented a new function to generate MCDA IDs based on names.
  - Enhanced JSON file handling for MCDA configurations with improved error handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->