### PR TITLE
fix(21325): improve cookie banner mobile styles

### DIFF
--- a/src/features/cookie_consent_banner/components/CookieConsentBanner.module.css
+++ b/src/features/cookie_consent_banner/components/CookieConsentBanner.module.css
@@ -14,10 +14,19 @@
 
 .body {
   margin-bottom: var(--double-unit);
+  margin-top: var(--unit);
 }
 
 .buttonsRow {
   margin-top: var(--unit);
   display: flex;
+  flex-wrap: wrap;
   gap: var(--double-unit);
+}
+
+@media screen and (max-width: 960px) {
+  .cookieBanner {
+    padding: 25px;
+    left: var(--unit);
+  }
 }


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/The-cookie-bar-is-oddly-sized-in-mobile-mode-and-cannot-be-fully-visible-21325

### before
![image](https://github.com/user-attachments/assets/681e734b-5772-462d-8edb-8d92e6eb9275)

### How it should looks like now
![image](https://github.com/user-attachments/assets/4cee5022-5cb9-45d8-ad36-43487220b726)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced the cookie consent banner's appearance with improved spacing.
	- Introduced responsive adjustments for better display on screens up to 960px wide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->