### PR TITLE
feat(18530): hide reference and selected area on layers panel if they are empty

### DIFF
--- a/src/core/logical_layers/atoms/layersTree/layersTree.ts
+++ b/src/core/logical_layers/atoms/layersTree/layersTree.ts
@@ -1,41 +1,32 @@
-import { createAtom } from '~utils/atoms/createPrimitives';
+import { atom } from '@reatom/core';
 import { layersCategoriesSettingsAtom } from '~core/shared_state/layersCategoriesSettings';
 import { layersGroupsSettingsAtom } from '~core/shared_state/layersGroupsSettings';
 import { focusedGeometryAtom } from '~core/focused_geometry/model';
-import { referenceAreaAtomV2 } from '~core/shared_state/referenceArea';
+import { referenceAreaAtom } from '~core/shared_state/referenceArea';
 import { FOCUSED_GEOMETRY_LOGICAL_LAYER_ID } from '~core/focused_geometry/constants';
 import { REFERENCE_AREA_LOGICAL_LAYER_ID } from '~features/reference_area/constants';
 import { logicalLayersHierarchyAtom } from '../layersHierarchy';
 import { sortChildren } from './sortTree';
 import { createTree } from './createTree';
+import type { Tree } from '~core/types/layers';
 
-export const layersTreeAtom = createAtom(
-  {
-    logicalLayersHierarchyAtom,
-    layersCategoriesSettingsAtom,
-    layersGroupsSettingsAtom,
-    referenceAreaAtomV2,
-    focusedGeometryAtom,
-  },
-  ({ get }, state = { children: [] }) => {
-    const hierarchy = get('logicalLayersHierarchyAtom');
-    const categoriesSettings = get('layersCategoriesSettingsAtom');
-    const groupsSettings = get('layersGroupsSettingsAtom');
-    const focusedGeometry = get('focusedGeometryAtom');
-    const referenceGeometry = get('referenceAreaAtomV2');
+export const layersTreeAtom = atom<Tree>((ctx) => {
+  const hierarchy = ctx.spy(logicalLayersHierarchyAtom.v3atom);
+  const categoriesSettings = ctx.spy(layersCategoriesSettingsAtom.v3atom);
+  const groupsSettings = ctx.spy(layersGroupsSettingsAtom.v3atom);
+  const focusedGeometry = ctx.spy(focusedGeometryAtom.v3atom);
+  const referenceGeometry = ctx.spy(referenceAreaAtom);
 
-    const layers = Object.values(hierarchy).filter((layer) => {
-      if (layer.id === FOCUSED_GEOMETRY_LOGICAL_LAYER_ID) return focusedGeometry;
-      if (layer.id === REFERENCE_AREA_LOGICAL_LAYER_ID) return referenceGeometry;
-      else return true;
-    });
+  const layers = Object.values(hierarchy).filter((layer) => {
+    if (layer.id === FOCUSED_GEOMETRY_LOGICAL_LAYER_ID) return focusedGeometry;
+    if (layer.id === REFERENCE_AREA_LOGICAL_LAYER_ID) return referenceGeometry;
+    else return true;
+  });
 
-    const tree = createTree(layers, { categoriesSettings, groupsSettings });
-    tree.children = sortChildren(tree.children, {
-      order: ['isGroup', 'isCategory'],
-      inClusterSortField: 'order',
-    });
-    return tree;
-  },
-  'layersTreeAtom',
-);
+  const tree = createTree(layers, { categoriesSettings, groupsSettings });
+  tree.children = sortChildren(tree.children, {
+    order: ['isGroup', 'isCategory'],
+    inClusterSortField: 'order',
+  });
+  return tree;
+}, 'layersTreeAtom');

--- a/src/core/logical_layers/atoms/layersTree/layersTree.ts
+++ b/src/core/logical_layers/atoms/layersTree/layersTree.ts
@@ -1,21 +1,35 @@
 import { createAtom } from '~utils/atoms/createPrimitives';
 import { layersCategoriesSettingsAtom } from '~core/shared_state/layersCategoriesSettings';
 import { layersGroupsSettingsAtom } from '~core/shared_state/layersGroupsSettings';
+import { focusedGeometryAtom } from '~core/focused_geometry/model';
+import { referenceAreaAtomV2 } from '~core/shared_state/referenceArea';
+import { FOCUSED_GEOMETRY_LOGICAL_LAYER_ID } from '~core/focused_geometry/constants';
+import { REFERENCE_AREA_LOGICAL_LAYER_ID } from '~features/reference_area/constants';
 import { logicalLayersHierarchyAtom } from '../layersHierarchy';
-import { createTree } from './createTree';
 import { sortChildren } from './sortTree';
