### PR TITLE
feat(18891): do not consider browser language for admin boundary tool

### DIFF
--- a/src/utils/map/boundaries.test.ts
+++ b/src/utils/map/boundaries.test.ts
@@ -21,30 +21,26 @@ const FEATURE: GeoJSON.Feature = {
 };
 
 describe('getLocalizedFeatureName', () => {
-  it('should return the first available localized name from the list of preferred languages', () => {
-    expect(getLocalizedFeatureName(FEATURE, ['fr', 'uk', 'en', 'es'])).toEqual(
+  it('should return available localized name for preferred language', () => {
+    expect(getLocalizedFeatureName(FEATURE, 'uk')).toEqual(
       FEATURE.properties!.tags['name:uk'],
     );
-    expect(
-      getLocalizedFeatureName(FEATURE as GeoJSON.Feature, ['zh', 'fr', 'uk', 'en']),
-    ).toEqual(FEATURE.properties!.tags['name:zh']);
+    expect(getLocalizedFeatureName(FEATURE as GeoJSON.Feature, 'zh')).toEqual(
+      FEATURE.properties!.tags['name:zh'],
+    );
   });
 
-  it('should return international name if none of the preferred languages is available', () => {
-    expect(
-      getLocalizedFeatureName(FEATURE as GeoJSON.Feature, ['fr', 'by', 'fi']),
-    ).toEqual(FEATURE.properties!.tags.int_name);
+  it("should return international name if preferred language isn't available", () => {
+    expect(getLocalizedFeatureName(FEATURE as GeoJSON.Feature, 'by')).toEqual(
+      FEATURE.properties!.tags.int_name,
+    );
   });
 
   it('should return standard feature name if neither localized nor international name is available', () => {
     const featureWithoutIntName = structuredClone(FEATURE);
     featureWithoutIntName.properties!.tags.int_name = '';
     expect(
-      getLocalizedFeatureName(featureWithoutIntName as GeoJSON.Feature, [
-        'fr',
-        'by',
-        'fi',
-      ]),
+      getLocalizedFeatureName(featureWithoutIntName as GeoJSON.Feature, 'fr'),
     ).toEqual(FEATURE.properties!.name);
   });
 });

--- a/src/utils/map/boundaries.test.ts
+++ b/src/utils/map/boundaries.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe, it } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { getLocalizedFeatureName } from './boundaries';
 
 const FEATURE: GeoJSON.Feature = {

--- a/src/utils/map/boundaries.ts
+++ b/src/utils/map/boundaries.ts
@@ -8,7 +8,7 @@ export function getLocalizedFeatureName(
 ): string {
   if (feature.properties?.tags) {
     const tags = feature.properties.tags;
-    // check names in preferred languages first
+    // check names for preferred language first
 
     if (tags[`name:${preferredLanguage}`]) {
       return tags[`name:${preferredLanguage}`];
@@ -19,8 +19,8 @@ export function getLocalizedFeatureName(
       return tags['int_name'];
     }
   }
-  // as a fallback, use feature name or if
-  return feature.properties?.name || feature.id;
+  // as a fallback, use feature name or id
+  return (feature.properties?.name || feature.id) as string;
 }
 
 export function constructOptionsFromBoundaries(

--- a/src/utils/map/boundaries.ts
+++ b/src/utils/map/boundaries.ts
@@ -4,16 +4,16 @@ export type BoundaryOption = { label: string; value: string | number };
 
 export function getLocalizedFeatureName(
   feature: GeoJSON.Feature<GeoJSON.Geometry, GeoJSON.GeoJsonProperties>,
-  preferredLanguages: string[],
+  preferredLanguage: string,
 ): string {
   if (feature.properties?.tags) {
     const tags = feature.properties.tags;
     // check names in preferred languages first
-    for (let i = 0; i < preferredLanguages.length; i++) {
-      if (tags[`name:${preferredLanguages[i]}`]) {
-        return tags[`name:${preferredLanguages[i]}`];
-      }
+
+    if (tags[`name:${preferredLanguage}`]) {
+      return tags[`name:${preferredLanguage}`];
     }
+
     // then try international name
     if (tags['int_name']) {
       return tags['int_name'];
@@ -32,16 +32,14 @@ export function constructOptionsFromBoundaries(
     (f1, f2) => f2.properties?.admin_level - f1.properties?.admin_level,
   );
 
-  const preferredLanguages = [
-    configRepo.get().user?.language,
-    ...navigator.languages,
-  ].filter(Boolean) as string[];
+  const preferredLanguage =
+    configRepo.get().user?.language || configRepo.get().defaultLanguage;
   const options: BoundaryOption[] = [];
   for (const feat of sortedFeatures) {
     const id = feat.id;
     if (id !== undefined) {
       options.push({
-        label: getLocalizedFeatureName(feat, preferredLanguages),
+        label: getLocalizedFeatureName(feat, preferredLanguage),
         value: id,
       });
     }


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Do-not-consider-browser-language-for-admin-boundary-tool-18891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the handling of language preferences by allowing a single preferred language string instead of an array.
	- Enhanced the `getLocalizedFeatureName` function for improved performance and usability.

- **Bug Fixes**
	- Updated test cases to reflect the new single string parameter for better clarity and accuracy in expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->