### PR TITLE
fix(18086): wrap long layer name

### DIFF
--- a/src/components/LayerControl/LayerControl.module.css
+++ b/src/components/LayerControl/LayerControl.module.css
@@ -16,6 +16,7 @@
   flex-flow: row nowrap;
   align-items: center;
   margin: 0 4px;
+  overflow-wrap: anywhere;
 }
 
 .layerLabelIcon {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Long-layer-name-breaks-layout-18086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved text handling in the Layer Control component by enhancing word wrapping for better layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->