### PR TITLE
feat(disasters panel): 20511 Added config-based filters by last N days (updatedAt and startedAt fields)

### DIFF
--- a/src/features/events_list/atoms/sortedEventList.ts
+++ b/src/features/events_list/atoms/sortedEventList.ts
@@ -6,6 +6,8 @@ import { sortEventsBySingleProperty } from '../helpers/singlePropertySort';
 import { sortEventsByMcda } from '../helpers/eventsMcdaSort';
 import {
   filterByExcludedEventTypes,
+  filterByLastNDaysStartedAt,
+  filterByLastNDaysUpdatedAt,
   filterByMinAffectedPopulation,
   filterByMinSeverity,
   filterByMinStartedAt,
@@ -56,11 +58,16 @@ function applyLocalEventListFilters(
   if (filtersConfig.excludedEventTypes) {
     result = filterByExcludedEventTypes(result, filtersConfig.excludedEventTypes);
   }
+  // date filters
   if (filtersConfig.minUpdatedAt) {
     result = filterByMinUpdatedAt(result, filtersConfig.minUpdatedAt);
+  } else if (isNumber(filtersConfig.lastNDaysUpdatedAt)) {
+    result = filterByLastNDaysUpdatedAt(result, filtersConfig.lastNDaysUpdatedAt);
   }
   if (filtersConfig.minStartedAt) {
     result = filterByMinStartedAt(result, filtersConfig.minStartedAt);
+  } else if (isNumber(filtersConfig.lastNDaysStartedAt)) {
+    result = filterByLastNDaysStartedAt(result, filtersConfig.lastNDaysStartedAt);
   }
   return result;
 }

--- a/src/features/events_list/helpers/localEventFilters.ts
+++ b/src/features/events_list/helpers/localEventFilters.ts
@@ -1,12 +1,26 @@
 import { SEVERITY_SORTING_SCORES } from '../constants';
 import type { Event, EventType, Severity } from '~core/types';
 
+export function filterByLastNDaysUpdatedAt(events: Event[], days: number): Event[] {
+  const minTime = getNDaysBack(days).getTime();
+  if (minTime > 0) {
+    return filterByMinTime(events, minTime, (event) => event.updatedAt);
+  }
+  return events;
+}
+
+export function filterByLastNDaysStartedAt(events: Event[], days: number): Event[] {
+  const minTime = getNDaysBack(days).getTime();
+  if (minTime > 0) {
+    return filterByMinTime(events, minTime, (event) => event.startedAt);
+  }
+  return events;
+}
+
 export function filterByMinUpdatedAt(events: Event[], minDateString: string): Event[] {
   const minTime = new Date(minDateString).getTime();
   if (minTime) {
-    return events.filter((event) => {
-      return event.updatedAt && new Date(event.updatedAt).getTime() >= minTime;
-    });
+    return filterByMinTime(events, minTime, (event) => event.updatedAt);
   }
   return events;
 }
@@ -14,9 +28,7 @@ export function filterByMinUpdatedAt(events: Event[], minDateString: string): Ev
 export function filterByMinStartedAt(events: Event[], minDateString: string): Event[] {
   const minTime = new Date(minDateString).getTime();
   if (minTime) {
-    return events.filter((event) => {
-      return event.startedAt && new Date(event.startedAt).getTime() >= minTime;
-    });
+    return filterByMinTime(events, minTime, (event) => event.startedAt);
   }
   return events;
 }
@@ -58,4 +70,26 @@ export function filterByExcludedEventTypes(
     });
   }
   return events;
+}
+
+function filterByMinTime(
+  events: Event[],
+  minTimeMs: number,
+  fieldExtractor: (event: Event) => string,
+): Event[] {
+  return events.filter((event) => {
+    return (
+      fieldExtractor(event) && new Date(fieldExtractor(event)).getTime() >= minTimeMs
+    );
+  });
+}
+
+function getNDaysBack(days: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  date.setHours(0);
+  date.setMinutes(0);
+  date.setSeconds(0);
+  date.setMilliseconds(0);
+  return date;
 }

--- a/src/features/events_list/types.ts
+++ b/src/features/events_list/types.ts
@@ -8,6 +8,10 @@ export type LocalEventListFilters = {
   minSeverity?: Severity;
   minStartedAt?: string;
   minUpdatedAt?: string;
+  // minUpdatedAt has priority
+  lastNDaysUpdatedAt?: number;
+  // minStartedAt has priority
+  lastNDaysStartedAt?: number;
 };
 
 export type EventsListFeatureConfig = {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Last-N-days-filter-for-startedAt-and-updatedAt-fields-20511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new filtering options for event lists based on the last N days for both start and update timestamps.
	- Added optional properties to enhance filtering configurations.

- **Bug Fixes**
	- Improved filtering logic for existing functions to utilize a new helper function, enhancing modularity.

- **Documentation**
	- Updated type definitions to include new optional properties for event filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->