### PR TITLE
feat(apiClient): add refreshTokenExpirationDate property

### DIFF
--- a/src/core/api_client/apiClient.ts
+++ b/src/core/api_client/apiClient.ts
@@ -114,7 +114,7 @@ export class ApiClient {
         }
       }
     } catch (e) {
-      errorMessage = 'Token decode error';
+      errorMessage = e?.['message'];
     }
     throw new ApiClientError(errorMessage || 'Token error', { kind: 'bad-data' });
   }

--- a/src/core/api_client/errors.ts
+++ b/src/core/api_client/errors.ts
@@ -66,8 +66,8 @@ export function createApiError(err: unknown) {
   }
   if (err instanceof wretch.WretchError) {
     status = err.status;
-    // In case of 400/401 error we need to parse error message from body and show it to user
-    if (status === 400 || status === 401) {
+    // In case of 401 error we need to parse error message from body and show it to user
+    if (status === 401) {
       errorMessage = err.json?.error_description ?? err?.message ?? 'Auth error';
       problem = { kind: 'unauthorized', data: err.json?.error };
     } else if (status === 403) {

--- a/src/core/api_client/tests/_clientTestsContext.ts
+++ b/src/core/api_client/tests/_clientTestsContext.ts
@@ -38,7 +38,8 @@ export const createContext = () => {
   const expiredToken =
     'eyJhbGciOiJIUzI1NiJ9.eyJSb2xlIjoiYWRtaW4iLCJVc2VybmFtZSI6InRlc3R1c2VyIiwiZXhwIjoxNjAyNDk4NDM0LCJpYXQiOjE2MzQwMzQ0MzR9.tIETTaRaiJYto0Wb4oPbfCJHUGGjw9--mTfXVWWsVMk';
   const actualToken = setTokenExp(expiredToken, setTimeOffset(10));
-  const refreshToken = 'testRefreshToken';
+  const refreshToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIyMGJjYzUzNy00MzRkLTQzMjItYTk2YS1hMjNlZDc0N2JhYjAi.ewogICJleHAiOiAxNzIwMDA0OTc0LAogICJpYXQiOiAxNzIwMDA0Njc0Cn0.RVI1MwYAh4Wle8vQeyRUYPy1id3wQWeXY0_M4jQ7ZV0'; //fake token
   const username = 'testuser';
   const password = 'testpassword';
 
@@ -59,6 +60,10 @@ export const createContext = () => {
   (apiClient as any).token = token;
   (apiClient as any).tokenExpirationDate = new Date(
     new Date().getTime() + 1000 * 60 * 30,
+  );
+  (apiClient as any).refreshToken = refreshToken;
+  (apiClient as any).refreshTokenExpirationDate = new Date(
+    new Date().getTime() + 1000 * 60 * 60 * 24 * 30,
   );
 
   return {

--- a/src/core/api_client/tests/authorization.test.ts
+++ b/src/core/api_client/tests/authorization.test.ts
@@ -88,7 +88,7 @@ test('no auth data error', async ({ ctx }) => {
     expect(getApiErrorKind(e) === 'bad-data');
   }
 });
-/** /
+/**
 test('refreshToken called when token is expired', async ({ ctx }) => {
   expect.assertions(4);
 
@@ -193,7 +193,7 @@ test('Calls api without authorization', async ({ ctx }) => {
     'Api without authorization have Authorization header',
   ).not.toBe(`Bearer ${ctx.token}`);
 });
-/**/
+**/
 test('Not add authorization header to api without authorization', async ({ ctx }) => {
   ctx.mockAdapter.onPost('/login').willResolve({
     access_token: ctx.token,


### PR DESCRIPTION
The `ApiClient` class now includes a `refreshTokenExpirationDate` property to track the expiration date of the refresh token. This property is used to determine if the refresh token is expired and should trigger a logout.

https://kontur.fibery.io/Tasks/Task/Access-token-on-test-doesn't-refresh-18701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved logic for managing refresh token expiration, including automatic logout for expired refresh tokens.

- **Bug Fixes**
  - Corrected comment syntax in authorization tests to ensure proper execution.

- **Tests**
  - Enhanced token management in test contexts, focusing on refresh tokens and their expiration dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->