### PR TITLE
feat(MCDA): 19032 Append units to custom axis labels in MCDA dropdown

### DIFF
--- a/src/utils/bivariate/helpers/converters/axisDTOtoAxis.ts
+++ b/src/utils/bivariate/helpers/converters/axisDTOtoAxis.ts
@@ -1,4 +1,7 @@
-import { formatBivariateAxisLabel } from '~utils/bivariate/labelFormatters';
+import {
+  formatBivariateAxisLabel,
+  formatCustomLabelForBivariateAxis,
+} from '~utils/bivariate/labelFormatters';
 import type { AxisDTO } from '~core/resources/bivariateStatisticsResource/types';
 import type { Axis } from '~utils/bivariate/types/stat.types';
 
@@ -6,6 +9,8 @@ export function axisDTOtoAxis(dto: AxisDTO): Axis {
   return {
     ...dto,
     id: dto.quotient.join('|'),
-    label: dto.label || formatBivariateAxisLabel(dto.quotients),
+    label: dto.label
+      ? formatCustomLabelForBivariateAxis(dto.label, dto.quotients)
+      : formatBivariateAxisLabel(dto.quotients),
   };
 }

--- a/src/utils/bivariate/helpers/converters/axisDTOtoAxis.ts
+++ b/src/utils/bivariate/helpers/converters/axisDTOtoAxis.ts
@@ -1,6 +1,6 @@
 import {
   formatBivariateAxisLabel,
-  formatCustomLabelForBivariateAxis,
+  formatCustomBivariateAxisLabel,
 } from '~utils/bivariate/labelFormatters';
 import type { AxisDTO } from '~core/resources/bivariateStatisticsResource/types';
 import type { Axis } from '~utils/bivariate/types/stat.types';
@@ -10,7 +10,7 @@ export function axisDTOtoAxis(dto: AxisDTO): Axis {
     ...dto,
     id: dto.quotient.join('|'),
     label: dto.label
-      ? formatCustomLabelForBivariateAxis(dto.label, dto.quotients)
+      ? formatCustomBivariateAxisLabel(dto.label, dto.quotients)
       : formatBivariateAxisLabel(dto.quotients),
   };
 }

--- a/src/utils/bivariate/labelFormatters.test.ts
+++ b/src/utils/bivariate/labelFormatters.test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it } from 'vitest';
 import {
   hasUnits,
   formatBivariateAxisLabel,
-  formatCustomLabelForBivariateAxis,
+  formatCustomBivariateAxisLabel,
 } from './labelFormatters';
 import type { Axis } from '~utils/bivariate';
 
@@ -148,7 +148,7 @@ describe('BivariateLegend labels formatting', () => {
         },
       ];
       const customLabel = 'Custom man-distance label';
-      expect(formatCustomLabelForBivariateAxis(customLabel, quotients)).toEqual(
+      expect(formatCustomBivariateAxisLabel(customLabel, quotients)).toEqual(
         'Custom man-distance label (km/ppl)',
       );
     });
@@ -177,7 +177,7 @@ describe('BivariateLegend labels formatting', () => {
         },
       ];
       const customLabel = 'Custom man-distance label';
-      expect(formatCustomLabelForBivariateAxis(customLabel, quotients)).toEqual(
+      expect(formatCustomBivariateAxisLabel(customLabel, quotients)).toEqual(
         'Custom man-distance label',
       );
     });

--- a/src/utils/bivariate/labelFormatters.test.ts
+++ b/src/utils/bivariate/labelFormatters.test.ts
@@ -1,5 +1,9 @@
 import { expect, describe, it } from 'vitest';
