### PR TITLE
fix(Disasters panel): 20467 Show feed selector and bbox filter in Empty state of Disasters panel

### DIFF
--- a/src/features/events_list/components/EventsPanel/EventsPanel.tsx
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.tsx
@@ -1,10 +1,9 @@
 import { Disasters24 } from '@konturio/default-icons';
 import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
 import { useAtom } from '@reatom/react-v2';
-import { useAction, useAtom as useAtomV3 } from '@reatom/npm-react';
+import { useAtom as useAtomV3 } from '@reatom/npm-react';
 import clsx from 'clsx';
 import { useCallback, useMemo } from 'react';
-import { ErrorMessage } from '~components/ErrorMessage/ErrorMessage';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';
 import { panelClasses } from '~components/Panel';
 import { AppFeature } from '~core/app/types';
@@ -17,12 +16,12 @@ import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import { useHeightResizer } from '~utils/hooks/useResizer';
 import { useShortPanelState } from '~utils/hooks/useShortPanelState';
 import { sortedEventListAtom } from '~features/events_list/atoms/sortedEventList';
-import { setEventSortingOrder } from '~features/events_list/atoms/eventSortingConfig';
 import { MIN_HEIGHT } from '../../constants';
 import { EpisodeTimelineToggle } from '../EpisodeTimelineToggle/EpisodeTimelineToggle';
 import { EventCard } from '../EventCard/EventCard';
 import { FullState } from '../FullState/FullState';
 import { ShortState } from '../ShortState/ShortState';
+import { EventsPanelErrorMessage } from '../EventsPanelErrorMessage/EventsPanelErrorMessage';
 import s from './EventsPanel.module.css';
 import type { Event } from '~core/types';
 
