### PR TITLE
fix(20649): Always show numbers in Bivariate hex popup

### DIFF
--- a/src/components/MapHexTooltip/MapHexTooltip.tsx
+++ b/src/components/MapHexTooltip/MapHexTooltip.tsx
@@ -30,7 +30,7 @@ type MapHexTooltipProps = {
   axis: BivariateLegend['axis'];
   cellIndex: number;
   cellLabel: string;
-  values?: { x: string; y: string };
+  values: { x: string; y: string };
 };
 
 export const MapHexTooltip = ({
@@ -52,12 +52,10 @@ export const MapHexTooltip = ({
           <span>{axis.y.label || formatBivariateAxisLabel(axis.y.quotients)}</span>
         </div>
 
-        {values && (
-          <div className={s.column}>
-            <span>{values.x}</span>
-            <span>{values.y}</span>
-          </div>
-        )}
+        <div className={s.column}>
+          <span>{values.x}</span>
+          <span>{values.y}</span>
+        </div>
 
         <div className={s.column}>
           <span>{getXIndicatorLabelByindex(cellIndex)}</span>

--- a/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
@@ -16,8 +16,6 @@ import {
 import { invertClusters } from '~utils/bivariate';
 import { getCellLabelByValue } from '~utils/bivariate/bivariateLegendUtils';
 import { dispatchMetricsEvent } from '~core/metrics/dispatch';
-import { configRepo } from '~core/config';
-import { AppFeature } from '~core/app/types';
 import { getMaxNumeratorZoomLevel } from '~utils/bivariate/getMaxZoomLevel';
 import { styleConfigs } from '../stylesConfigs';
 import { generatePopupContent } from '../MCDARenderer/popup';
@@ -54,8 +52,6 @@ const convertFillColorToRGBA = (fillColor: RGBAColor, withTransparency = true): 
   `rgba(${fillColor.r * 255 * 2},${fillColor.g * 255 * 2},${fillColor.b * 255 * 2}${
     withTransparency ? ',' + fillColor.a : ''
   })`;
-
-const featureFlags = configRepo.get().features;
 
 function calcValueByNumeratorDenominator(
   cellValues: Exclude<GeoJsonProperties, null>,
@@ -191,8 +187,6 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
       /* Skip when color empty */
       if (!isFeatureVisible(feature)) return true;
       if (!feature.properties) return true;
-
-      const showValues = featureFlags[AppFeature.BIVARIATE_MANAGER];
       const [xNumerator, xDenominator] = legend.axis.x.quotient;
       const [yNumerator, yDenominator] = legend.axis.y.quotient;
       const xValue = calcValueByNumeratorDenominator(
@@ -226,7 +220,7 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
           cellLabel={cells[cellIndex].label}
           cellIndex={cellIndex}
           axis={legend.axis}
-          values={showValues ? { x: xValue, y: yValue } : undefined}
+          values={{ x: xValue, y: yValue }}
           hexagonColor={rgba}
         />,
       );


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Show-numbers-in-bivariate-popup-by-default-20649

![image](https://github.com/user-attachments/assets/0b7f1dd2-f5c8-4be0-a019-b5eb5e1ab60e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified rendering logic for map hex tooltips.
	- Removed feature flag dependency for displaying values in map tooltips.
	- Made `values` a required property in map hex tooltip component, ensuring consistent value display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->