### PR TITLE
fix(MCDAConfig): 19281 remove "custom" property from MCDAConfig

### DIFF
--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
@@ -42,7 +42,6 @@ export interface MCDAConfig {
   version: 4;
   layers: Array<MCDALayer>;
   colors: ColorsBySentiments | ColorsByMapLibreExpression;
-  custom?: boolean;
 }
 
 export type Normalization = 'max-min' | 'no';

--- a/src/core/logical_layers/utils/logicalLayerFabric.ts
+++ b/src/core/logical_layers/utils/logicalLayerFabric.ts
@@ -138,7 +138,7 @@ export function createLogicalLayerAtom(
           asyncLayerSource.data?.style?.type === 'mcda',
         isEditable:
           asyncLayerSource.data?.style?.type === 'mcda' &&
-          !!asyncLayerSource.data?.style?.config.custom,
+          !!asyncLayerSettings.data?.ownedByUser,
         settings: deepFreeze(asyncLayerSettings.data),
         meta: deepFreeze(asyncLayerMeta.data),
         legend: deepFreeze(asyncLayerLegend.data),

--- a/src/core/logical_layers/utils/logicalLayerFabric.ts
+++ b/src/core/logical_layers/utils/logicalLayerFabric.ts
@@ -134,7 +134,7 @@ export function createLogicalLayerAtom(
         isMounted: mounted.has(id),
         isVisible: !get('hiddenLayersAtom').has(id),
         isDownloadable:
-          asyncLayerSource.data?.source.type === 'geojson' || // details.data.source.type === 'geojson'
+          asyncLayerSource.data?.source.type === 'geojson' ||
           asyncLayerSource.data?.style?.type === 'mcda',
         isEditable:
           asyncLayerSource.data?.style?.type === 'mcda' &&

--- a/src/features/mcda/mcdaConfig.tsx
+++ b/src/features/mcda/mcdaConfig.tsx
@@ -84,7 +84,6 @@ function createDefaultMCDAConfig(overrides?: Partial<MCDAConfig>): MCDAConfig {
         midpoints: [{ value: 0.5, color: DEFAULT_YELLOW }],
       },
     },
-    custom: true,
   };
 }
 

--- a/src/features/mcda/utils/openMcdaFile.ts
+++ b/src/features/mcda/utils/openMcdaFile.ts
@@ -47,7 +47,7 @@ function readMcdaJSONFile(file): Promise<MCDAConfig> {
         const jsonConfig: Partial<MCDAConfig> =
           json?.type === 'mcda' ? json.config : json;
         const mcdaConfig = createMCDAConfigFromJSON(jsonConfig);
-        res({ ...mcdaConfig, custom: true } as MCDAConfig);
+        res({ ...mcdaConfig } as MCDAConfig);
       } catch (error) {
         rej(error);
       }


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Remove-redundant-custom-property-from-MCDAConfig-19281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the Multi-Criteria Decision Analysis (MCDA) configuration to streamline the configuration structure by removing the `custom` property.

- **Bug Fixes**
	- Enhanced logic for determining the properties of the logical layer atom, focusing on user ownership for editability instead of customization.

- **Refactor**
	- Simplified the default MCDA configuration by eliminating the unnecessary `custom` property, improving usability across the application.
	
- **Chores**
	- Updated file reading function to remove the `custom` property from the returned configuration, reflecting changes in MCDA structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->