### PR TITLE
fix(multivariate popup): fix rounding of small values in Multivariate popup

### DIFF
--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -3,6 +3,14 @@ import { capitalize } from '~utils/common';
 import s from './PopupMCDA.module.css';
 import type { PopupMCDAProps } from '../types';
 
+function formatValue(value: number): string {
+  if (Math.abs(value) < 0.01 && Math.abs(value) > 0) {
+    return value.toExponential(2);
+  } else {
+    return value.toFixed(2);
+  }
+}
+
 export function OneLayerPopup({
   layer,
   normalized,
@@ -33,17 +41,17 @@ export function OneLayerPopup({
     <ul className={s.list}>
       <li>
         <span className={s.entryName}>{num}:</span>{' '}
-        {parseFloat(normalized[key]?.numValue.toFixed(2))}
+        {formatValue(normalized[key].numValue)}
       </li>
       <li>
         <span className={s.entryName}>{den}:</span>{' '}
-        {parseFloat(normalized[key]?.denValue.toFixed(2))}
+        {formatValue(normalized[key].denValue)}
       </li>
       <li>
         <span className={s.entryName}>
           {num} / {den}:
         </span>{' '}
-        {resultMCDA.toFixed(2)}
+        {formatValue(resultMCDA)}
       </li>
     </ul>
   );

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -34,17 +34,17 @@ export function OneLayerPopup({
     <ul className={s.list}>
       <li>
         <span className={s.entryName}>{num}:</span>{' '}
-        {roundNumberToPrecision(normalized[key].numValue, 3, 2)}
+        {roundNumberToPrecision(normalized[key].numValue, 3, false, 2)}
       </li>
       <li>
         <span className={s.entryName}>{den}:</span>{' '}
-        {roundNumberToPrecision(normalized[key].denValue, 3, 2)}
+        {roundNumberToPrecision(normalized[key].denValue, 3, false, 2)}
       </li>
       <li>
         <span className={s.entryName}>
           {num} / {den}:
         </span>{' '}
-        {roundNumberToPrecision(resultMCDA, 3)}
+        {roundNumberToPrecision(resultMCDA, 2, true)}
       </li>
     </ul>
   );
@@ -74,7 +74,8 @@ export function MultiLayerPopup({ layers, normalized, resultMCDA }: MultiLayerPo
                 {num} / {den}
               </td>
               <td>
-                {roundNumberToPrecision(min, 2)} - {roundNumberToPrecision(max, 2)}
+                {roundNumberToPrecision(min, 2, true)} -{' '}
+                {roundNumberToPrecision(max, 2, true)}
               </td>
               <td>{coefficient}</td>
               <td>{roundNumberToPrecision(normalized[`${num}-${den}`].val, 3)}</td>
@@ -84,7 +85,9 @@ export function MultiLayerPopup({ layers, normalized, resultMCDA }: MultiLayerPo
         })}
         <tr>
           <td colSpan={5}>
-            <b className={s.result}>Result: {roundNumberToPrecision(resultMCDA, 3)}</b>
+            <b className={s.result}>
+              Result: {roundNumberToPrecision(resultMCDA, 2, true)}
+            </b>
           </td>
         </tr>
       </tbody>

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -76,17 +76,17 @@ export function MultiLayerPopup({ layers, normalized, resultMCDA }: MultiLayerPo
                 {num} / {den}
               </td>
               <td>
-                {min} - {max}
+                {roundNumberToPrecision(min, 3)} - {roundNumberToPrecision(max, 3)}
               </td>
               <td>{coefficient}</td>
-              <td>{normalized[`${num}-${den}`].val.toFixed(2)}</td>
-              <td>{normalized[`${num}-${den}`].norm.toFixed(2)}</td>
+              <td>{roundNumberToPrecision(normalized[`${num}-${den}`].val, 2)}</td>
+              <td>{roundNumberToPrecision(normalized[`${num}-${den}`].norm, 2)}</td>
             </tr>
           );
         })}
         <tr>
           <td colSpan={5}>
