### PR TITLE
feat(20572): fix second 2 scrolls on search results mobile page

### DIFF
--- a/src/features/search/componets/SearchBar/SearchBar.module.css
+++ b/src/features/search/componets/SearchBar/SearchBar.module.css
@@ -48,6 +48,7 @@
   .resultsList {
     width: 100%;
     box-shadow: none;
+    overflow-y: unset;
   }
 }
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Second-scroll-can-appear-on-search-when-having-overflowed-list-of-result-items-20572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated responsive styling for search results list on smaller screens to improve display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->