### PR TITLE
Pass icon rotation as-is

### DIFF
--- a/src/utils/map/mapCSSToMapBoxPropertiesConverter/config.ts
+++ b/src/utils/map/mapCSSToMapBoxPropertiesConverter/config.ts
@@ -154,7 +154,30 @@ export const MAP_CSS_MAPBOX = {
     name: 'symbol-placement',
     valueConverter: null,
   },
-
+  'icon-rotate': {
+    type: 'symbol',
+    category: 'layout',
+    name: 'icon-rotate',
+    valueConverter: null,
+  },
+  'symbol-z-order': {
+    type: 'symbol',
+    category: 'layout',
+    name: 'symbol-z-order',
+    valueConverter: null,
+  },
+  'icon-allow-overlap': {
+    type: 'symbol',
+    category: 'layout',
+    name: 'icon-allow-overlap',
+    valueConverter: null,
+  },
+  'icon-rotation-alignment': {
+    type: 'symbol',
+    category: 'layout',
+    name: 'icon-rotation-alignment',
+    valueConverter: null,
+  },
   // font
   'font-family': {
     type: 'symbol',


### PR DESCRIPTION
We'd love to be able to rotate the aircraft.
![image](https://github.com/user-attachments/assets/86aa1b6d-0451-4ffa-96b5-54d3888309c1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for additional symbol layout properties, allowing for enhanced customization of map symbols, including icon rotation, overlap handling, z-order, and rotation alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->