### PR TITLE
feat(tiles): 20269 set fallback max zoom for bivariate tiles to 14

### DIFF
--- a/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
@@ -264,8 +264,8 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     const mapSource: VectorSourceSpecification = {
       type: 'vector',
       tiles: layer.source.urls.map((url) => adaptTileUrl(url)),
-      minzoom: layer.minZoom || 0,
-      maxzoom: layer.maxZoom || 22,
+      minzoom: layer.minZoom || FALLBACK_BIVARIATE_MIN_ZOOM,
+      maxzoom: layer.maxZoom || FALLBACK_BIVARIATE_MAX_ZOOM,
     };
     // I expect that all servers provide url with same scheme
     setTileScheme(layer.source.urls[0], mapSource);

--- a/src/core/logical_layers/renderers/BivariateRenderer/constants.ts
+++ b/src/core/logical_layers/renderers/BivariateRenderer/constants.ts
@@ -1,8 +1,8 @@
-import type { Expression, LineLayerSpecification } from 'maplibre-gl';
+import type { LineLayerSpecification } from 'maplibre-gl';
 
 export const SOURCE_LAYER_BIVARIATE = 'stats';
 export const FALLBACK_BIVARIATE_MIN_ZOOM = 0;
-export const FALLBACK_BIVARIATE_MAX_ZOOM = 22;
+export const FALLBACK_BIVARIATE_MAX_ZOOM = 14;
 
 export const FEATURE_STATES = {
   hover: 'hover',

--- a/src/features/mcda/atoms/mcdaLayer.ts
+++ b/src/features/mcda/atoms/mcdaLayer.ts
@@ -13,6 +13,10 @@ import {
   DEFAULT_GREEN,
   DEFAULT_RED,
 } from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants';
+import {
+  FALLBACK_BIVARIATE_MAX_ZOOM,
+  FALLBACK_BIVARIATE_MIN_ZOOM,
+} from '~core/logical_layers/renderers/BivariateRenderer/constants';
 import { MCDALayerEditor } from '../components/MCDALayerEditor';
 import { generateHclGradientColors } from '../utils/generateHclGradientColors';
 import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
@@ -67,8 +71,8 @@ export const mcdaLayerAtom = createAtom(
           id,
           createAsyncWrapper({
             id,
-            maxZoom: 22,
-            minZoom: 0,
+            maxZoom: FALLBACK_BIVARIATE_MAX_ZOOM,
+            minZoom: FALLBACK_BIVARIATE_MIN_ZOOM,
             source: {
               type: 'vector' as const,
               urls: [


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Set-fallback-maxzoom-for-bivariate-MCDA-layers-to-14-20269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability of zoom levels for bivariate rendering by introducing constants for minimum and maximum zoom.
  
- **Bug Fixes**
	- Updated maximum zoom level for bivariate rendering from 22 to 14, improving map performance and usability.

- **Chores**
	- Removed unnecessary import statement to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->