### PR TITLE
feat(multivariate): 21063 Use maxZoom based on indicators in Multivariate config

### DIFF
--- a/src/core/logical_layers/renderers/ClickableFeaturesRenderer/ClickableFeaturesRenderer.tsx
+++ b/src/core/logical_layers/renderers/ClickableFeaturesRenderer/ClickableFeaturesRenderer.tsx
@@ -8,11 +8,7 @@ import { registerMapListener } from '~core/shared_state/mapListeners';
 import { bivariateHexagonPopupContentRoot } from '~components/MapHexTooltip/MapHexTooltip';
 import { dispatchMetricsEvent } from '~core/metrics/dispatch';
 import { setTileScheme } from '../setTileScheme';
-import {
-  FALLBACK_BIVARIATE_MAX_ZOOM,
-  FALLBACK_BIVARIATE_MIN_ZOOM,
-  SOURCE_LAYER_BIVARIATE,
-} from '../BivariateRenderer/constants';
+import { SOURCE_LAYER_BIVARIATE } from '../BivariateRenderer/constants';
 import { createFeatureStateHandlers } from '../helpers/activeAndHoverFeatureStates';
 import { H3_HOVER_LAYER } from '../BivariateRenderer/constants';
 import { isFeatureVisible } from '../helpers/featureVisibilityCheck';
@@ -56,6 +52,8 @@ export abstract class ClickableFeaturesRenderer extends LogicalLayerDefaultRende
 
   protected abstract getSourcePrefix(): string;
   protected abstract getClickableLayerId(): string;
+  protected abstract getMinZoomLevel(layer: LayerTileSource): number;
+  protected abstract getMaxZoomLevel(layer: LayerTileSource): number;
 
   protected abstract mountLayers(
     map: ApplicationMap,
@@ -68,7 +66,7 @@ export abstract class ClickableFeaturesRenderer extends LogicalLayerDefaultRende
     layerStyle: LayerStyle,
   ): JSX.Element | null;
 
-  protected createTileSource(
+  createTileSource(
     map: ApplicationMap,
     layer: LayerTileSource,
   ): VectorSourceSpecification {
@@ -76,8 +74,8 @@ export abstract class ClickableFeaturesRenderer extends LogicalLayerDefaultRende
     const mapSource: VectorSourceSpecification = {
       type: 'vector',
       tiles: layer.source.urls.map((url) => adaptTileUrl(url)),
-      minzoom: layer.minZoom || FALLBACK_BIVARIATE_MIN_ZOOM,
-      maxzoom: layer.maxZoom || FALLBACK_BIVARIATE_MAX_ZOOM,
+      minzoom: layer.minZoom || this.getMinZoomLevel(layer),
+      maxzoom: layer.maxZoom || this.getMaxZoomLevel(layer),
     };
     // I expect that all servers provide url with same scheme
     setTileScheme(layer.source.urls[0], mapSource);

--- a/src/core/logical_layers/renderers/ClickableFeaturesRenderer/ClickableFeaturesRenderer.tsx
+++ b/src/core/logical_layers/renderers/ClickableFeaturesRenderer/ClickableFeaturesRenderer.tsx
@@ -66,7 +66,7 @@ export abstract class ClickableFeaturesRenderer extends LogicalLayerDefaultRende
     layerStyle: LayerStyle,
   ): JSX.Element | null;
 
-  createTileSource(
+  private createTileSource(
     map: ApplicationMap,
     layer: LayerTileSource,
   ): VectorSourceSpecification {

--- a/src/core/logical_layers/renderers/MultivariateRenderer/MultivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/MultivariateRenderer/MultivariateRenderer.tsx
@@ -1,6 +1,11 @@
 import { layerByOrder } from '~core/logical_layers/utils/layersOrder/layerByOrder';
+import { getMaxMultivariateZoomLevel } from '~utils/bivariate/getMaxZoomLevel';
 import { styleConfigs } from '../stylesConfigs';
 import { ClickableFeaturesRenderer } from '../ClickableFeaturesRenderer';
+import {
+  FALLBACK_BIVARIATE_MAX_ZOOM,
+  FALLBACK_BIVARIATE_MIN_ZOOM,
+} from '../BivariateRenderer/constants';
 import { generateMultivariatePopupContent } from './popup';
 import type { LayerSpecification } from 'maplibre-gl';
 import type { LayerTileSource } from '~core/logical_layers/types/source';
@@ -43,6 +48,17 @@ export class MultivariateRenderer extends ClickableFeaturesRenderer {
         style.type,
       );
     }
+  }
+
+  protected getMinZoomLevel(): number {
+    return FALLBACK_BIVARIATE_MIN_ZOOM;
+  }
+
+  protected getMaxZoomLevel(layer: LayerTileSource): number {
+    if (layer.style?.type !== 'multivariate') {
+      return FALLBACK_BIVARIATE_MAX_ZOOM;
+    }
+    return getMaxMultivariateZoomLevel(layer.style.config, FALLBACK_BIVARIATE_MAX_ZOOM);
   }
 
   protected createPopupContent(


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/My-tasks-3575#Task/Use-maxZoom-based-on-indicators-in-multivariate-config-21063

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d3f6339e-9a63-4af7-a3d9-0b71b0166863" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Map rendering now dynamically adjusts zoom levels for interactive and multivariate layers, providing a smoother and more responsive viewing experience.
  
- **Refactor**
  - Updated zoom level determination logic ensures consistent tile display across various map views, with new methods introduced for better handling of zoom levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->