### PR TITLE
feat(MCDA): 19440 Show human readable name of chosen mcda transformation

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -134,7 +134,7 @@
         "square_root": "Square root: sign(x)√(|x|)",
         "cube_root": "Cube root: ∛x",
         "log_one": "log₁₀(x - xmin + 1)",
-        "log_epsilon": "Log₁₀(x - xmin + ε)"
+        "log_epsilon": "log₁₀(x - xmin + ε)"
       },
       "no": "No",
       "max_min": "Max-min",

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -132,7 +132,7 @@
       "transformations": {
         "no_transformation": "No transformation",
         "square_root": "Square root: sign(x)√(|x|)",
-        "cube_root": "Cube root: : ∛x",
+        "cube_root": "Cube root: ∛x",
         "log_one": "Log(x - xmin + 1)",
         "log_epsilon": "Log(x - xmin + ε)"
       },

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -131,7 +131,7 @@
       },
       "transformations": {
         "no_transformation": "No transformation",
-        "square_root": "Square root: sign(x)√(|x|)",
+        "square_root": "Square root: sign(x)⋅√|x|",
         "cube_root": "Cube root: ∛x",
         "log_one": "log₁₀(x - xmin + 1)",
         "log_epsilon": "log₁₀(x - xmin + ε)"

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -133,8 +133,8 @@
         "no_transformation": "No transformation",
         "square_root": "Square root: sign(x)√(|x|)",
         "cube_root": "Cube root: ∛x",
-        "log_one": "Log(x - xmin + 1)",
-        "log_epsilon": "Log(x - xmin + ε)"
+        "log_one": "log₁₀(x - xmin + 1)",
+        "log_epsilon": "Log₁₀(x - xmin + ε)"
       },
       "no": "No",
       "max_min": "Max-min",

--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
@@ -66,8 +66,13 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
     setRangeTo(layer.range?.at(1)?.toString() ?? '');
     setSentiment(layer.sentiment.at(0) === 'good' ? 'good-bad' : 'bad-good');
     setCoefficient(layer.coefficient.toString());
+    const knownTransformation = transformOptions.find(
+      (option) =>
+        option.value ===
+        (layer.transformation?.transformation ?? layer.transformationFunction),
+    );
     setTransformationFunction(
-      layer.transformation?.transformation ?? layer.transformationFunction,
+      (knownTransformation?.value as TransformationFunction) ?? 'no',
     );
     setNormalization(layer.normalization);
     setOutliers(layer.outliers ?? DEFAULTS.outliers);
@@ -125,10 +130,13 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
         value: layer.coefficient,
       });
     }
-    if (layer.transformationFunction !== DEFAULTS.transform) {
+    const knownTransformation = transformOptions.find(
+      (option) => option.value === layer.transformation?.transformation,
+    );
+    if (knownTransformation && knownTransformation !== DEFAULTS.transform) {
       result.push({
         paramName: i18n.t('mcda.layer_editor.transformation'),
-        value: layer.transformationFunction,
+        value: knownTransformation.title.toLocaleLowerCase(),
       });
     }
     if (layer.normalization !== DEFAULTS.normalization) {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Show-human-readable-name-of-chosen-MCDA-transformation-19440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Corrected the display of the cube root notation by removing an extraneous colon, enhancing clarity in mathematical expressions.
  - Updated logarithm expressions to specify base as log₁₀, improving accuracy in mathematical context.

- **Improvements**
  - Enhanced handling of transformation functions in the MCDALayerParameters component, improving robustness and reducing potential errors in transformation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->