### PR TITLE
fix(Layer Features): 20021 Don't require ACAPS layer to be enabled in order to show layer features

### DIFF
--- a/src/features/layer_features_panel/atoms/layerFeaturesCollectionAtom.ts
+++ b/src/features/layer_features_panel/atoms/layerFeaturesCollectionAtom.ts
@@ -11,6 +11,7 @@ import {
   ACAPS_LAYER_ID,
   ACAPS_SIMPLE_LAYER_ID,
   HOT_PROJECTS_LAYER_ID,
+  LAYERS_REQUIRED_BY_FEATURE_PANEL,
 } from '../constants';
 import { getHotProjectsPanelData } from './hotProjects_outlines';
 import { getAcapsFeatureCards } from './acapsToFeatureCards';
@@ -24,6 +25,8 @@ export const featuresPanelLayerId: string =
   featuresPanelConfig && typeof featuresPanelConfig === 'object'
     ? (featuresPanelConfig as LayerFeaturesPanelConfig).layerId
     : '';
+const isLayerMustBeEnabled =
+  LAYERS_REQUIRED_BY_FEATURE_PANEL.includes(featuresPanelLayerId);
 
 // TODO: update to reatom3 - in separate PR. Clean up commented values and mocks
 export const currentFeatureIdAtom = createNumberAtom(undefined, 'currentFeatureIdAtom');
@@ -55,7 +58,7 @@ export const layerFeaturesCollectionAtom = createAtom(
       currentFeatureIdAtom.set.dispatch(undefined);
       state = null;
       const enabledLayers = get('enabledLayersAtom');
-      if (!enabledLayers.has(featuresPanelLayerId)) {
+      if (isLayerMustBeEnabled && !enabledLayers.has(featuresPanelLayerId)) {
         return;
       }
       if (!isGeoJSONEmpty(focusedGeometry?.geometry))
@@ -70,7 +73,7 @@ export const layerFeaturesCollectionAtom = createAtom(
     });
 
     onChange('mountedLayersAtom', (mountedLayers) => {
-      if (!mountedLayers.has(featuresPanelLayerId)) {
+      if (isLayerMustBeEnabled && !mountedLayers.has(featuresPanelLayerId)) {
         // @ts-expect-error needs better atom type
         currentFeatureIdAtom.set.dispatch(undefined);
         state = null;

--- a/src/features/layer_features_panel/constants.ts
+++ b/src/features/layer_features_panel/constants.ts
@@ -4,3 +4,5 @@ export const ACAPS_LAYER_ID = 'acaps';
 export const ACAPS_SIMPLE_LAYER_ID = 'acaps_simple';
 export const ACAPS_DATA_HEADER = 'ACAPS data';
 export const FEATURESPANEL_MIN_HEIGHT = 80;
+
+export const LAYERS_REQUIRED_BY_FEATURE_PANEL = [HOT_PROJECTS_LAYER_ID];


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Show-ACAPS-layer-features-even-if-ACAPS-layer-is-disabled-20021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced validation logic to ensure certain layers are mandatory before processing feature loading.
	- Added a new constant to define layers required by the feature panel, enhancing clarity on dependencies.

These changes improve the overall functionality and reliability of the features panel, ensuring that necessary layers are present for optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->