### PR TITLE
feat(21382): remove trial button for logged in users

### DIFF
--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
@@ -127,6 +127,10 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+
+  &:empty {
+    margin: 0;
+  }
 }
 
 .subscribeButtonsWrapper {

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -78,18 +78,8 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
 
   const renderSubscribeButtons = (paypalPlanId: string) => {
     return currentSubscription?.billingPlanId !== paypalPlanId ? (
-      <div className={s.subscribeButtonsWrapper}>
-        <a
-          className={s.linkAsButton}
-          href={salesLink}
-          onClick={() => dispatchMetricsEvent('request_trial')}
-          target="_blank"
-          rel="noreferrer"
-          aria-label={i18n.t('subscription.request_trial_button')}
-        >
-          {i18n.t('subscription.request_trial_button')}
-        </a>
-        {!currentSubscription && (
+      !currentSubscription && (
+        <div className={s.subscribeButtonsWrapper}>
           <PayPalButtonsGroup
             billingPlanId={paypalPlanId}
             onSubscriptionApproved={(planId, subscriptionId) => {
@@ -102,8 +92,8 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
               }
             }}
           />
-        )}
-      </div>
+        </div>
+      )
     ) : (
       <Button disabled>{i18n.t('subscription.current_plan_button')}</Button>
     );


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/remove-Request-trial-button-from-plan-cards-21382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout by removing unnecessary margin from empty button wrappers.
- **Refactor**
  - Simplified the logic for displaying subscription action buttons, removing the trial request link and ensuring PayPal buttons only appear when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->