### PR TITLE
fix(bivariate matrix): 18057 Fix new Bivariate layer (created in Bivariate Matrix) overlapping previously selected layer. Create its settings before enabling it

### DIFF
--- a/src/features/bivariate_manager/atoms/bivariateMatrixSelection.ts
+++ b/src/features/bivariate_manager/atoms/bivariateMatrixSelection.ts
@@ -307,6 +307,10 @@ export const setMatrixSelectionAction = action(
           );
         }
 
+        if (updateActions.length) {
+          store.dispatch(updateActions);
+        }
+
         // Register and Enable
         const currentRegistry = ctx.get(layersRegistryAtom);
         if (!currentRegistry.has(id)) {
@@ -322,10 +326,6 @@ export const setMatrixSelectionAction = action(
             },
           ]);
           enableBivariateLayerAction(ctx, id);
-        }
-
-        if (updateActions.length) {
-          store.dispatch(updateActions);
         }
       }
     }


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Created-Bivariate-layer-overlaps-previously-selected-layer-18057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Upgraded to the latest version of the `@reatom/core` library
  - Refactored the code for managing the bivariate matrix selection
- **New Features**
  - Added actions and atoms to handle the selection of cells in the bivariate matrix
  - Implemented a function to handle the pre-selection of cells in the bivariate matrix
  - Updated the `setMatrixSelectionAction` to generate and register the necessary bivariate layer
  - Added a function to retrieve the currently enabled bivariate layer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->