### PR TITLE
feat(20564): center profile loading icon

### DIFF
--- a/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
+++ b/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
@@ -18,6 +18,7 @@ import {
 import { SettingsNavigation } from '~features/user_profile/components/SettingsForm/SettingsNavigation/SettingsNavigation';
 import { SettingsSection } from '~features/user_profile/components/SettingsForm/SettingsSection/SettingsSection';
 import stylesV1 from '~features/user_profile/components/SettingsForm/SettingsForm.module.css';
+import { FullScreenLoader } from '~components/LoadingSpinner/LoadingSpinner';
 import { currentProfileAtom, pageStatusAtom } from '../../atoms/userProfile';
 import s from './SettingsForm.module.css';
 
@@ -47,12 +48,7 @@ export function SettingsForm() {
     getUserProfile();
   }, [getUserProfile]);
 
-  if (status === 'init')
-    return (
-      <div className={s.spinnerContainer}>
-        <KonturSpinner />
-      </div>
-    );
+  if (status === 'init') return <FullScreenLoader />;
 
   return <SettingsFormGen userProfile={user} updateUserProfile={updateUserProfile} />;
 }


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Loading-icon-is-placed-on-top-left-corner-when-loading-profile-20564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated loading indicator in settings form to use a full-screen loader
- **Refactor**
	- Simplified loading state visualization with a new component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->