### PR TITLE
fix(mcdaStyle): 18787 fix style calculation for MCDA with a single axis

### DIFF
--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -49,9 +49,8 @@ export function filterSetup(layers: MCDAConfig['layers']) {
 }
 
 export function linearNormalization(layers: MCDAConfig['layers']) {
-  const layersCount = layers.length;
-  if (layersCount === 1) {
-    return calculateLayer(layers.at(0)!);
+  if (layers.length === 1) {
+    return ['/', calculateLayer(layers.at(0)!), layers.at(0)!.coefficient];
   } else {
     return ['/', ['+', ...layers.map(calculateLayer)], sumBy(layers, 'coefficient')];
   }
@@ -85,7 +84,7 @@ function sentimentPaint({
     'fill-color': [
       'let',
       'mcdaResult',
-      ['to-number', mcdaResult, -9999], // falsy values become -9999
+      mcdaResult,
       [
         'case',
         [
@@ -105,7 +104,8 @@ function sentimentPaint({
         // paint all values above absoluteMax (1 by default) same as absoluteMax
         ['>', ['var', 'mcdaResult'], absoluteMax],
         good,
-        // default color value. We shouldn't get it, because all cases are covered
+        // Default color value. We get here in case of incorrect values (null, NaN etc)
+        // Transparent features don't show popups on click
         'transparent',
       ],
     ],

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -84,7 +84,7 @@ function sentimentPaint({
     'fill-color': [
       'let',
       'mcdaResult',
-      mcdaResult,
+      ['to-number', mcdaResult, -9999], // falsy values become -9999
       [
         'case',
         [
@@ -104,8 +104,7 @@ function sentimentPaint({
         // paint all values above absoluteMax (1 by default) same as absoluteMax
         ['>', ['var', 'mcdaResult'], absoluteMax],
         good,
-        // Default color value. We get here in case of incorrect values (null, NaN etc)
-        // Transparent features don't show popups on click
+        // default color value. We shouldn't get it, because all cases are covered
         'transparent',
       ],
     ],


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Weight-works-incorrectly-for-MCDA-with-a-single-axis-18787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic of the normalization function for better performance and readability.
  - Enhanced the handling of default color values for incorrect inputs to ensure more consistent rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->