### PR TITLE
fix(18582): Update current state coordinates when map initialize with extent

### DIFF
--- a/src/components/ConnectedMap/map-libre-adapter/index.tsx
+++ b/src/components/ConnectedMap/map-libre-adapter/index.tsx
@@ -154,6 +154,14 @@ function MapboxMap(
     const extent = configRepo.get().extent;
     if (!currentMapPosition && extent) {
       mapInstance.fitBounds(extent, { animate: false });
+      const zoom = mapInstance.getZoom();
+      const { lng, lat } = mapInstance.getCenter();
+
+      currentMapPositionAtom.setCurrentMapPosition.dispatch({
+        lat,
+        lng,
+        zoom,
+      });
     }
   }, [mapEl, externalStyleLink, options, ref]);
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Edit-map-in-OSM-doesn't-work-when-there's-no-coordinates-in-URL-18582
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to set the current map position using the map's zoom level, longitude, and latitude for improved map navigation and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->