### PR TITLE
fix(18607): fix MCDA style: paint faulty values (null, NaN, etc.) as transparent

### DIFF
--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -85,7 +85,7 @@ function sentimentPaint({
     'fill-color': [
       'let',
       'mcdaResult',
-      ['to-number', mcdaResult, -9999], // falsy values become -9999
+      mcdaResult,
       [
         'case',
         [
@@ -105,7 +105,8 @@ function sentimentPaint({
         // paint all values above absoluteMax (1 by default) same as absoluteMax
         ['>', ['var', 'mcdaResult'], absoluteMax],
         good,
-        // default color value. We shouldn't get it, because all cases are covered
+        // Default color value. We get here in case of incorrect values (null, NaN etc)
+        // Transparent features don't show popups on click
         'transparent',
       ],
     ],


### PR DESCRIPTION
https://kontur.fibery.io/favorites/Tasks/My-tasks-3575#Tasks/Task/Nulls-in-MCDA-layer-are-red-instead-of-transparent-18607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved color mapping logic for sentiment analysis results, ensuring better handling of incorrect values (`null`, `NaN`) with a default transparent color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->