### PR TITLE
hack(MCDA): 19471 Add HACK for handling (lowerRange === upperRange) or (lowerBound === upperBound)

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "minimist": "^1.2.8",
     "nanoid": "^5.0.7",
     "nanoid-dictionary": "^4.3.0",
+    "nextafter": "^1.0.0",
     "npm-run-all": "^4.1.5",
     "papaparse": "^5.4.1",
     "patch-package": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,9 @@ importers:
       nanoid-dictionary:
         specifier: ^4.3.0
         version: 4.3.0
+      nextafter:
+        specifier: ^1.0.0
+        version: 1.0.0
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -3275,6 +3278,9 @@ packages:
   dotty@0.1.2:
     resolution: {integrity: sha512-V0EWmKeH3DEhMwAZ+8ZB2Ao4OK6p++Z0hsDtZq3N0+0ZMVqkzrcEGROvOnZpLnvBg5PTNG23JEDLAm64gPaotQ==}
 
+  double-bits@1.1.1:
+    resolution: {integrity: sha512-BCLEIBq0O/DWoA7BsCu/R+RP0ZXiowP8BhtJT3qeuuQEBpnS8LK/Wo6UTJQv6v8mK1fj8n90YziHLwGdM5whSg==}
+
   downshift@8.3.1:
     resolution: {integrity: sha512-djPzjGfTSEjOsfmlur4onCV3Mtd6oGI+eOQIBNwoS7oEYTjPrxk6n+sJLmndT/KKwHvUyBSh3AFb64eHIFifTQ==}
     peerDependencies:
@@ -5169,6 +5175,9 @@ packages:
 
   netrc@0.1.4:
     resolution: {integrity: sha512-ye8AIYWQcP9MvoM1i0Z2jV0qed31Z8EWXYnyGNkiUAd+Fo8J+7uy90xTV8g/oAbhtjkY7iZbNTizQaXdKUuwpQ==}
+
+  nextafter@1.0.0:
+    resolution: {integrity: sha512-7PO+A89Tll2rSEfyrjtqO0MaI37+nnxBdnQcPypfbEYYuGaJxWGCqaOwQX4a3GHNTS08l1kazuiLEWZniZjMUQ==}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -10545,6 +10554,8 @@ snapshots:
 
   dotty@0.1.2: {}
 
+  double-bits@1.1.1: {}
+
   downshift@8.3.1(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.5
@@ -12925,6 +12936,10 @@ snapshots:
   neo-async@2.6.2: {}
 
   netrc@0.1.4: {}
+
+  nextafter@1.0.0:
+    dependencies:
+      double-bits: 1.1.1
 
   nice-try@1.0.5: {}
 

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
@@ -232,7 +232,6 @@ export const calculateLayerPipeline =
       // HACK: see #19471. Changing min to avoid breaking MCDA calculation with 0 in denominator.
       // TODO: Should apply proper solution later
       if (lowerBound === upperBound) {
-        // MapLibre expressions seem to have limited precision. So we need to apply Epsilon * 10 ^ number_of_digits
         lowerBound = nextFloatValueInDirection(lowerBound, Number.NEGATIVE_INFINITY);
       }
       tMin = operations.max(tMin, lowerBound);

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
@@ -14,17 +14,21 @@ const nextFloatValueInDirection = (
   transformation?: TransformationFunction,
 ): number => {
   const deltaAdjustmentFunctions = {
-    no: null,
     cube_root: (x) => Math.cbrt(x),
     square_root: (x) => Math.sqrt(x),
-    log: (x) => 10000 * x,
-    log_epsilon: (x) => 10000 * x,
+    log: (x) => 10 * x,
+    log_epsilon: (x) => 10 * x,
   };
 
   const sign = Math.sign(direction - value);
   const nextNumber = nextafter(value, direction);
-  if (transformation && deltaAdjustmentFunctions[transformation]) {
-    return value + sign * deltaAdjustmentFunctions[transformation](value - nextNumber);
+  const delta = Math.abs(value - nextNumber);
+  if (delta < 1 && transformation && deltaAdjustmentFunctions[transformation]) {
+    let adjustedDelta = deltaAdjustmentFunctions[transformation](delta);
+    if (adjustedDelta > 1) {
+      adjustedDelta = 0.1;
+    }
+    return value + sign * adjustedDelta;
   }
   return nextNumber;
 };


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/MCDA-score-calculation-breaks-if-lowerBound-equals-upperBound-19471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency to enhance numerical computations.
	- Enhanced handling of range values in calculations to improve precision and prevent division by zero errors.
	- Adjustments made to lower and upper bounds to ensure valid calculations.

- **Bug Fixes**
	- Addressed edge cases related to equal minimum and maximum values, improving the reliability of MCDA calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->