### PR TITLE
feat(21382): rename trial button -> demo button

### DIFF
--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -28,11 +28,6 @@ for (const project of projects) {
       await pageManager.atPricingPage.checkPageAndTextsAvailability();
       await pageManager.atPricingPage.clickBtnAndAssertUrl({
         context,
-        buttonName: 'Request trial',
-        expectedUrlPart: linkToSurveyProd,
-      });
-      await pageManager.atPricingPage.clickBtnAndAssertUrl({
-        context,
         buttonName: 'Book a demo',
         expectedUrlPart: linkToSurveyProd,
       });

--- a/e2e/registration.spec.ts
+++ b/e2e/registration.spec.ts
@@ -100,7 +100,7 @@ for (const [countryCode, fullPhone] of testedPhoneByCountry) {
         await pageManager.atPricingPage.checkPageAndTextsAvailability();
         await pageManager.atPricingPage.clickBtnAndAssertUrl({
           context,
-          buttonName: 'Request trial',
+          buttonName: 'Book a demo',
           expectedUrlPart: 'book-a-demo',
         });
         await pageManager.atNavigationMenu.clickButtonToOpenPage('Profile');

--- a/src/features/subscriptions/__mocks__/_subscriptionsConfig.ts
+++ b/src/features/subscriptions/__mocks__/_subscriptionsConfig.ts
@@ -87,7 +87,6 @@ export const config = {
       id: 'kontur_atlas_custom',
       name: 'Custom',
       style: 'custom',
-      actions: ['contact_sales', 'book_a_demo'], //
     },
   ],
 };

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.module.css
@@ -127,6 +127,10 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+
+  &:empty {
+    margin: 0;
+  }
 }
 
 .subscribeButtonsWrapper {

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -48,12 +48,9 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
   /** Get custom plan special properties */
   let planName;
   let description;
-  let demoLink;
   if (isCustomPlan) {
     planName = (content[0] as ReactElement).props.children[0];
     description = content[1];
-    demoLink = planConfig.actions?.find((action) => action.name === 'contact_sales')
-      ?.params.link;
   } else {
     description = content[0];
   }
@@ -139,10 +136,10 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
           href={salesLink}
           target="_blank"
           rel="noreferrer"
-          onClick={() => dispatchMetricsEvent('request_trial')}
-          aria-label={i18n.t('subscription.request_trial_button')}
+          onClick={() => dispatchMetricsEvent('book_demo')}
+          aria-label={i18n.t('subscription.book_demo_button')}
         >
-          {i18n.t('subscription.request_trial_button')}
+          {i18n.t('subscription.book_demo_button')}
         </a>
       )}
     </>
@@ -155,10 +152,10 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
           {i18n.t('subscription.sales_button')}
         </Button>
       )}
-      {demoLink && (
+      {salesLink && (
         <a
           className={s.linkAsButton}
-          href={demoLink}
+          href={salesLink}
           target="_blank"
           rel="noreferrer"
           onClick={() => dispatchMetricsEvent('book_demo')}

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -78,18 +78,8 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
 
   const renderSubscribeButtons = (paypalPlanId: string) => {
     return currentSubscription?.billingPlanId !== paypalPlanId ? (
-      <div className={s.subscribeButtonsWrapper}>
-        <a
-          className={s.linkAsButton}
-          href={salesLink}
-          onClick={() => dispatchMetricsEvent('request_trial')}
-          target="_blank"
-          rel="noreferrer"
-          aria-label={i18n.t('subscription.request_trial_button')}
-        >
-          {i18n.t('subscription.request_trial_button')}
-        </a>
-        {!currentSubscription && (
+      !currentSubscription && (
+        <div className={s.subscribeButtonsWrapper}>
           <PayPalButtonsGroup
             billingPlanId={paypalPlanId}
             onSubscriptionApproved={(planId, subscriptionId) => {
@@ -102,8 +92,8 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
               }
             }}
           />
-        )}
-      </div>
+        </div>
+      )
     ) : (
       <Button disabled>{i18n.t('subscription.current_plan_button')}</Button>
     );


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/remove-Request-trial-button-from-plan-cards-21382

Result: 
![image](https://github.com/user-attachments/assets/6504747b-f3d6-4b10-a696-67a16470c9eb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the button on the pricing page for the "atlas" project to "Book a demo," with corresponding changes to button labels, event tracking, and navigation flow.
- **Bug Fixes**
	- Unified and simplified the logic for sales/demo links, ensuring consistent behavior and labeling across the app.
- **Tests**
	- Adjusted end-to-end tests to reflect the new "Book a demo" flow and removed outdated steps related to the "Request trial" button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->