### PR TITLE
feat: update osm editors urls

### DIFF
--- a/configs/config.default.json
+++ b/configs/config.default.json
@@ -39,12 +39,12 @@
     {
       "id": "josm",
       "title": "JOSM",
-      "url": "https://www.openstreetmap.org/edit?editor=remote#map="
+      "url": "https://www.openstreetmap.org/edit?#map="
     },
     {
       "id": "id",
       "title": "iD",
-      "url": "https://www.openstreetmap.org/edit?editor=id&node=2188188227#map="
+      "url": "https://www.openstreetmap.org/edit?editor=id&#map="
     },
     {
       "id": "rapid",
@@ -56,5 +56,4 @@
   "KEYCLOAK_REALM": "kontur",
   "KEYCLOAK_CLIENT_ID": "kontur_platform",
   "SENTRY_DSN": "https://fixme@dsn.ingest.sentry.io/project-id"
-
 }

--- a/configs/config.default.json
+++ b/configs/config.default.json
@@ -44,7 +44,7 @@
     {
       "id": "josm",
       "title": "JOSM",
-      "url": "http://127.0.0.1:8111/load_and_zoom?left={left}&right={right}&top={top}&bottom={bottom}"
+      "url": "http://127.0.0.1:8111/load_and_zoom"
     },
     {
       "id": "id",

--- a/configs/config.default.json
+++ b/configs/config.default.json
@@ -37,14 +37,19 @@
   "DEFAULT_LANGUAGE": "en",
   "OSM_EDITORS": [
     {
+      "id": "osm",
+      "title": "OpenStreetMap.org default editor",
+      "url": "https://www.openstreetmap.org/edit#map="
+    },
+    {
       "id": "josm",
       "title": "JOSM",
-      "url": "https://www.openstreetmap.org/edit?#map="
+      "url": "http://127.0.0.1:8111/load_and_zoom?left={left}&right={right}&top={top}&bottom={bottom}"
     },
     {
       "id": "id",
       "title": "iD",
-      "url": "https://www.openstreetmap.org/edit?editor=id&#map="
+      "url": "https://www.openstreetmap.org/edit?editor=id#map="
     },
     {
       "id": "rapid",

--- a/src/features/osm_edit_link/constants.ts
+++ b/src/features/osm_edit_link/constants.ts
@@ -2,4 +2,4 @@ import { i18n } from '~core/localization';
 
 export const EDIT_IN_OSM_CONTROL_ID = 'EditInOsm';
 export const EDIT_IN_OSM_CONTROL_NAME = i18n.t('toolbar.edit_in_osm');
-export const DEFAULT_OSM_EDITOR = 'josm';
+export const DEFAULT_OSM_EDITOR = 'osm';

--- a/src/features/osm_edit_link/index.tsx
+++ b/src/features/osm_edit_link/index.tsx
@@ -1,8 +1,4 @@
-import {
-  currentMapPositionAtom,
-  currentUserAtom,
-  currentMapAtom,
-} from '~core/shared_state';
+import { currentMapPositionAtom, currentUserAtom } from '~core/shared_state';
 import { toolbar } from '~core/toolbar';
 import { i18n } from '~core/localization';
 import { configRepo } from '~core/config';
@@ -39,10 +35,7 @@ osmEditControl.onStateChange((ctx, state) => {
       if (!('lng' in position)) throw Error('Unknown position type');
 
       if (editor?.id === 'josm') {
-        const map = currentMapAtom.getState();
-        if (!map) return;
-        const bbox = map.getBounds().toArray().flat() as [number, number, number, number];
-        openJosmLink(bbox, editor?.url);
+        openJosmLink(position, editor?.url);
       } else openOsmLink(position, editor?.url);
     } catch (e) {
       console.error(e);

--- a/src/features/osm_edit_link/index.tsx
+++ b/src/features/osm_edit_link/index.tsx
@@ -1,4 +1,8 @@
-import { currentMapPositionAtom, currentUserAtom } from '~core/shared_state';
+import {
+  currentMapPositionAtom,
+  currentUserAtom,
+  currentMapAtom,
+} from '~core/shared_state';
 import { toolbar } from '~core/toolbar';
 import { i18n } from '~core/localization';
 import { configRepo } from '~core/config';
@@ -8,7 +12,7 @@ import {
   EDIT_IN_OSM_CONTROL_ID,
   EDIT_IN_OSM_CONTROL_NAME,
 } from './constants';
-import { openOsmLink } from './openOsmLink';
+import { openOsmLink, openJosmLink } from './openOsmLink';
 
 export const osmEditControl = toolbar.setupControl({
   id: EDIT_IN_OSM_CONTROL_ID,
@@ -32,9 +36,14 @@ osmEditControl.onStateChange((ctx, state) => {
         .get()
         .osmEditors.find((editor) => editor.id === osmEditor);
 
-      if ('lng' in position) {
-        openOsmLink(position, editor?.url);
-      } else throw Error('Unknown position type');
+      if (!('lng' in position)) throw Error('Unknown position type');
+
+      if (editor?.id === 'josm') {
+        const map = currentMapAtom.getState();
+        if (!map) return;
+        const bbox = map.getBounds().toArray().flat() as [number, number, number, number];
+        openJosmLink(bbox, editor?.url);
+      } else openOsmLink(position, editor?.url);
     } catch (e) {
       console.error(e);
     } finally {

--- a/src/features/osm_edit_link/openOsmLink.ts
+++ b/src/features/osm_edit_link/openOsmLink.ts
@@ -9,12 +9,26 @@ export function openOsmLink(
   window.open(url)?.focus();
 }
 
+function calculateMaxJosmArea(
+  lat: number,
+  lng: number,
+): { left: number; right: number; top: number; bottom: number } {
+  const maxSize = 0.5 / 3.5;
+
+  const left = lng - maxSize / 2;
+  const right = lng + maxSize / 2;
+  const top = lat + maxSize / 2;
+  const bottom = lat - maxSize / 2;
+
+  return { left, right, top, bottom };
+}
+
 // Функция для открытия ссылки в JOSM
 export function openJosmLink(
-  bbox: [number, number, number, number],
+  { lat, lng },
   baseLink = 'http://127.0.0.1:8111/load_and_zoom?',
 ) {
-  const [left, bottom, right, top] = bbox;
-  const url = `${baseLink}left=${left}&right=${right}&top=${top}&bottom=${bottom}`;
+  const { left, bottom, right, top } = calculateMaxJosmArea(lat, lng);
+  const url = `${baseLink}?left=${left}&right=${right}&top=${top}&bottom=${bottom}`;
   window.open(url)?.focus();
 }

--- a/src/features/osm_edit_link/openOsmLink.ts
+++ b/src/features/osm_edit_link/openOsmLink.ts
@@ -1,9 +1,20 @@
 import { URL_ZOOM_OFFSET } from '~core/constants';
 
+// Функция для открытия ссылки в редакторах OpenStreetMap, iD и RapiD
 export function openOsmLink(
   { lat, lng, zoom },
-  baseLink = 'https://www.openstreetmap.org/edit?#map=',
+  baseLink = 'https://www.openstreetmap.org/edit#map=',
 ) {
   const url = `${baseLink}${zoom + URL_ZOOM_OFFSET}/${lat}/${lng}`;
+  window.open(url)?.focus();
+}
+
+// Функция для открытия ссылки в JOSM
+export function openJosmLink(
+  bbox: [number, number, number, number],
+  baseLink = 'http://127.0.0.1:8111/load_and_zoom?',
+) {
+  const [left, bottom, right, top] = bbox;
+  const url = `${baseLink}left=${left}&right=${right}&top=${top}&bottom=${bottom}`;
   window.open(url)?.focus();
 }

--- a/src/features/osm_edit_link/openOsmLink.ts
+++ b/src/features/osm_edit_link/openOsmLink.ts
@@ -1,6 +1,5 @@
 import { URL_ZOOM_OFFSET } from '~core/constants';
 
-// Функция для открытия ссылки в редакторах OpenStreetMap, iD и RapiD
 export function openOsmLink(
   { lat, lng, zoom },
   baseLink = 'https://www.openstreetmap.org/edit#map=',
@@ -23,7 +22,6 @@ function calculateMaxJosmArea(
   return { left, right, top, bottom };
 }
 
-// Функция для открытия ссылки в JOSM
 export function openJosmLink(
   { lat, lng },
   baseLink = 'http://127.0.0.1:8111/load_and_zoom?',


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/BE-Default-OSM-editor-usage-causes-Unknown-editor-error-18784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new simplified URL for the JOSM mapping editor to enhance usability.
	- Introduced a new entry for the OpenStreetMap editor, providing an additional editing option.
	- Implemented a dedicated function for generating links to the JOSM editor.
- **Bug Fixes**
	- Streamlined URLs for JOSM and iD editors by removing unnecessary query parameters for easier access.
- **Chores**
	- Updated default editor preference to reflect the OpenStreetMap editor as the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->