+import { createTree } from './createTree';
 
 export const layersTreeAtom = createAtom(
   {
     logicalLayersHierarchyAtom,
     layersCategoriesSettingsAtom,
     layersGroupsSettingsAtom,
+    referenceAreaAtomV2,
+    focusedGeometryAtom,
   },
   ({ get }, state = { children: [] }) => {
     const hierarchy = get('logicalLayersHierarchyAtom');
     const categoriesSettings = get('layersCategoriesSettingsAtom');
     const groupsSettings = get('layersGroupsSettingsAtom');
-    const layers = Object.values(hierarchy);
+    const focusedGeometry = get('focusedGeometryAtom');
+    const referenceGeometry = get('referenceAreaAtomV2');
+
+    const layers = Object.values(hierarchy).filter((layer) => {
+      if (layer.id === FOCUSED_GEOMETRY_LOGICAL_LAYER_ID) return focusedGeometry;
+      if (layer.id === REFERENCE_AREA_LOGICAL_LAYER_ID) return referenceGeometry;
+      else return true;
+    });
+
     const tree = createTree(layers, { categoriesSettings, groupsSettings });
     tree.children = sortChildren(tree.children, {
       order: ['isGroup', 'isCategory'],

--- a/src/core/shared_state/referenceArea.ts
+++ b/src/core/shared_state/referenceArea.ts
@@ -2,9 +2,9 @@ import { crc32 } from 'hash-wasm';
 import { action, atom } from '@reatom/core';
 import { updateReferenceArea } from '~core/api/features';
 import { configRepo } from '~core/config';
+import { v3toV2 } from '~utils/atoms/v3tov2';
 import { FeatureFlag } from './featureFlags';
 import type { GeometryWithHash } from '~core/focused_geometry/types';
-import type { FeaturesConfig } from '~core/config/types';
 
 export const referenceAreaAtom = atom<GeometryWithHash | null>(
   getReferenceAreaFromConfigRepo(),

--- a/src/core/shared_state/referenceArea.ts
+++ b/src/core/shared_state/referenceArea.ts
@@ -2,7 +2,6 @@ import { crc32 } from 'hash-wasm';
 import { action, atom } from '@reatom/core';
 import { updateReferenceArea } from '~core/api/features';
 import { configRepo } from '~core/config';
-import { v3toV2 } from '~utils/atoms/v3tov2';
 import { FeatureFlag } from './featureFlags';
 import type { GeometryWithHash } from '~core/focused_geometry/types';
 

--- a/src/features/layers_panel/components/LayersTree/LayersTree.tsx
+++ b/src/features/layers_panel/components/LayersTree/LayersTree.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from '@reatom/react-v2';
+import { useAtom } from '@reatom/npm-react';
 import { layersTreeAtom } from '~core/logical_layers/atoms/layersTree';
 import { Layer } from '../Layer/Layer';
 import { Category } from '../Category/Category';

--- a/src/features/legend_panel/components/PanelContent/PanelContent.tsx
+++ b/src/features/legend_panel/components/PanelContent/PanelContent.tsx
@@ -1,12 +1,26 @@
 import { useAtom } from '@reatom/react-v2';
+import { useAtom as useAtomV3 } from '@reatom/npm-react';
 import { useMemo } from 'react';
 import { mountedLayersAtom } from '~core/logical_layers/atoms/mountedLayers';
+import { FOCUSED_GEOMETRY_LOGICAL_LAYER_ID } from '~core/focused_geometry/constants';
+import { focusedGeometryAtom } from '~core/focused_geometry/model';
+import { referenceAreaAtom } from '~core/shared_state/referenceArea';
+import { REFERENCE_AREA_LOGICAL_LAYER_ID } from '~features/reference_area/constants';
 import { LegendsList } from '../LegendsList/LegendsList';
 import s from './PanelContent.module.css';
 
 export function PanelContent() {
   const [layers] = useAtom(mountedLayersAtom);
-  const layersAtoms = useMemo(() => Array.from(layers.values()), [layers]);
+  const [focusedGeometry] = useAtom(focusedGeometryAtom);
+  const [referenceAreaGeometry] = useAtomV3(referenceAreaAtom);
+
+  const layersAtoms = useMemo(() => {
+    return Array.from(layers.values()).filter((layer) => {
+      if (layer.id === FOCUSED_GEOMETRY_LOGICAL_LAYER_ID) return focusedGeometry;
+      if (layer.id === REFERENCE_AREA_LOGICAL_LAYER_ID) return referenceAreaGeometry;
+      else return true;
+    });
+  }, [focusedGeometry, layers, referenceAreaGeometry]);
 
   return (
     <div className={s.scrollable}>

--- a/src/features/legend_panel/components/PanelContent/PanelContent.tsx
+++ b/src/features/legend_panel/components/PanelContent/PanelContent.tsx
@@ -1,5 +1,4 @@
-import { useAtom } from '@reatom/react-v2';
-import { useAtom as useAtomV3 } from '@reatom/npm-react';
+import { useAtom } from '@reatom/npm-react';
 import { useMemo } from 'react';
 import { mountedLayersAtom } from '~core/logical_layers/atoms/mountedLayers';
 import { FOCUSED_GEOMETRY_LOGICAL_LAYER_ID } from '~core/focused_geometry/constants';
@@ -10,9 +9,9 @@ import { LegendsList } from '../LegendsList/LegendsList';
 import s from './PanelContent.module.css';
 
 export function PanelContent() {
-  const [layers] = useAtom(mountedLayersAtom);
-  const [focusedGeometry] = useAtom(focusedGeometryAtom);
-  const [referenceAreaGeometry] = useAtomV3(referenceAreaAtom);
+  const [layers] = useAtom(mountedLayersAtom.v3atom);
+  const [focusedGeometry] = useAtom(focusedGeometryAtom.v3atom);
+  const [referenceAreaGeometry] = useAtom(referenceAreaAtom);
 
   const layersAtoms = useMemo(() => {
     return Array.from(layers.values()).filter((layer) => {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Hide-Reference-and-Selected-area-on-Layers-panel-if-they-are-empty-18530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced layer management with filtering capabilities in the LayersTree and PanelContent components.
  
- **Refactor**
  - Updated atom creation and usage in the LayersTree to improve performance and maintainability.

- **Bug Fixes**
  - Improved logic for layer filtering based on specific conditions to ensure accurate data display in the PanelContent component.

- **Miscellaneous**
  - Updated `useAtom` function imports for better compatibility and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->