### PR TITLE
feat: Refresh auth tokens during the app initialization

### DIFF
--- a/src/core/api_client/apiClient.ts
+++ b/src/core/api_client/apiClient.ts
@@ -193,7 +193,7 @@ export class ApiClient {
   /**
    * @throws {ApiClientError}
    */
-  private async refreshAuthToken(): Promise<boolean> {
+  public async refreshAuthToken(): Promise<boolean> {
     const params = {
       client_id: this.keycloakClientId,
       refresh_token: this.refreshToken,

--- a/src/core/app/postAppInit.ts
+++ b/src/core/app/postAppInit.ts
@@ -7,7 +7,9 @@ import type { Config } from '~core/config/types';
 
 export async function postAppInit(config: Config) {
   authClientInstance.loginHook = onLogin.bind(authClientInstance);
-  authClientInstance.checkAuth();
+  const isAuthenticated = authClientInstance.checkAuth();
+  // It's required to refresh auth tokens to get the fresh roles data from keycloak
+  if (isAuthenticated) await authClientInstance.refreshAuth();
   urlStoreAtom.init.dispatch({
     ...config.initialUrl,
     layers: config.activeLayers,

--- a/src/core/auth/client/AuthClient.ts
+++ b/src/core/auth/client/AuthClient.ts
@@ -50,6 +50,16 @@ export class AuthClient {
   }
 
   /**
+   * refreshAuth
+   * @returns void
+   *
+   * @throws {ApiClientError}
+   */
+  public async refreshAuth() {
+    await this._apiClient.refreshAuthToken();
+  }
+
+  /**
    * @returns true or error message
    */
   public async authenticate(user: string, password: string) {


### PR DESCRIPTION
The `refreshAuthToken` method in the `ApiClient` class was changed from private to public. This change allows external code to refresh the authentication token. This is necessary to get fresh roles data from Keycloak.

https://kontur.fibery.io/Tasks/Task/Refresh-access-token-during-Kontur-app-initialization-18527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved authentication handling to ensure roles data is consistently refreshed when the user is authenticated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->