### PR TITLE
feat(MCDA): 19176 Add clamping of transformed values by upperBound and lowerBound of used transformation

### DIFF
--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
@@ -1,4 +1,4 @@
-import { isNumber } from '@turf/helpers';
+import { isNumber } from '~utils/common';
 import { sentimentDefault, sentimentReversed } from './constants';
 import { JsMath, MapMath } from './operations';
 import type { IsomorphMath } from './operations';

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
@@ -31,7 +31,7 @@ export class MapMath implements IsomorphMath<MapExpression> {
   clamp = (x: MapExpression, min: MapExpression, max: MapExpression): MapExpression => [
     'let',
     'clampedX',
-    ['to-number', x],
+    ['to-number', x, 1],
     [
       'case',
       ['<', ['var', 'clampedX'], min],
@@ -44,17 +44,17 @@ export class MapMath implements IsomorphMath<MapExpression> {
   min = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1],
+    ['to-number', v1, 0],
     'v2',
-    ['to-number', v2],
+    ['to-number', v2, 0],
     ['case', ['<', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
   max = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1],
+    ['to-number', v1, 0],
     'v2',
-    ['to-number', v2],
+    ['to-number', v2, 0],
     ['case', ['>', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
 }

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
@@ -31,7 +31,7 @@ export class MapMath implements IsomorphMath<MapExpression> {
   clamp = (x: MapExpression, min: MapExpression, max: MapExpression): MapExpression => [
     'let',
     'clampedX',
-    ['to-number', x, Infinity],
+    ['to-number', x, Number.POSITIVE_INFINITY],
     [
       'case',
       ['<', ['var', 'clampedX'], min],
@@ -44,17 +44,17 @@ export class MapMath implements IsomorphMath<MapExpression> {
   min = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1, Infinity],
+    ['to-number', v1, Number.POSITIVE_INFINITY],
     'v2',
-    ['to-number', v2, Infinity],
+    ['to-number', v2, Number.POSITIVE_INFINITY],
     ['case', ['<', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
   max = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1, -Infinity],
+    ['to-number', v1, Number.NEGATIVE_INFINITY],
     'v2',
-    ['to-number', v2, -Infinity],
+    ['to-number', v2, Number.NEGATIVE_INFINITY],
     ['case', ['>', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
 }

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
@@ -10,6 +10,8 @@ export interface IsomorphMath<T> {
   abs: (x: T) => T;
   sign: (x: T) => T;
   clamp: (x: T, min: T, max: T) => T;
+  min: (v1: T, v2: T) => T;
+  max: (v1: T, v2: T) => T;
 }
 
 export type MapExpression = maplibregl.ExpressionSpecification;
@@ -39,6 +41,22 @@ export class MapMath implements IsomorphMath<MapExpression> {
       ['var', 'clampedX'],
     ],
   ];
+  min = (v1: MapExpression, v2: MapExpression): MapExpression => [
+    'let',
+    'v1',
+    ['to-number', v1, 0],
+    'v2',
+    ['to-number', v2, 0],
+    ['case', ['<', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
+  ];
+  max = (v1: MapExpression, v2: MapExpression): MapExpression => [
+    'let',
+    'v1',
+    ['to-number', v1, 0],
+    'v2',
+    ['to-number', v2, 0],
+    ['case', ['>', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
+  ];
 }
 
 export class JsMath implements IsomorphMath<number> {
@@ -61,4 +79,6 @@ export class JsMath implements IsomorphMath<number> {
     }
     return x;
   };
+  min = (v1: number, v2: number): number => Math.min(v1, v2);
+  max = (v1: number, v2: number): number => Math.max(v1, v2);
 }

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
@@ -31,7 +31,7 @@ export class MapMath implements IsomorphMath<MapExpression> {
   clamp = (x: MapExpression, min: MapExpression, max: MapExpression): MapExpression => [
     'let',
     'clampedX',
-    ['to-number', x, 1],
+    ['to-number', x, Infinity],
     [
       'case',
       ['<', ['var', 'clampedX'], min],
@@ -44,17 +44,17 @@ export class MapMath implements IsomorphMath<MapExpression> {
   min = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1, 0],
+    ['to-number', v1, Infinity],
     'v2',
-    ['to-number', v2, 0],
+    ['to-number', v2, Infinity],
     ['case', ['<', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
   max = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1, 0],
+    ['to-number', v1, -Infinity],
     'v2',
-    ['to-number', v2, 0],
+    ['to-number', v2, -Infinity],
     ['case', ['>', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
 }

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/operations.ts
@@ -31,7 +31,7 @@ export class MapMath implements IsomorphMath<MapExpression> {
   clamp = (x: MapExpression, min: MapExpression, max: MapExpression): MapExpression => [
     'let',
     'clampedX',
-    ['to-number', x, 1],
+    ['to-number', x],
     [
       'case',
       ['<', ['var', 'clampedX'], min],
@@ -44,17 +44,17 @@ export class MapMath implements IsomorphMath<MapExpression> {
   min = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1, 0],
+    ['to-number', v1],
     'v2',
-    ['to-number', v2, 0],
+    ['to-number', v2],
     ['case', ['<', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
   max = (v1: MapExpression, v2: MapExpression): MapExpression => [
     'let',
     'v1',
-    ['to-number', v1, 0],
+    ['to-number', v1],
     'v2',
-    ['to-number', v2, 0],
+    ['to-number', v2],
     ['case', ['>', ['var', 'v2'], ['var', 'v1']], ['var', 'v2'], ['var', 'v1']],
   ];
 }

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
@@ -1,4 +1,4 @@
-import type { Indicator } from '~utils/bivariate/types/stat.types';
+import type { AxisTransformation, Indicator } from '~utils/bivariate/types/stat.types';
 
 export type ColorsByMapLibreExpression = {
   type: 'mapLibreExpression';
@@ -30,7 +30,9 @@ export interface MCDALayer {
   sentiment: [string, string];
   outliers: OutliersPolicy;
   coefficient: number;
+  // TODO: once all presets are updated, delete transformation Function and make transformation mandatory
   transformationFunction: TransformationFunction;
+  transformation?: AxisTransformation;
   normalization: Normalization;
   unit: string | null;
   datasetRange?: [number, number];

--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
@@ -196,6 +196,7 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
       outliers,
       coefficient: isNumber(coefficientNum) ? coefficientNum : 1,
       transformationFunction: transform,
+      transformation: layer.transformation,
       normalization,
       datasetRange: layer.datasetRange,
     };
@@ -208,6 +209,7 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
     layer.id,
     layer.indicators,
     layer.name,
+    layer.transformation,
     layer.unit,
     normalization,
     onLayerEdited,

--- a/src/features/mcda/mcdaConfig.tsx
+++ b/src/features/mcda/mcdaConfig.tsx
@@ -119,6 +119,7 @@ function createMCDALayersFromBivariateAxises(axises: Axis[]): MCDALayer[] {
         outliers: 'clamp',
         coefficient: 1,
         transformationFunction: axis.transformation?.transformation ?? 'no',
+        transformation: axis.transformation,
         normalization: 'max-min',
       });
     } catch (e) {

--- a/src/utils/bivariate/types/stat.types.ts
+++ b/src/utils/bivariate/types/stat.types.ts
@@ -20,10 +20,11 @@ export type Quotient = [string, string]; // this field will be removed in next t
 
 export type AxisTransformation = {
   transformation: TransformationFunction;
-  min: number;
   mean: number;
   skew: number;
   stddev: number;
+  lowerBound: number;
+  upperBound: number;
 };
 
 export type Axis = {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Support-re-clamping-after-transformation-19176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced `min` and `max` methods for enhanced mathematical calculations.
	- Added a `transformation` property to support dynamic data handling in layers.

- **Bug Fixes**
	- Improved handling of transformations within calculation functions.

- **Documentation**
	- Updated type definitions to reflect new properties and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->