-import { hasUnits, formatBivariateAxisLabel } from './labelFormatters';
+import {
+  hasUnits,
+  formatBivariateAxisLabel,
+  formatCustomLabelForBivariateAxis,
+} from './labelFormatters';
 import type { Axis } from '~utils/bivariate';
 
 describe('BivariateLegend labels formatting', () => {
@@ -115,6 +119,66 @@ describe('BivariateLegend labels formatting', () => {
       ];
       expect(formatBivariateAxisLabel(quotients)).toEqual(
         'Total road length to Population (km/ppl)',
+      );
+    });
+  });
+
+  describe('formatCustomLabelForBivariateAxis', () => {
+    it('must return customLabel with units from quotients', () => {
+      const quotients: Axis['quotients'] = [
+        {
+          name: 'total_road_length',
+          label: 'Total road length',
+          direction: [['unimportant'], ['important']],
+          unit: {
+            id: 'km',
+            shortName: 'km',
+            longName: 'kilometers',
+          },
+        },
+        {
+          name: 'population',
+          label: 'Population',
+          direction: [['unimportant'], ['important']],
+          unit: {
+            id: 'ppl',
+            shortName: 'ppl',
+            longName: 'people',
+          },
+        },
+      ];
+      const customLabel = 'Custom man-distance label';
+      expect(formatCustomLabelForBivariateAxis(customLabel, quotients)).toEqual(
+        'Custom man-distance label (km/ppl)',
+      );
+    });
+
+    it('must return customLabel without units if numerator has no unit', () => {
+      const quotients: Axis['quotients'] = [
+        {
+          name: 'total_road_length',
+          label: 'Total road length',
+          direction: [['unimportant'], ['important']],
+          unit: {
+            id: null,
+            shortName: null,
+            longName: null,
+          },
+        },
+        {
+          name: 'population',
+          label: 'Population',
+          direction: [['unimportant'], ['important']],
+          unit: {
+            id: 'ppl',
+            shortName: 'ppl',
+            longName: 'people',
+          },
+        },
+      ];
+      const customLabel = 'Custom man-distance label';
+      expect(formatCustomLabelForBivariateAxis(customLabel, quotients)).toEqual(
+        'Custom man-distance label',
       );
     });
   });

--- a/src/utils/bivariate/labelFormatters.ts
+++ b/src/utils/bivariate/labelFormatters.ts
@@ -11,14 +11,14 @@ export const convertDirectionsArrayToLabel = (directions: string[][]) => {
 };
 
 export const formatCustomLabelForBivariateAxis = (
-  cusotmLabel: string,
+  customLabel: string,
   quotients: Axis['quotients'],
 ): string => {
   const units = formatBivariateAxisUnit(quotients);
   if (units) {
-    return `${cusotmLabel} (${units})`;
+    return `${customLabel} (${units})`;
   }
-  return cusotmLabel;
+  return customLabel;
 };
 
 export const formatBivariateAxisLabel = (quotients: Axis['quotients']): string => {

--- a/src/utils/bivariate/labelFormatters.ts
+++ b/src/utils/bivariate/labelFormatters.ts
@@ -10,15 +10,12 @@ export const convertDirectionsArrayToLabel = (directions: string[][]) => {
   return `${formatSentimentDirection(from)} → ${formatSentimentDirection(to)}`;
 };
 
-export const formatCustomLabelForBivariateAxis = (
+export const formatCustomBivariateAxisLabel = (
   customLabel: string,
   quotients: Axis['quotients'],
 ): string => {
   const units = formatBivariateAxisUnit(quotients);
-  if (units) {
-    return `${customLabel} (${units})`;
-  }
-  return customLabel;
+  return units ? `${customLabel} (${units})` : customLabel;
 };
 
 export const formatBivariateAxisLabel = (quotients: Axis['quotients']): string => {

--- a/src/utils/bivariate/labelFormatters.ts
+++ b/src/utils/bivariate/labelFormatters.ts
@@ -10,6 +10,17 @@ export const convertDirectionsArrayToLabel = (directions: string[][]) => {
   return `${formatSentimentDirection(from)} → ${formatSentimentDirection(to)}`;
 };
 
+export const formatCustomLabelForBivariateAxis = (
+  cusotmLabel: string,
+  quotients: Axis['quotients'],
+): string => {
+  const units = formatBivariateAxisUnit(quotients);
+  if (units) {
+    return `${cusotmLabel} (${units})`;
+  }
+  return cusotmLabel;
+};
+
 export const formatBivariateAxisLabel = (quotients: Axis['quotients']): string => {
   if (!quotients) return '';
   const [numerator, denominator] = quotients;


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-MCDA-dropdown-add-units-to-custom-axis-labels-19032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a custom label formatting function for bivariate axes, allowing more descriptive and flexible labeling.
	- Updated logic for axis label generation to better handle custom labels and associated quotients.

- **Bug Fixes**
	- Improved the label generation process to ensure accurate formatting when custom labels are used.

- **Tests**
	- Added comprehensive unit tests for the new custom label formatting function, validating various scenarios for accurate label representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->