### PR TITLE
feat(MCDA): 19659 Add tooltip button near Reverse Sentiment button

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -150,6 +150,7 @@
       },
       "tips": {
         "range": "The values that will be considered the worst and the best in your analysis.",
+        "sentiment": "Determine the direction of sentiment for the layer's impact on the analysis:\n* **Bad → Good**: Higher values indicate a positive sentiment.\n* **Good → Bad**: Higher values indicate a negative sentiment.",
         "weight": "By default, all layers contribute equally to the analysis through a weighted average. Adjusting the increased weight of a layer (2, 3, etc.) allows you to assign additional importance to it in the analysis.",
         "transform": "Apply calculations to the values. Achieving a more linear distribution will provide more useful information for analysis.\n\n **Note**: Calculations are done before normalization.",
         "normalize": "Adjusts values to a standardized scale. This helps compare them easily and make decisions.\n* **Standard score scaling**: This option adjusts values to a standardized scale, ensuring they are all comparable.\n* **No (for specialists only)**: Leaves values unmodified.",

--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.module.css
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.module.css
@@ -116,3 +116,10 @@
 .reverseButton {
   margin: var(--half-unit) 0;
 }
+
+.topControlsContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--half-unit);
+}

--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
@@ -11,6 +11,7 @@ import { LayerInfo } from '~components/LayerInfo/LayerInfo';
 import { availableBivariateAxesAtom } from '~features/mcda/atoms/availableBivariateAxisesAtom';
 import { getAxisTransformations } from '~core/api/mcda';
 import { KonturSpinner } from '~components/LoadingSpinner/KonturSpinner';
+import { PopupTooltipTrigger } from '~components/PopupTooltipTrigger';
 import { Sentiments } from '../Sentiments';
 import MCDARangeControls from '../MCDARangeControls/MCDARangeControls';
 import { MCDALayerParameterRow } from './MCDALayerParameterRow/MCDALayerParameterRow';
@@ -282,7 +283,7 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
             right={sentiments.right}
             units={layer.unit}
           />
-          <div>
+          <div className={s.topControlsContainer}>
             <Button
               className={s.reverseButton}
               variant="invert-outline"
@@ -293,6 +294,11 @@ export function MCDALayerParameters({ layer, onLayerEdited }: MCDALayerLegendPro
                 ? i18n.t('mcda.layer_editor.reverse_to_good_bad')
                 : i18n.t('mcda.layer_editor.reverse_to_bad_good')}
             </Button>
+            <PopupTooltipTrigger
+              className={s.infoButton}
+              tipText={i18n.t('mcda.layer_editor.tips.sentiment')}
+              tooltipId={LAYERS_PANEL_FEATURE_ID}
+            />
           </div>
         </div>
         {!editMode ? (


### PR DESCRIPTION

<img width="381" alt="image" src="https://github.com/user-attachments/assets/26b0de27-3815-41f9-9cef-9b2500a84ec3">

https://kontur.fibery.io/Tasks/Task/Return-sentiments-explanation-to-MCDA-UI-19659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a tooltip feature in the MCDALayerParameters component to provide contextual information about sentiment settings.
	- Introduced a new entry in the localization file explaining sentiment direction in analysis.

- **Style**
	- Added a new CSS class for improved layout of control elements in the MCDALayerParameters component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->