### PR TITLE
fix(mcdaStyle): 18809 don't show hexes with MCDA value === Infinity on the map

### DIFF
--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/__snapshots__/mcdaStyle.test.ts.snap
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/__snapshots__/mcdaStyle.test.ts.snap
@@ -2,34 +2,53 @@
 
 exports[`createMCDAStyle > filterSetup() > creates correct filter when both MCDA layers have outliers === "as_on_limits" 1`] = `
 [
-  "any",
+  "all",
+  [
+    "any",
+    [
+      "!=",
+      [
+        "/",
+        [
+          "get",
+          "hazardous_days_count",
+        ],
+        [
+          "get",
+          "one",
+        ],
+      ],
+      0,
+    ],
+    [
+      "!=",
+      [
+        "/",
+        [
+          "get",
+          "population",
+        ],
+        [
+          "get",
+          "area_km2",
+        ],
+      ],
+      0,
+    ],
+  ],
   [
     "!=",
     [
-      "/",
-      [
-        "get",
-        "hazardous_days_count",
-      ],
-      [
-        "get",
-        "one",
-      ],
+      "get",
+      "one",
     ],
     0,
   ],
   [
     "!=",
     [
-      "/",
-      [
-        "get",
-        "population",
-      ],
-      [
-        "get",
-        "area_km2",
-      ],
+      "get",
+      "area_km2",
     ],
     0,
   ],
@@ -101,6 +120,22 @@ exports[`createMCDAStyle > filterSetup() > creates correct filter when one of th
       ],
     ],
     46200,
+  ],
+  [
+    "!=",
+    [
+      "get",
+      "one",
+    ],
+    0,
+  ],
+  [
+    "!=",
+    [
+      "get",
+      "area_km2",
+    ],
+    0,
   ],
 ]
 `;

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -25,6 +25,7 @@ const calculateLayer = calculateLayerPipeline(inStyleCalculations, (axis) => ({
 }));
 
 export function filterSetup(layers: MCDAConfig['layers']) {
+  // TODO: is this condition really needed?
   // checks that at least one layer has a non-zero value
   const conditions = [
     anyCondition(

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -42,6 +42,15 @@ export function filterSetup(layers: MCDAConfig['layers']) {
       );
     }
   });
+  layers.forEach(({ axis, range }) => {
+    conditions.push(
+      // check  numerator and denominator for null/undefined
+      notEqual(featureProp(axis[0]), null),
+      notEqual(featureProp(axis[1]), null),
+      // this checks for 0 in denominator (which causes makes the result == Infinity)
+      notEqual(featureProp(axis[1]), 0),
+    );
+  });
   if (conditions.length > 1) {
     return allCondition(...conditions);
   }
@@ -98,10 +107,6 @@ function sentimentPaint({
           ['var', 'mcdaResult'],
           ...colorPoints.flatMap((point) => [point.value, point.color]),
         ],
-        // mcdaResult == Infinity if any of the denominators is 0.
-        // We consider these values invalid
-        ['==', ['var', 'mcdaResult'], Infinity],
-        'transparent',
         // paint all values below absoluteMin (0 by default) same as absoluteMin
         ['<', ['var', 'mcdaResult'], absoluteMin],
         bad,

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -98,6 +98,10 @@ function sentimentPaint({
           ['var', 'mcdaResult'],
           ...colorPoints.flatMap((point) => [point.value, point.color]),
         ],
+        // mcdaResult == Infinity if any of the denominators is 0.
+        // We consider these values invalid
+        ['==', ['var', 'mcdaResult'], Infinity],
+        'transparent',
         // paint all values below absoluteMin (0 by default) same as absoluteMin
         ['<', ['var', 'mcdaResult'], absoluteMin],
         bad,

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -44,9 +44,6 @@ export function filterSetup(layers: MCDAConfig['layers']) {
   });
   layers.forEach(({ axis, range }) => {
     conditions.push(
-      // check  numerator and denominator for null/undefined
-      notEqual(featureProp(axis[0]), null),
-      notEqual(featureProp(axis[1]), null),
       // this checks for 0 in denominator (which causes makes the result == Infinity)
       notEqual(featureProp(axis[1]), 0),
     );

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -44,7 +44,7 @@ export function filterSetup(layers: MCDAConfig['layers']) {
   });
   layers.forEach(({ axis, range }) => {
     conditions.push(
-      // this checks for 0 in denominator (which causes makes the result == Infinity)
+      // this checks for 0 in denominator (0 in denominator makes the result === Infinity)
       notEqual(featureProp(axis[1]), 0),
     );
   });


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-MCDA-hex-shows-Infinity-result-if-the-denominator-is-0-18809

UPD:  It was decided to not filter out Infinity values on FE (because they can be valid in theory), and instead to try and fix this on BE/data side within MVTs. See comment: https://kontur.fibery.io/Tasks/Task/FE-MCDA-hex-shows-Infinity-result-if-the-denominator-is-0-18809/comment=23678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent division by zero in calculations, ensuring more stable performance.
  - Marked invalid results (like `Infinity`) as transparent to avoid display issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->