### PR TITLE
fix(API) 19453: add useAuth to several api calls

### DIFF
--- a/src/core/shared_state/currentEventResource.ts
+++ b/src/core/shared_state/currentEventResource.ts
@@ -31,7 +31,7 @@ export const currentEventResourceAtom = createAsyncAtom(
       const responseData = await apiClient.get<EventWithGeometry>(
         `/events/${deps.feed.id}/${deps.event.id}`,
         undefined,
-        undefined,
+        true,
         {
           signal: abortController.signal,
           errorsConfig: {

--- a/src/features/event_episodes/atoms/episodesResource.ts
+++ b/src/features/event_episodes/atoms/episodesResource.ts
@@ -30,7 +30,7 @@ export const episodesResource = createAsyncAtom(
       const responseData = await apiClient.get<Episode[]>(
         `/events/${deps.feed.id}/${deps.event.id}/episodes`,
         undefined,
-        undefined,
+        true,
         { signal: abortController.signal },
       );
       if (!responseData) throw 'No data received';

--- a/src/features/layer_features_panel/atoms/layerFeaturesCollectionAtom.ts
+++ b/src/features/layer_features_panel/atoms/layerFeaturesCollectionAtom.ts
@@ -81,6 +81,7 @@ export async function getFeatureCollection(geometry) {
       appId: configRepo.get().id,
       geoJSON: geometry,
     },
+    true,
   );
   return features ?? [];
 }


### PR DESCRIPTION
https://kontur.fibery.io/favorites/Tasks/My-tasks-3575#Tasks/Task/FE-Some-API-calls-don't-use-authentication-after-recent-auth-client-changes-19453
