### PR TITLE
fix(disasters): 19936 Prevent event from disappearing from URL after the page reload. Only clean it up when actually changing the feed

### DIFF
--- a/src/core/shared_state/currentEventFeed.ts
+++ b/src/core/shared_state/currentEventFeed.ts
@@ -21,8 +21,8 @@ export const currentEventFeedAtom = createAtom(
     onAction('setCurrentFeed', (feedId) => {
       if (state?.id !== feedId) {
         state = { id: feedId };
+        schedule((dispatch) => dispatch(currentEventAtom.setCurrentEventId(null)));
       }
-      schedule((dispatch) => dispatch(currentEventAtom.setCurrentEventId(null)));
     });
 
     onAction('resetCurrentFeed', () => {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Reopen-Shared-event-is-disappearing-from-url-on-Kontur-apps-19936
https://kontur.fibery.io/Tasks/Task/FE-Page-reloading-loses-selected-disaster-18589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for resetting the current event ID based on the state, ensuring it only triggers when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->