### PR TITLE
bugfix(17438): fix error when there is no source when reset layer

### DIFF
--- a/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
@@ -425,6 +425,7 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     }
 
     this.cleanPopup();
+    this.resetFeatureStates?.();
 
     if (map.getSource(this._sourceId)) {
       map.removeSource(this._sourceId);
@@ -436,7 +437,6 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     this.cleanUpListeners();
     map.off('zoom', this.onMapZoom);
     this.onMapZoomHandlers.clear();
-    this.resetFeatureStates?.();
   }
 
   willHide({ map }: { map: ApplicationMap }) {

--- a/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
@@ -130,8 +130,6 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     this._listenersCleaningTasks.add(registerMapListener('mouseleave', onMouseLeave, 60));
 
     this.resetFeatureStates = reset;
-    // Reset states on zoom
-    this.onMapZoomHandlers.add(this.resetFeatureStates);
   }
 
   async mountBivariateLayer(
@@ -259,9 +257,6 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
 
     // Save it for next call
     this.removeBivariatePopupClickHandler = removeClickListener;
-
-    // Close on map zoom
-    this.onMapZoomHandlers.add(this.cleanPopup);
   }
 
   async mountMCDALayer(map: ApplicationMap, layer: LayerTileSource, style: LayerStyle) {
@@ -333,8 +328,6 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     // Click
     const removeClickListener = registerMapListener('click', clickHandler, 60);
     this._listenersCleaningTasks.add(removeClickListener);
-    // Close on map zoom
-    this.onMapZoomHandlers.add(this.cleanPopup);
   }
 
   protected _updateMap(
@@ -358,7 +351,6 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     if (!isVisible) this.willHide({ map });
   }
 
-  onMapZoomHandlers = new Set<() => void>();
   onMapZoom = (ev: maplibregl.MapLibreEvent<MapLibreZoomEvent>) => {
     this.cleanPopup();
   };
@@ -436,7 +428,6 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     }
     this.cleanUpListeners();
     map.off('zoom', this.onMapZoom);
-    this.onMapZoomHandlers.clear();
   }
 
   willHide({ map }: { map: ApplicationMap }) {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Bivariate-renderer-errors-when-switching-on-off-MCDA-layer-17438

The reason for the error was that in the `willUnmount ` function, the call to `resetFeatureStates `(the `reset `method from `createFeatureStateHandlers`) occurred after the current source was removed from the map.
And in this `resetFeatureStates ` function there is call to the source, that has already been removed, so the function should be raised higher in the code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced cleanup process during unmounting by resetting feature states.
	- Improved layer styling for MCDA layers, ensuring a more consistent visual representation.

- **Bug Fixes**
	- Addressed issues with the previous unmounting logic, ensuring proper cleanup.

- **Refactor**
	- Updated method for determining layer styles to streamline the rendering process.
	- Removed unnecessary handling of map zoom events in popup methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->