### PR TITLE
fix(18750): delete selected area after pressing save as reference area

### DIFF
--- a/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
+++ b/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
@@ -142,6 +142,11 @@ export const boundaryMarkerAtom = createAtom(
                 [
                   // Reset button state to default
                   boundarySelectorControl.setState('regular'),
+                  // Clear highlightedGeometry
+                  highlightedGeometryAtom.set({
+                    type: 'FeatureCollection',
+                    features: [],
+                  }),
                   // Load selected boundary as focused geometry
                   focusedGeometryAtom.setFocusedGeometry(
                     {

--- a/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
+++ b/src/features/boundary_selector/atoms/boundaryMarkerAtom.ts
@@ -143,10 +143,7 @@ export const boundaryMarkerAtom = createAtom(
                   // Reset button state to default
                   boundarySelectorControl.setState('regular'),
                   // Clear highlightedGeometry
-                  highlightedGeometryAtom.set({
-                    type: 'FeatureCollection',
-                    features: [],
-                  }),
+                  highlightedGeometryAtom.set(new FeatureCollection([])),
                   // Load selected boundary as focused geometry
                   focusedGeometryAtom.setFocusedGeometry(
                     {
@@ -155,7 +152,7 @@ export const boundaryMarkerAtom = createAtom(
                     },
                     boundaryGeometry,
                   ),
-                  // Adjust map view to fin new geometry
+                  // Adjust map view to fit new geometry
                   boundaryCamera &&
                     currentMapPositionAtom.setCurrentMapPosition(boundaryCamera),
                 ].filter(withoutUndefined),

--- a/src/features/reference_area/index.ts
+++ b/src/features/reference_area/index.ts
@@ -13,6 +13,7 @@ import type { Unsubscribe } from '@reatom/core';
 let focusedGeometryUnsubscribe: Unsubscribe | null;
 
 const focusedGeometryAtom = focusedGeometryAtomV2.v3atom;
+const resetFocusedGeometryAction = focusedGeometryAtomV2.reset.v3action;
 
 export const saveAsReferenceAreaControl = toolbar.setupControl({
   id: SAVE_AS_REFERENCE_AREA_CONTROL_ID,
@@ -31,7 +32,8 @@ async function saveFocusedGeometryAsReferenceArea() {
   if (focusedGeometryExists(geometryState)) {
     const geometry = (geometryState as FocusedGeometry)?.geometry;
     await updateReferenceArea(geometry);
-    setReferenceArea(store.v3ctx, geometry);
+    await setReferenceArea(store.v3ctx, geometry);
+    resetFocusedGeometryAction(store.v3ctx);
     notificationServiceInstance.success(
       {
         title: i18n.t('reference_area.selected_area_saved_as_reference_area'),


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Delete-selected-area-after-pressing-Save-as-reference-area-18750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a functionality to reset the focused geometry after saving a reference area, improving workflow and user interaction.
 
- **Improvements**
	- Enhanced application state consistency by ensuring the geometry state is reset after saving, minimizing potential user errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->