### PR TITLE
fix(18858): Fix incorrect label for MCDA axes with area_km2 in denominator

### DIFF
--- a/src/utils/bivariate/labelFormatters.test.ts
+++ b/src/utils/bivariate/labelFormatters.test.ts
@@ -90,34 +90,6 @@ describe('BivariateLegend labels formatting', () => {
       expect(formatBivariateAxisLabel(quotients)).toEqual('NDVI (avg) to Test (index)');
     });
 
-    it('denominator - area_km2', () => {
-      const quotients: Axis['quotients'] = [
-        {
-          name: 'highway_length_6_months',
-          label: 'OSM: new road length (last 6 months)',
-          direction: [['bad'], ['good']],
-          unit: {
-            id: 'km',
-            shortName: 'km',
-            longName: 'kilometers',
-          },
-        },
-        {
-          name: 'area_km2',
-          label: 'Area',
-          direction: [['neutral'], ['neutral']],
-          unit: {
-            id: 'km2',
-            shortName: 'km²',
-            longName: 'square kilometers',
-          },
-        },
-      ];
-      expect(formatBivariateAxisLabel(quotients)).toEqual(
-        'OSM: new road length (last 6 months) (km/km²)',
-      );
-    });
-
     it('other cases', () => {
       const quotients: Axis['quotients'] = [
         {

--- a/src/utils/bivariate/labelFormatters.ts
+++ b/src/utils/bivariate/labelFormatters.ts
@@ -26,10 +26,6 @@ export const formatBivariateAxisLabel = (quotients: Axis['quotients']): string =
   if (!hasUnits(denominator.unit.id)) {
     return `${numerator.label} to ${denominator.label} (${numerator.unit.shortName})`;
   }
-  // cases for both units
-  if (denominator.name === 'area_km2') {
-    return `${numerator.label} (${numerator.unit.shortName}/${denominator.unit.shortName})`;
-  }
 
   return `${numerator.label} to ${denominator.label} (${numerator.unit.shortName}/${denominator.unit.shortName})`;
 };
@@ -51,11 +47,6 @@ export const formatBivariateAxisUnit = (quotients: Axis['quotients']): string | 
   //  numerator unit + no denominator unit - show only numerator unit
   if (!hasUnits(denominator.unit.id)) {
     return numerator.unit.shortName;
-  }
-
-  // cases for both units
-  if (denominator.name === 'area_km2') {
-    return `${numerator.unit.shortName}/${denominator.unit.shortName}`;
   }
 
   return `${numerator.unit.shortName}/${denominator.unit.shortName}`;


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Fix-incorrect-label-for-MCDA-axes-with-area_km2-in-denominator-18858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the formatting logic for bivariate axis labels and units by removing specific cases for 'area_km2.'

- **Tests**
  - Removed a test case related to denominator formatting for 'area_km2' in `BivariateLegend` labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->