### PR TITLE
refactor(19945): render paypal buttons if there is no active subscription

### DIFF
--- a/src/features/subscriptions/components/PayPalButtonsGroup/PayPalButtonsGroup.tsx
+++ b/src/features/subscriptions/components/PayPalButtonsGroup/PayPalButtonsGroup.tsx
@@ -7,27 +7,22 @@ import { dispatchMetricsEvent } from '~core/metrics/dispatch';
 
 type PayPalButtonsGroupProps = {
   billingPlanId: string;
-  activeBillingPlanId?: string | null;
-  activeSubscriptionId?: string | null;
   onSubscriptionApproved?: (planId: string, subscriptionID?: string | null) => void;
 };
 
 export function PayPalButtonsGroup({
   billingPlanId,
-  activeBillingPlanId,
-  activeSubscriptionId,
   onSubscriptionApproved,
 }: PayPalButtonsGroupProps) {
   return (
     <PayPalButtons
-      disabled={!!activeBillingPlanId}
       style={{
         label: 'subscribe',
         color: 'blue',
         height: 38,
         shape: 'rect',
       }}
-      forceReRender={[activeSubscriptionId, activeBillingPlanId, billingPlanId]}
+      forceReRender={[billingPlanId]}
       onError={(err) => {
         dispatchMetricsEvent('pay_error');
         console.error('error from PayPal SDK:', err.toString());

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
@@ -104,7 +104,7 @@
   font-weight: 500;
   line-height: 40px;
   font-size: 52px;
-  margin: 36px 0 22px;
+  margin: 36px 0 21px;
 }
 
 .planDescription {
@@ -128,14 +128,11 @@
   flex-direction: column;
   align-items: flex-start;
   width: 100%;
+  row-gap: 11px;
 
   /* Paypal buttons specific styles */
   & > div {
     width: 100%;
-  }
-
-  & .trialButton {
-    margin-bottom: 11px;
   }
 }
 
@@ -161,7 +158,7 @@
   line-height: 16px;
   letter-spacing: 0.019px;
   color: var(--primary-color);
-  padding: 11px 12px;
+  padding: 10px 12px;
   border-radius: var(--border-radius);
   border: 1px solid var(--primary-color, #2e3d4a);
   text-decoration: none;

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -74,7 +74,7 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
     return currentSubscription?.billingPlanId !== paypalPlanId ? (
       <div className={s.subscribeButtonsWrapper}>
         <a
-          className={clsx(s.linkAsButton, s.trialButton)}
+          className={s.linkAsButton}
           href={salesLink}
           target="_blank"
           rel="noreferrer"
@@ -82,20 +82,20 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
         >
           {i18n.t('subscription.request_trial_button')}
         </a>
-        <PayPalButtonsGroup
-          billingPlanId={paypalPlanId}
-          activeBillingPlanId={currentSubscription?.billingPlanId}
-          activeSubscriptionId={currentSubscription?.billingSubscriptionId}
-          onSubscriptionApproved={(planId, subscriptionId) => {
-            if (subscriptionId) {
-              onNewSubscriptionApproved();
-            } else {
-              console.error(
-                'Unexpected result: subscriptionId came null/undefined from Paypal SDK',
-              );
-            }
-          }}
-        />
+        {!currentSubscription && (
+          <PayPalButtonsGroup
+            billingPlanId={paypalPlanId}
+            onSubscriptionApproved={(planId, subscriptionId) => {
+              if (subscriptionId) {
+                onNewSubscriptionApproved();
+              } else {
+                console.error(
+                  'Unexpected result: subscriptionId came null/undefined from Paypal SDK',
+                );
+              }
+            }}
+          />
+        )}
       </div>
     ) : (
       <Button disabled>{i18n.t('subscription.current_plan_button')}</Button>

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -90,7 +90,7 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
                 onNewSubscriptionApproved();
               } else {
                 console.error(
-                  'Unexpected result: subscriptionId came null/undefined from Paypal SDK',
+                  'Unexpected result: subscriptionId came with null/undefined value from Paypal SDK',
                 );
               }
             }}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Hide-disabled-PayPal-buttons-on-Atlas-for-subscribed-users-19945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined the PayPal subscription button rendering logic for improved user experience.
- **Bug Fixes**
	- Enhanced error messaging for subscription approval process.
- **Style**
	- Adjusted CSS styles for better layout and spacing in the Payment Plan Card component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->