### PR TITLE
feat(19523): add request trial button

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -344,6 +344,7 @@
     "current_plan_button": "Current plan",
     "sales_button": "Contact sales",
     "book_demo_button": "Book a demo",
+    "request_trial_button": "Request trial",
     "errors": {
       "payment_initialization": "There was an error during payment initialization. Please try again or contact our support"
     },

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
@@ -123,9 +123,20 @@
   align-items: center;
 }
 
-/* Paypal buttons specific styles */
-.buttonWrapper > div {
-  flex-grow: 1;
+.subscribeButtonsWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+
+  /* Paypal buttons specific styles */
+  & > div {
+    width: 100%;
+  }
+
+  & .trialButton {
+    margin-bottom: 11px;
+  }
 }
 
 .cancelButton {

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
@@ -1,5 +1,5 @@
 .planCard {
-  /* Color for plan type, highlights */
+  /* Color for plan type, highlights, link */
   --primary-color: var(--success-strong);
   /* Color for plan type background */
   --secondary-color: #def5df;
@@ -7,6 +7,8 @@
   --plan-bg-color: transparent;
   /* Border color of card */
   --plan-border-color: var(--faint-weak-up, #d2d5d8);
+  /* Color for buttons hover */
+  --cta-hover-color: #269b00;
 
   border: 1px solid var(--plan-border-color);
   border-radius: var(--double-unit, 16px);
@@ -27,6 +29,7 @@
   &.custom {
     --primary-color: var(--base-strong-down);
     --secondary-color: var(--faint-weak);
+    --cta-hover-color: var(--base-strong);
   }
 
   /* Specific premium styles */
@@ -35,6 +38,7 @@
     --secondary-color: #d8effc;
     --plan-bg-color: var(--accent-weak);
     --plan-border-color: var(--accent-weak-up);
+    --cta-hover-color: var(--accent-strong-up);
   }
 
   /* Highlights section */
@@ -114,12 +118,14 @@
 
 .buttonWrapper {
   margin-bottom: 24px;
-}
-
-.customButtonsWrapper {
   column-gap: 16px;
   display: flex;
   align-items: center;
+}
+
+/* Paypal buttons specific styles */
+.buttonWrapper > div {
+  flex-grow: 1;
 }
 
 .cancelButton {
@@ -138,21 +144,21 @@
   }
 }
 
-.bookDemoLink {
+.linkAsButton {
   font: var(--font-xs);
   font-weight: 400;
   line-height: 16px;
   letter-spacing: 0.019px;
-  color: var(--base-strong-down);
+  color: var(--primary-color);
   padding: 11px 12px;
   border-radius: var(--border-radius);
-  border: 1px solid var(--base-strong-down, #2e3d4a);
+  border: 1px solid var(--primary-color, #2e3d4a);
   text-decoration: none;
   cursor: pointer;
 
   &:hover {
-    border-color: var(--base-strong);
-    color: var(--base-strong);
+    border-color: var(--cta-hover-color);
+    color: var(--cta-hover-color);
   }
 
   &:focus-visible {
@@ -163,25 +169,10 @@
   }
 }
 
-/** Buttons color */
 .paymentPlanButton {
-  background-color: var(--success-strong);
+  background-color: var(--primary-color);
 
   &:hover {
-    background-color: #269b00;
+    background-color: var(--cta-hover-color);
   }
-}
-
-.planCard.custom .paymentPlanButton {
-  background-color: var(--base-strong-down);
-}
-.planCard.premium .paymentPlanButton {
-  background-color: var(--accent-strong);
-}
-
-.planCard.custom .paymentPlanButton:hover {
-  background-color: var(--base-strong);
-}
-.planCard.premium .paymentPlanButton:hover {
-  background-color: var(--accent-strong-up);
 }

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -160,7 +160,7 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
       {demoLink && (
         <a
           className={s.linkAsButton}
-          href={salesLink}
+          href={demoLink}
           target="_blank"
           rel="noreferrer"
           aria-label={i18n.t('subscription.book_demo_button')}

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -20,6 +20,7 @@ export type PaymentPlanCardProps = {
   planConfig: PaymentPlanConfig;
   planContent: ReactNode[];
   currentBillingCycleId: string;
+  salesLink?: string;
   currentSubscription: CurrentSubscription | null;
   isUserAuthorized: boolean;
   onUnauthorizedUserClick: () => void;
@@ -33,6 +34,7 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
   isUserAuthorized,
   onUnauthorizedUserClick,
   onNewSubscriptionApproved,
+  salesLink,
   planContent,
 }: PaymentPlanCardProps) {
   const [isChatButtonVisible] = useAtom(intercomVisibleAtom);
@@ -45,11 +47,11 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
   /** Get custom plan special properties */
   let planName;
   let description;
-  let salesLink;
+  let demoLink;
   if (isCustomPlan) {
     planName = (content[0] as ReactElement).props.children[0];
     description = content[1];
-    salesLink = planConfig.actions?.find((action) => action.name === 'contact_sales')
+    demoLink = planConfig.actions?.find((action) => action.name === 'contact_sales')
       ?.params.link;
   } else {
     description = content[0];
@@ -118,6 +120,25 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
     </>
   );
 
+  const unauthorizedButtons = (
+    <>
+      <Button className={clsx(s.paymentPlanButton)} onClick={onUnauthorizedUserClick}>
+        {i18n.t('subscription.unauthorized_button')}
+      </Button>
+      {salesLink && (
+        <a
+          className={s.linkAsButton}
+          href={salesLink}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={i18n.t('subscription.request_trial_button')}
+        >
+          {i18n.t('subscription.request_trial_button')}
+        </a>
+      )}
+    </>
+  );
+
   const customButtons = (
     <>
       {isChatButtonVisible && (
@@ -125,9 +146,9 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
           {i18n.t('subscription.sales_button')}
         </Button>
       )}
-      {salesLink && (
+      {demoLink && (
         <a
-          className={s.bookDemoLink}
+          className={s.linkAsButton}
           href={salesLink}
           target="_blank"
           rel="noreferrer"
@@ -140,20 +161,15 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
   );
 
   const buttonsBlock = (
-    <div className={clsx(s.buttonWrapper, { [s.customButtonsWrapper]: isCustomPlan })}>
+    <div className={s.buttonWrapper}>
       {/* Non-authorized */}
-      {!isUserAuthorized && !isCustomPlan && (
-        <Button className={clsx(s.paymentPlanButton)} onClick={onUnauthorizedUserClick}>
-          {i18n.t('subscription.unauthorized_button')}
-        </Button>
-      )}
+      {!isUserAuthorized && !isCustomPlan && unauthorizedButtons}
       {/* Authorized */}
       {isUserAuthorized && paypalPlanId && renderSubscribeButtons(paypalPlanId)}
       {/* Custom Plan buttons */}
       {isCustomPlan && customButtons}
     </div>
   );
-
   const footerBlock = !isCustomPlan && (
     <div className={s.footerWrapper}>
       <PaymentPlanCardFooter

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -72,20 +72,31 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
 
   const renderSubscribeButtons = (paypalPlanId: string) => {
     return currentSubscription?.billingPlanId !== paypalPlanId ? (
-      <PayPalButtonsGroup
-        billingPlanId={paypalPlanId}
-        activeBillingPlanId={currentSubscription?.billingPlanId}
-        activeSubscriptionId={currentSubscription?.billingSubscriptionId}
-        onSubscriptionApproved={(planId, subscriptionId) => {
-          if (subscriptionId) {
-            onNewSubscriptionApproved();
-          } else {
-            console.error(
-              'Unexpected result: subscriptionId came null/undefined from Paypal SDK',
-            );
-          }
-        }}
-      />
+      <div className={s.subscribeButtonsWrapper}>
+        <a
+          className={clsx(s.linkAsButton, s.trialButton)}
+          href={salesLink}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={i18n.t('subscription.request_trial_button')}
+        >
+          {i18n.t('subscription.request_trial_button')}
+        </a>
+        <PayPalButtonsGroup
+          billingPlanId={paypalPlanId}
+          activeBillingPlanId={currentSubscription?.billingPlanId}
+          activeSubscriptionId={currentSubscription?.billingSubscriptionId}
+          onSubscriptionApproved={(planId, subscriptionId) => {
+            if (subscriptionId) {
+              onNewSubscriptionApproved();
+            } else {
+              console.error(
+                'Unexpected result: subscriptionId came null/undefined from Paypal SDK',
+              );
+            }
+          }}
+        />
+      </div>
     ) : (
       <Button disabled>{i18n.t('subscription.current_plan_button')}</Button>
     );

--- a/src/features/subscriptions/components/PricingContent/PricingContent.tsx
+++ b/src/features/subscriptions/components/PricingContent/PricingContent.tsx
@@ -134,6 +134,7 @@ export function PricingContent({ config }: { config: SubscriptionsConfig }) {
               isUserAuthorized={!!user}
               onUnauthorizedUserClick={onUnauthorizedUserClick}
               onNewSubscriptionApproved={onNewSubscriptionApproved}
+              salesLink={config.salesLink}
             />
           ))}
         </div>

--- a/src/features/subscriptions/types.ts
+++ b/src/features/subscriptions/types.ts
@@ -36,4 +36,5 @@ export interface SubscriptionsConfig {
   billingMethodsDetails: BillingMethodDetails[];
   billingCyclesDetails: BillingCycleDetails[];
   plans: PaymentPlanConfig[];
+  salesLink?: string;
 }


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Add-Request-trial-button-to-Atlas-plans-19523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Request trial" button for users to easily request a trial subscription.
	- Added a new optional property for sales inquiries in the PaymentPlanCard component.

- **Style**
	- Updated styles for the PaymentPlanCard component to enhance button hover effects and visual consistency.
	- Introduced a new layout class for managing subscription buttons.

- **Bug Fixes**
	- Improved the handling of demo and sales links within the PaymentPlanCard component for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->