### PR TITLE
feat(osm_edit_link): set default osmEditor value to josm

### DIFF
--- a/src/features/osm_edit_link/constants.ts
+++ b/src/features/osm_edit_link/constants.ts
@@ -2,3 +2,4 @@ import { i18n } from '~core/localization';
 
 export const EDIT_IN_OSM_CONTROL_ID = 'EditInOsm';
 export const EDIT_IN_OSM_CONTROL_NAME = i18n.t('toolbar.edit_in_osm');
+export const DEFAULT_OSM_EDITOR = 'josm';

--- a/src/features/osm_edit_link/index.tsx
+++ b/src/features/osm_edit_link/index.tsx
@@ -22,8 +22,7 @@ osmEditControl.onStateChange((ctx, state) => {
     try {
       const position = store.getState(currentMapPositionAtom);
       if (!position) throw Error('Unknown position');
-      const { osmEditor } = store.getState(currentUserAtom);
-      if (!osmEditor) throw Error('Unknown editor');
+      const { osmEditor = 'josm' } = store.getState(currentUserAtom);
 
       const editor = configRepo
         .get()

--- a/src/features/osm_edit_link/index.tsx
+++ b/src/features/osm_edit_link/index.tsx
@@ -3,7 +3,11 @@ import { toolbar } from '~core/toolbar';
 import { i18n } from '~core/localization';
 import { configRepo } from '~core/config';
 import { store } from '~core/store/store';
-import { EDIT_IN_OSM_CONTROL_ID, EDIT_IN_OSM_CONTROL_NAME } from './constants';
+import {
+  DEFAULT_OSM_EDITOR,
+  EDIT_IN_OSM_CONTROL_ID,
+  EDIT_IN_OSM_CONTROL_NAME,
+} from './constants';
 import { openOsmLink } from './openOsmLink';
 
 export const osmEditControl = toolbar.setupControl({
@@ -22,7 +26,7 @@ osmEditControl.onStateChange((ctx, state) => {
     try {
       const position = store.getState(currentMapPositionAtom);
       if (!position) throw Error('Unknown position');
-      const { osmEditor = 'josm' } = store.getState(currentUserAtom);
+      const { osmEditor = DEFAULT_OSM_EDITOR } = store.getState(currentUserAtom);
 
       const editor = configRepo
         .get()


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/BE-Default-OSM-editor-usage-causes-Unknown-editor-error-18784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for obtaining the `osmEditor` value from the store, providing a default value of `'josm'` to prevent errors when the value is not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->