-            <b className={s.result}>Result: {resultMCDA.toFixed(2)}</b>
+            <b className={s.result}>Result: {roundNumberToPrecision(resultMCDA, 2)}</b>
           </td>
         </tr>
       </tbody>

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -1,15 +1,8 @@
 import { useMemo } from 'react';
 import { capitalize } from '~utils/common';
+import { roundNumberToPrecision } from '~utils/common/roundNumberToPrecision';
 import s from './PopupMCDA.module.css';
 import type { PopupMCDAProps } from '../types';
-
-function formatValue(value: number): string {
-  if (Math.abs(value) < 0.00001 && Math.abs(value) > 0) {
-    return value.toExponential(3);
-  } else {
-    return Number.parseFloat(value.toFixed(3)).toString();
-  }
-}
 
 export function OneLayerPopup({
   layer,
@@ -41,17 +34,19 @@ export function OneLayerPopup({
     <ul className={s.list}>
       <li>
         <span className={s.entryName}>{num}:</span>{' '}
-        {normalized[key].denValue ? formatValue(normalized[key].numValue) : '--'}
+        {normalized[key].denValue
+          ? roundNumberToPrecision(normalized[key].numValue, 5, 3)
+          : '--'}
       </li>
       <li>
         <span className={s.entryName}>{den}:</span>{' '}
-        {normalized[key] ? formatValue(normalized[key].denValue) : '--'}
+        {normalized[key] ? roundNumberToPrecision(normalized[key].denValue, 5, 3) : '--'}
       </li>
       <li>
         <span className={s.entryName}>
           {num} / {den}:
         </span>{' '}
-        {formatValue(resultMCDA)}
+        {roundNumberToPrecision(resultMCDA, 3)}
       </li>
     </ul>
   );

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -34,11 +34,11 @@ export function OneLayerPopup({
     <ul className={s.list}>
       <li>
         <span className={s.entryName}>{num}:</span>{' '}
-        {roundNumberToPrecision(normalized[key].numValue, 5, 3)}
+        {roundNumberToPrecision(normalized[key].numValue, 3, 2)}
       </li>
       <li>
         <span className={s.entryName}>{den}:</span>{' '}
-        {roundNumberToPrecision(normalized[key].denValue, 5, 3)}
+        {roundNumberToPrecision(normalized[key].denValue, 3, 2)}
       </li>
       <li>
         <span className={s.entryName}>
@@ -74,17 +74,17 @@ export function MultiLayerPopup({ layers, normalized, resultMCDA }: MultiLayerPo
                 {num} / {den}
               </td>
               <td>
-                {roundNumberToPrecision(min, 3)} - {roundNumberToPrecision(max, 3)}
+                {roundNumberToPrecision(min, 2)} - {roundNumberToPrecision(max, 2)}
               </td>
               <td>{coefficient}</td>
-              <td>{roundNumberToPrecision(normalized[`${num}-${den}`].val, 2)}</td>
-              <td>{roundNumberToPrecision(normalized[`${num}-${den}`].norm, 2)}</td>
+              <td>{roundNumberToPrecision(normalized[`${num}-${den}`].val, 3)}</td>
+              <td>{roundNumberToPrecision(normalized[`${num}-${den}`].norm, 3)}</td>
             </tr>
           );
         })}
         <tr>
           <td colSpan={5}>
-            <b className={s.result}>Result: {roundNumberToPrecision(resultMCDA, 2)}</b>
+            <b className={s.result}>Result: {roundNumberToPrecision(resultMCDA, 3)}</b>
           </td>
         </tr>
       </tbody>

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -4,10 +4,10 @@ import s from './PopupMCDA.module.css';
 import type { PopupMCDAProps } from '../types';
 
 function formatValue(value: number): string {
-  if (Math.abs(value) < 0.01 && Math.abs(value) > 0) {
-    return value.toExponential(2);
+  if (Math.abs(value) < 0.00001 && Math.abs(value) > 0) {
+    return value.toExponential(3);
   } else {
-    return value.toFixed(2);
+    return parseFloat(value.toFixed(3)).toString();
   }
 }
 

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -41,11 +41,11 @@ export function OneLayerPopup({
     <ul className={s.list}>
       <li>
         <span className={s.entryName}>{num}:</span>{' '}
-        {formatValue(normalized[key].numValue)}
+        {normalized[key].denValue ? formatValue(normalized[key].numValue) : '--'}
       </li>
       <li>
         <span className={s.entryName}>{den}:</span>{' '}
-        {formatValue(normalized[key].denValue)}
+        {normalized[key] ? formatValue(normalized[key].denValue) : '--'}
       </li>
       <li>
         <span className={s.entryName}>

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -34,13 +34,11 @@ export function OneLayerPopup({
     <ul className={s.list}>
       <li>
         <span className={s.entryName}>{num}:</span>{' '}
-        {normalized[key].denValue
-          ? roundNumberToPrecision(normalized[key].numValue, 5, 3)
-          : '--'}
+        {roundNumberToPrecision(normalized[key].numValue, 5, 3)}
       </li>
       <li>
         <span className={s.entryName}>{den}:</span>{' '}
-        {normalized[key] ? roundNumberToPrecision(normalized[key].denValue, 5, 3) : '--'}
+        {roundNumberToPrecision(normalized[key].denValue, 5, 3)}
       </li>
       <li>
         <span className={s.entryName}>

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -7,7 +7,7 @@ function formatValue(value: number): string {
   if (Math.abs(value) < 0.00001 && Math.abs(value) > 0) {
     return value.toExponential(3);
   } else {
-    return parseFloat(value.toFixed(3)).toString();
+    return Number.parseFloat(value.toFixed(3)).toString();
   }
 }
 

--- a/src/utils/common/roundNumberToPrecision.test.ts
+++ b/src/utils/common/roundNumberToPrecision.test.ts
@@ -5,11 +5,13 @@ describe('roundNumberToPrecision', () => {
   it('should round numbers to specified number of decimals', () => {
     expect(roundNumberToPrecision(0.0078, 3)).toEqual('0.008');
     expect(roundNumberToPrecision(-0.0078, 3)).toEqual('-0.008');
+    expect(roundNumberToPrecision(-0.02, 3)).toEqual('-0.020');
   });
 
-  it('should truncate trailing zeros', () => {
-    expect(roundNumberToPrecision(0.01, 3)).toEqual('0.01');
-    expect(roundNumberToPrecision(-0.01, 3)).toEqual('-0.01');
+  it('should remove trailing zeros if removeTrailingZeros === true', () => {
+    expect(roundNumberToPrecision(0.01, 3, true)).toEqual('0.01');
+    expect(roundNumberToPrecision(-0.01, 3, true)).toEqual('-0.01');
+    expect(roundNumberToPrecision(25.0, 3, true)).toEqual('25');
   });
 
   it('should return string in exponential notation if abs(value) is smaller than specified precision', () => {
@@ -19,8 +21,9 @@ describe('roundNumberToPrecision', () => {
   });
 
   it('should use exponentialDecimals parameter for exponential precision if it is specified', () => {
-    expect(roundNumberToPrecision(0.0025, 2, 1)).toEqual('2.5e-3');
-    expect(roundNumberToPrecision(-0.0025, 2, 2)).toEqual('-2.50e-3');
-    expect(roundNumberToPrecision(0.0025, 2, 4)).toEqual('2.5000e-3');
+    expect(roundNumberToPrecision(0.0025, 2, false, 1)).toEqual('2.5e-3');
+    expect(roundNumberToPrecision(0.0025, 2, true, 1)).toEqual('2.5e-3');
+    expect(roundNumberToPrecision(-0.0025, 2, false, 2)).toEqual('-2.50e-3');
+    expect(roundNumberToPrecision(0.0025, 2, false, 4)).toEqual('2.5000e-3');
   });
 });

--- a/src/utils/common/roundNumberToPrecision.test.ts
+++ b/src/utils/common/roundNumberToPrecision.test.ts
@@ -1,0 +1,26 @@
+import { expect, describe, it } from 'vitest';
+import { roundNumberToPrecision } from './roundNumberToPrecision';
+
+describe('roundNumberToPrecision', () => {
+  it('should round numbers to specified number of decimals', () => {
+    expect(roundNumberToPrecision(0.0078, 3)).toEqual('0.008');
+    expect(roundNumberToPrecision(-0.0078, 3)).toEqual('-0.008');
+  });
+
+  it('should truncate trailing zeros', () => {
+    expect(roundNumberToPrecision(0.01, 3)).toEqual('0.01');
+    expect(roundNumberToPrecision(-0.01, 3)).toEqual('-0.01');
+  });
+
+  it('should return string in exponential notation if abs(value) is smaller than specified precision', () => {
+    expect(roundNumberToPrecision(0.00758, 1)).toEqual('7.6e-3');
+    expect(roundNumberToPrecision(-0.00758, 1)).toEqual('-7.6e-3');
+    expect(roundNumberToPrecision(0.001, 2)).toEqual('1.00e-3');
+  });
+
+  it('should use exponentialDecimals parameter for exponential precision if it is specified', () => {
+    expect(roundNumberToPrecision(0.0025, 2, 1)).toEqual('2.5e-3');
+    expect(roundNumberToPrecision(-0.0025, 2, 2)).toEqual('-2.50e-3');
+    expect(roundNumberToPrecision(0.0025, 2, 4)).toEqual('2.5000e-3');
+  });
+});

--- a/src/utils/common/roundNumberToPrecision.test.ts
+++ b/src/utils/common/roundNumberToPrecision.test.ts
@@ -26,4 +26,10 @@ describe('roundNumberToPrecision', () => {
     expect(roundNumberToPrecision(-0.0025, 2, false, 2)).toEqual('-2.50e-3');
     expect(roundNumberToPrecision(0.0025, 2, false, 4)).toEqual('2.5000e-3');
   });
+
+  it('should return "NaN", "Infinity" acoordingly to the original value', () => {
+    expect(roundNumberToPrecision(NaN, 2)).toEqual('NaN');
+    expect(roundNumberToPrecision(Infinity, 2)).toEqual('Infinity');
+    expect(roundNumberToPrecision(-Infinity, 2)).toEqual('-Infinity');
+  });
 });

--- a/src/utils/common/roundNumberToPrecision.ts
+++ b/src/utils/common/roundNumberToPrecision.ts
@@ -12,7 +12,7 @@ import { isNumber } from './isNumber';
 export function roundNumberToPrecision(
   value: number,
   decimals: number,
-  removeTrailingZeros: boolean = false,
+  removeTrailingZeros = false,
   exponentialDecimals?: number,
 ): string {
   const precisionThreshold = Math.pow(10, -decimals);

--- a/src/utils/common/roundNumberToPrecision.ts
+++ b/src/utils/common/roundNumberToPrecision.ts
@@ -14,9 +14,6 @@ export function roundNumberToPrecision(
   removeTrailingZeros: boolean = false,
   exponentialDecimals?: number,
 ): string {
-  if (decimals < 0) {
-    console.error('decimals and exponentialDecimals argument must be between 0 and 100');
-  }
   const precisionThreshold = Math.pow(10, -decimals);
   if (Math.abs(value) < precisionThreshold && Math.abs(value) > 0) {
     return value.toExponential(

--- a/src/utils/common/roundNumberToPrecision.ts
+++ b/src/utils/common/roundNumberToPrecision.ts
@@ -11,6 +11,7 @@ import { isNumber } from './isNumber';
 export function roundNumberToPrecision(
   value: number,
   decimals: number,
+  removeTrailingZeros: boolean = false,
   exponentialDecimals?: number,
 ): string {
   if (decimals < 0) {
@@ -22,6 +23,8 @@ export function roundNumberToPrecision(
       isNumber(exponentialDecimals) ? exponentialDecimals : decimals,
     );
   } else {
-    return Number.parseFloat(value.toFixed(decimals)).toString();
+    return removeTrailingZeros
+      ? Number.parseFloat(value.toFixed(decimals)).toString()
+      : value.toFixed(decimals);
   }
 }

--- a/src/utils/common/roundNumberToPrecision.ts
+++ b/src/utils/common/roundNumberToPrecision.ts
@@ -4,8 +4,8 @@ import { isNumber } from './isNumber';
  * Rounds numerical value to specified number of digits after the decimal point.
  * If the value is smaller than specified precision (e.g. value = 0.009, decimals = 2), exponential notation is used.
  * @param value
- * @param decimals Number of digits after decimal comma.
- * @param exponentialDecimals (Optional) Number of digits after decimal point in exponential notation. If absent, decimals parameter is used instead.
+ * @param decimals Number of digits after decimal comma. Must be 0..100.
+ * @param exponentialDecimals (Optional) Number of digits after decimal point in exponential notation. Must be 0..100. If absent, decimals parameter is used instead.
  * @returns String representation of the number, either in fixed-point or in exponential notation.
  */
 export function roundNumberToPrecision(
@@ -13,10 +13,10 @@ export function roundNumberToPrecision(
   decimals: number,
   exponentialDecimals?: number,
 ): string {
-  let precisionThreshold = 1;
-  for (let i = 0; i < decimals; i++) {
-    precisionThreshold = precisionThreshold / 10;
+  if (decimals < 0) {
+    console.error('decimals and exponentialDecimals argument must be between 0 and 100');
   }
+  const precisionThreshold = Math.pow(10, -decimals);
   if (Math.abs(value) < precisionThreshold && Math.abs(value) > 0) {
     return value.toExponential(
       isNumber(exponentialDecimals) ? exponentialDecimals : decimals,

--- a/src/utils/common/roundNumberToPrecision.ts
+++ b/src/utils/common/roundNumberToPrecision.ts
@@ -1,0 +1,27 @@
+import { isNumber } from './isNumber';
+
+/**
+ * Rounds numerical value to specified number of digits after the decimal point.
+ * If the value is smaller than specified precision (e.g. value = 0.009, decimals = 2), exponential notation is used.
+ * @param value
+ * @param decimals Number of digits after decimal comma.
+ * @param exponentialDecimals (Optional) Number of digits after decimal point in exponential notation. If absent, decimals parameter is used instead.
+ * @returns String representation of the number, either in fixed-point or in exponential notation.
+ */
+export function roundNumberToPrecision(
+  value: number,
+  decimals: number,
+  exponentialDecimals?: number,
+): string {
+  let precisionThreshold = 1;
+  for (let i = 0; i < decimals; i++) {
+    precisionThreshold = precisionThreshold / 10;
+  }
+  if (Math.abs(value) < precisionThreshold && Math.abs(value) > 0) {
+    return value.toExponential(
+      isNumber(exponentialDecimals) ? exponentialDecimals : decimals,
+    );
+  } else {
+    return Number.parseFloat(value.toFixed(decimals)).toString();
+  }
+}

--- a/src/utils/common/roundNumberToPrecision.ts
+++ b/src/utils/common/roundNumberToPrecision.ts
@@ -5,6 +5,7 @@ import { isNumber } from './isNumber';
  * If the value is smaller than specified precision (e.g. value = 0.009, decimals = 2), exponential notation is used.
  * @param value
  * @param decimals Number of digits after decimal comma. Must be 0..100.
+ * @param removeTrailingZeros (Optional) If set to true, trailing zeros will be removed from the decimal part. Default: false.
  * @param exponentialDecimals (Optional) Number of digits after decimal point in exponential notation. Must be 0..100. If absent, decimals parameter is used instead.
  * @returns String representation of the number, either in fixed-point or in exponential notation.
  */


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Indicator-values-in-multivariate-popup-are-truncated-21303

<img width="931" alt="image" src="https://github.com/user-attachments/assets/b9b47f71-b036-4493-9823-3c1503048b0f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the display of numerical values in pop-up windows. Values now appear with enhanced precision: very small numbers use exponential notation with three decimals, while other numbers are rounded to three decimals for clearer, more consistent presentation.
- **Tests**
  - Introduced a suite of unit tests for the new rounding utility, covering various scenarios for rounding numbers to specified decimal places.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->