### PR TITLE
fix(18791): Don't remove ownedByUser layers when currentUser is set

### DIFF
--- a/src/core/shared_state/currentUser.ts
+++ b/src/core/shared_state/currentUser.ts
@@ -1,6 +1,4 @@
 import { createAtom } from '~utils/atoms';
-import { layersSettingsAtom } from '~core/logical_layers/atoms/layersSettings';
-import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
 import { configRepo } from '~core/config';
 import type { CurrentUser } from '~core/app/user';
 
@@ -8,33 +6,13 @@ export const currentUserAtom = createAtom(
   {
     setUser: (user: CurrentUser = configRepo.get().initialUser) => user,
   },
-  (
-    { onAction, schedule, getUnlistedState },
-    state: CurrentUser = configRepo.get().initialUser,
-  ) => {
+  ({ onAction }, state: CurrentUser = configRepo.get().initialUser) => {
     onAction('setUser', (usr) => {
       if (usr) {
         state = usr;
       } else {
         state = configRepo.get().initialUser;
       }
-      // remove all ownByUser layers from map
-      const settingsRegistryKeys = Array.from(getUnlistedState(layersSettingsAtom))
-        .filter(([, val]) => val?.data?.ownedByUser)
-        .map(([key]) => key);
-
-      if (!settingsRegistryKeys.length) return;
-
-      const registeredAtoms = Array.from(getUnlistedState(layersRegistryAtom))
-        .filter(([key]) => settingsRegistryKeys.includes(key))
-        .map(([key, val]) => val);
-
-      if (!registeredAtoms.length) return;
-
-      const actions = registeredAtoms.map((lr) => lr.destroy());
-      schedule((dispatch) => {
-        dispatch(actions);
-      });
     });
 
     return state;


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-MCDA-gets-deleted-if-user-goes-to-their-profile-18791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic of user state management to improve performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->