### PR TITLE
feat(18760): prevent toasts if response error occurred on Analytics and Disasters

### DIFF
--- a/src/core/api/insights.ts
+++ b/src/core/api/insights.ts
@@ -14,7 +14,7 @@ export function getPolygonDetails(
       features,
     },
     true,
-    { signal: abortController.signal },
+    { signal: abortController.signal, errorsConfig: { hideErrors: true } },
   );
 }
 
@@ -27,7 +27,7 @@ export function getAdvancedPolygonDetails(
     `/advanced_polygon_details/`,
     geometry,
     true,
-    { signal: abortController.signal },
+    { signal: abortController.signal, errorsConfig: { hideErrors: true } },
   );
 }
 

--- a/src/core/api/insights.ts
+++ b/src/core/api/insights.ts
@@ -45,6 +45,7 @@ export function getLlmAnalysis(
     {
       signal: abortController.signal,
       headers: { 'user-language': i18n.instance.language },
+      errorsConfig: { hideErrors: true },
       retryAfterTimeoutError: {
         times: 5,
         delayMs: 1000,

--- a/src/features/events_list/atoms/eventListResource.ts
+++ b/src/features/events_list/atoms/eventListResource.ts
@@ -29,6 +29,7 @@ export const eventListResourceAtom = createAsyncAtom(
     const responseData =
       (await apiClient.get<Event[]>('/events/', params, true, {
         signal: abortController.signal,
+        errorsConfig: { hideErrors: true },
       })) ?? ([] as Event[]);
 
     dispatchMetricsEventOnce(AppFeature.EVENTS_LIST, responseData.length > 0);


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Do-not-display-toasts-if-the-same-error-is-displayed-on-the-Kontur-app-panel-18760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling with an option to hide errors for polygon and advanced polygon details requests.
  - Introduced custom error handling for LLM analysis, including hiding errors and retrying after a timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->