### PR TITLE
fix(20691): remove resetting active control on another control click

### DIFF
--- a/src/core/toolbar/index.ts
+++ b/src/core/toolbar/index.ts
@@ -104,17 +104,6 @@ class ToolbarImpl implements Toolbar {
     );
   }
 
-  resetOtherActiveControls(activeControlId: ControlID) {
-    this.updateControlsState(
-      (stateAtom) => {
-        if (stateAtom.getState() === 'active') store.dispatch(stateAtom.set('regular'));
-      },
-      (controlId, settings) =>
-        controlId !== activeControlId &&
-        settings.id !== FOCUSED_GEOMETRY_EDITOR_CONTROL_ID,
-    );
-  }
-
   // Sets up a control with its settings and state management logic
   setupControl<Ctx extends Record<string, unknown>>(
     settings: ToolbarControlSettings,
@@ -144,9 +133,6 @@ class ToolbarImpl implements Toolbar {
 
     // Subscribing to state changes to manage enabling/disabling of controls
     const unsubscribe = controlStateAtom.subscribe((state) => {
-      // Order of execution is important here, resetOtherActiveControls should be called before disableBorrowMapControls
-      if (state === 'active') this.resetOtherActiveControls(settings.id);
-
       if (state === 'active' && settings.borrowMapInteractions)
         this.disableBorrowMapControls(settings.id);
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Locate-me-cancels-sensors-recording-20691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the toolbar’s control behavior so that activating a new control no longer automatically deactivates others. This change allows you more flexibility when engaging with toolbar options, as multiple controls can now remain active as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->