### PR TITLE
fix(navigation): 18547 Fix "Set reference area" link in Profile

### DIFF
--- a/src/features/user_profile/components/SettingsForm/ReferenceAreaInfo/ReferenceAreaInfo.tsx
+++ b/src/features/user_profile/components/SettingsForm/ReferenceAreaInfo/ReferenceAreaInfo.tsx
@@ -46,7 +46,7 @@ export function ReferenceAreaInfo() {
           <Text type="long-m" className={s.hint}>
             {i18n.t('profile.reference_area.select_are_on_the_map')}
           </Text>
-          <div className={s.clickableText} onClick={() => goTo('/')}>
+          <div className={s.clickableText} onClick={() => goTo('/map')}>
             {i18n.t('profile.reference_area.set_the_reference_area')}
           </div>
         </>


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Set-reference-area-button-is-not-working-properly-on-Atlas-user-profile-18547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated navigation for the clickable text in the Reference Area Info component to direct users to the map page instead of the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->