### PR TITLE
fix(18447): clear previously selected area

### DIFF
--- a/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
+++ b/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
@@ -142,6 +142,11 @@ export const boundaryMarkerAtom = createAtom(
                 [
                   // Reset button state to default
                   boundarySelectorControl.setState('regular'),
+                  // Clear highlightedGeometry
+                  highlightedGeometryAtom.set({
+                    type: 'FeatureCollection',
+                    features: [],
+                  }),
                   // Load selected boundary as focused geometry
                   focusedGeometryAtom.setFocusedGeometry(
                     {

--- a/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
+++ b/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
@@ -143,10 +143,7 @@ export const boundaryMarkerAtom = createAtom(
                   // Reset button state to default
                   boundarySelectorControl.setState('regular'),
                   // Clear highlightedGeometry
-                  highlightedGeometryAtom.set({
-                    type: 'FeatureCollection',
-                    features: [],
-                  }),
+                  highlightedGeometryAtom.set(new FeatureCollection([])),
                   // Load selected boundary as focused geometry
                   focusedGeometryAtom.setFocusedGeometry(
                     {
@@ -155,7 +152,7 @@ export const boundaryMarkerAtom = createAtom(
                     },
                     boundaryGeometry,
                   ),
-                  // Adjust map view to fin new geometry
+                  // Adjust map view to fit new geometry
                   boundaryCamera &&
                     currentMapPositionAtom.setCurrentMapPosition(boundaryCamera),
                 ].filter(withoutUndefined),


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Previously-selected-admin-boundary-appears-18447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a functionality to clear highlighted geometry, resetting the view and focusing on the selected boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->