### PR TITLE
fix(MCDA maxZoom): 21227 Fix applying maxZoom for MCDA presets

### DIFF
--- a/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/BivariateRenderer/BivariateRenderer.tsx
@@ -16,7 +16,11 @@ import {
 import { invertClusters } from '~utils/bivariate';
 import { getCellLabelByValue } from '~utils/bivariate/bivariateLegendUtils';
 import { dispatchMetricsEvent } from '~core/metrics/dispatch';
-import { getMaxNumeratorZoomLevel } from '~utils/bivariate/getMaxZoomLevel';
+import {
+  getMaxMCDAZoomLevel,
+  getMaxNumeratorZoomLevel,
+} from '~utils/bivariate/getMaxZoomLevel';
+import { isNumber } from '~utils/common';
 import { styleConfigs } from '../stylesConfigs';
 import { generateMCDAPopupContent } from '../MCDARenderer/popup';
 import { setTileScheme } from '../setTileScheme';
@@ -267,12 +271,18 @@ export class BivariateRenderer extends LogicalLayerDefaultRenderer {
     layer: LayerTileSource,
     style: MCDALayerStyle,
   ) {
+    const minZoomLevel = isNumber(layer.minZoom)
+      ? layer.minZoom
+      : FALLBACK_BIVARIATE_MIN_ZOOM;
+    const maxZoomLevel = isNumber(layer.maxZoom)
+      ? layer.maxZoom
+      : getMaxMCDAZoomLevel(style.config, FALLBACK_BIVARIATE_MAX_ZOOM);
     /* Create source */
     const mapSource: VectorSourceSpecification = {
       type: 'vector',
       tiles: layer.source.urls.map((url) => adaptTileUrl(url)),
-      minzoom: layer.minZoom || FALLBACK_BIVARIATE_MIN_ZOOM,
-      maxzoom: layer.maxZoom || FALLBACK_BIVARIATE_MAX_ZOOM,
+      minzoom: minZoomLevel,
+      maxzoom: maxZoomLevel,
     };
     // I expect that all servers provide url with same scheme
     setTileScheme(layer.source.urls[0], mapSource);

--- a/src/core/logical_layers/renderers/MultivariateRenderer/MultivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/MultivariateRenderer/MultivariateRenderer.tsx
@@ -1,5 +1,6 @@
 import { layerByOrder } from '~core/logical_layers/utils/layersOrder/layerByOrder';
 import { getMaxMultivariateZoomLevel } from '~utils/bivariate/getMaxZoomLevel';
+import { isNumber } from '~utils/common';
 import { styleConfigs } from '../stylesConfigs';
 import { ClickableFeaturesRenderer } from '../ClickableFeaturesRenderer';
 import {
@@ -50,15 +51,17 @@ export class MultivariateRenderer extends ClickableFeaturesRenderer {
     }
   }
 
-  protected getMinZoomLevel(): number {
-    return FALLBACK_BIVARIATE_MIN_ZOOM;
+  protected getMinZoomLevel(layer: LayerTileSource): number {
+    return isNumber(layer.minZoom) ? layer.minZoom : FALLBACK_BIVARIATE_MIN_ZOOM;
   }
 
   protected getMaxZoomLevel(layer: LayerTileSource): number {
     if (layer.style?.type !== 'multivariate') {
       return FALLBACK_BIVARIATE_MAX_ZOOM;
     }
-    return getMaxMultivariateZoomLevel(layer.style.config, FALLBACK_BIVARIATE_MAX_ZOOM);
+    return isNumber(layer.maxZoom)
+      ? layer.maxZoom
+      : getMaxMultivariateZoomLevel(layer.style.config, FALLBACK_BIVARIATE_MAX_ZOOM);
   }
 
   protected createPopupContent(

--- a/src/features/mcda/atoms/mcdaLayer.ts
+++ b/src/features/mcda/atoms/mcdaLayer.ts
@@ -9,11 +9,6 @@ import { adaptTileUrl } from '~utils/bivariate/tile/adaptTileUrl';
 import { layersEditorsAtom } from '~core/logical_layers/atoms/layersEditors';
 import { layersLegendsAtom } from '~core/logical_layers/atoms/layersLegends';
 import { i18n } from '~core/localization';
-import {
-  FALLBACK_BIVARIATE_MAX_ZOOM,
-  FALLBACK_BIVARIATE_MIN_ZOOM,
-} from '~core/logical_layers/renderers/BivariateRenderer/constants';
-import { getMaxMCDAZoomLevel } from '~utils/bivariate/getMaxZoomLevel';
 import { generateMCDALegendColors } from '~utils/mcda/mcdaLegendsUtils';
 import { MCDALayerEditor } from '../components/MCDALayerEditor';
 import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
@@ -25,7 +20,7 @@ export const mcdaLayerAtom = createAtom(
     enableMCDALayer: (layerId: string) => layerId,
     disableMCDALayer: () => null,
   },
-  ({ onAction, schedule, getUnlistedState, create }) => {
+  ({ onAction, schedule, getUnlistedState }) => {
     onAction('createMCDALayer', (json) => {
       const id = json.id;
       const name = json.name;
@@ -33,7 +28,6 @@ export const mcdaLayerAtom = createAtom(
       if (json.colors.type === 'sentiments') {
         legendColors = generateMCDALegendColors(json.colors);
       }
-      const maxZoomLevel = getMaxMCDAZoomLevel(json, FALLBACK_BIVARIATE_MAX_ZOOM);
 
       const actions: Array<Action> = [
         // Set layer settings once
@@ -53,8 +47,6 @@ export const mcdaLayerAtom = createAtom(
           id,
           createAsyncWrapper({
             id,
-            maxZoom: maxZoomLevel,
-            minZoom: FALLBACK_BIVARIATE_MIN_ZOOM,
             source: {
               type: 'vector' as const,
               urls: [


### PR DESCRIPTION
* Moves usage of getMaxMCDAZoomLevel() from mcdaLayerAtom action into `BivariateRenderer`
* Adds checking for maxZoom/minZoom properties in MultivariateRenderer

https://kontur.fibery.io/Tasks/Task/MCDA-based-presets-are-displayed-at-a-maximum-of-9-zoom-21227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced map layer zoom behavior for more consistent and reliable rendering.
  - Updated the logic to validate and apply zoom settings more accurately during layer display.
  - Removed outdated configuration options for a cleaner, more efficient process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->