@@ -58,7 +57,6 @@ export function EventsPanel({
   const [focusedGeometry] = useAtom(focusedGeometryAtom);
   const isMobile = useMediaQuery(IS_MOBILE_QUERY);
   const [{ data: eventsList, error, loading }] = useAtomV3(sortedEventListAtom);
-  const setSortingOrder = useAction(setEventSortingOrder);
 
   const handleRefChange = useHeightResizer(
     (isOpen) => !isOpen && closePanel(),
@@ -102,26 +100,18 @@ export function EventsPanel({
     [handleEventClick],
   );
 
-  const handleSort = useCallback(
-    (order: 'asc' | 'desc') => {
-      setSortingOrder(order);
-    },
-    [setSortingOrder],
-  );
-
   const panelContent = useCallback(
     (state: typeof panelState) => {
       if (state === 'closed') return null;
       if (loading)
         return <LoadingSpinner message={i18n.t('loading_events')} marginTop="none" />;
-      if (error) return <ErrorMessage message={error} />;
+      if (error) return <EventsPanelErrorMessage state={state} message={error} />;
 
       return state === 'full' ? (
         <FullState
           eventsList={eventsList}
           currentEventId={currentEventId ?? null}
           renderEventCard={renderEventCard}
-          onSort={handleSort}
         />
       ) : (
         <ShortState
@@ -137,7 +127,6 @@ export function EventsPanel({
       eventsList,
       currentEventId,
       renderEventCard,
-      handleSort,
       openFullState,
       currentEvent,
     ],

--- a/src/features/events_list/components/EventsPanelErrorMessage/EventsPanelErrorMessage.module.css
+++ b/src/features/events_list/components/EventsPanelErrorMessage/EventsPanelErrorMessage.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/src/features/events_list/components/EventsPanelErrorMessage/EventsPanelErrorMessage.tsx
+++ b/src/features/events_list/components/EventsPanelErrorMessage/EventsPanelErrorMessage.tsx
@@ -1,0 +1,22 @@
+import { ErrorMessage } from '~components/ErrorMessage/ErrorMessage';
+import { EventsPanelSettings } from '../EventsPanelSettings/EventsPanelSettings';
+import s from './EventsPanelErrorMessage.module.css';
+import type { PanelState } from '~utils/hooks/useShortPanelState';
+
+export function EventsPanelErrorMessage({
+  message,
+  state,
+}: {
+  message: string;
+  state: Exclude<PanelState, 'closed'>;
+}) {
+  if (state === 'short') {
+    return <ErrorMessage message={message} />;
+  }
+  return (
+    <div className={s.container}>
+      <EventsPanelSettings />
+      <ErrorMessage message={message} />
+    </div>
+  );
+}

--- a/src/features/events_list/components/EventsPanelSettings/EventsPanelSettings.tsx
+++ b/src/features/events_list/components/EventsPanelSettings/EventsPanelSettings.tsx
@@ -1,0 +1,21 @@
+import { configRepo } from '~core/config';
+import { AppFeature } from '~core/app/types';
+import { EventListSettingsRow } from '../EventListSettingsRow/EventListSettingsRow';
+import { FeedSelectorFlagged } from '../FeedSelector';
+import { BBoxFilterToggle } from '../BBoxFilterToggle/BBoxFilterToggle';
+
+const featureFlags = configRepo.get().features;
+
+export function EventsPanelSettings() {
+  return (
+    <EventListSettingsRow>
+      <FeedSelectorFlagged />
+      {featureFlags[AppFeature.EVENTS_LIST__BBOX_FILTER] && <BBoxFilterToggle />}
+      {/* TODO: for now we don't want these sort buttons, there was no design for them */}
+      {/* <EventListSortButton
+              onSort={onSort}
+              onFocus={currentEventIndex !== undefined ? scrollToCurrentEvent : undefined}
+            /> */}
+    </EventListSettingsRow>
+  );
+}

--- a/src/features/events_list/components/FullState/FullState.tsx
+++ b/src/features/events_list/components/FullState/FullState.tsx
@@ -22,16 +22,6 @@ export function FullState({
     return eventsList.findIndex((event) => event.eventId === currentEventId);
   }, [currentEventId, eventsList]);
 
-  const scrollToCurrentEvent = useCallback(() => {
-    if (currentEventIndex !== undefined && virtuosoRef.current) {
-      virtuosoRef.current.scrollToIndex({
-        index: currentEventIndex,
-        align: 'center',
-        behavior: 'auto',
-      });
-    }
-  }, [currentEventIndex]);
-
   const itemContent = useCallback(
     (_: number, event: Event) => renderEventCard(event, event.eventId === currentEventId),
     [renderEventCard, currentEventId],

--- a/src/features/events_list/components/FullState/FullState.tsx
+++ b/src/features/events_list/components/FullState/FullState.tsx
@@ -1,27 +1,18 @@
 import { useRef, useCallback, useMemo } from 'react';
 import { Virtuoso } from 'react-virtuoso';
-import { AppFeature } from '~core/app/types';
-import { configRepo } from '~core/config';
-import { BBoxFilterToggle } from '../BBoxFilterToggle/BBoxFilterToggle';
-import { EventListSettingsRow } from '../EventListSettingsRow/EventListSettingsRow';
-import { FeedSelectorFlagged } from '../FeedSelector';
-import { EventListSortButton } from '../EventListSortButton/EventListSortButton';
+import { EventsPanelSettings } from '../EventsPanelSettings/EventsPanelSettings';
 import s from './FullState.module.css';
 import type { Event } from '~core/types';
 import type { VirtuosoHandle } from 'react-virtuoso';
-
-const featureFlags = configRepo.get().features;
 
 export function FullState({
   eventsList,
   currentEventId,
   renderEventCard,
-  onSort,
 }: {
   eventsList: Event[] | null;
   currentEventId: string | null;
   renderEventCard: (event: Event, isActive: boolean) => JSX.Element;
-  onSort: (order: 'asc' | 'desc') => void;
 }) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
@@ -31,7 +22,7 @@ export function FullState({
     return eventsList.findIndex((event) => event.eventId === currentEventId);
   }, [currentEventId, eventsList]);
 
-  const handleFocus = useCallback(() => {
+  const scrollToCurrentEvent = useCallback(() => {
     if (currentEventIndex !== undefined && virtuosoRef.current) {
       virtuosoRef.current.scrollToIndex({
         index: currentEventIndex,
@@ -50,15 +41,7 @@ export function FullState({
 
   return (
     <div className={s.panelBody}>
-      <EventListSettingsRow>
-        <FeedSelectorFlagged />
-        {featureFlags[AppFeature.EVENTS_LIST__BBOX_FILTER] && <BBoxFilterToggle />}
-        {/* TODO: for now we don't want thede sort buttons, there was no design for them */}
-        {/* <EventListSortButton
-          onSort={onSort}
-          onFocus={currentEventIndex !== undefined ? handleFocus : undefined}
-        /> */}
-      </EventListSettingsRow>
+      <EventsPanelSettings />
       <div className={s.scrollable}>
         <Virtuoso
           ref={virtuosoRef}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Empty-state-in-Disasters-panel-doesn't-show-feed-selector-and-bbox-filter-20467

<img width="410" alt="image" src="https://github.com/user-attachments/assets/e78fd3d6-9830-4c2c-a5f3-6bd7aad80038" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `EventsPanelErrorMessage` component for improved error handling.
	- Added a new `EventsPanelSettings` component to manage event panel settings dynamically.

- **Bug Fixes**
	- Updated error presentation logic within the `EventsPanel`.

- **Refactor**
	- Removed sorting functionality from the `EventsPanel` and `FullState` components to streamline event management.

- **Style**
	- Added a new CSS class `.container` to ensure proper layout for the `EventsPanelErrorMessage`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->