### PR TITLE
Fix router redirect on reload

### DIFF
--- a/src/core/router/components/Router.tsx
+++ b/src/core/router/components/Router.tsx
@@ -111,8 +111,13 @@ function initRouter() {
 
   // if landing redirect is not needed
   // check if user is logged in and doesn't have access to map (means no subscription)
-  // and redirect to pricing page
-  if (initialRedirect === false && isAuthenticated && !isMapFeatureEnabled) {
+  // and redirect to pricing page, but only when no route was matched
+  if (
+    initialRedirect === false &&
+    router.state.matches.length < 2 &&
+    isAuthenticated &&
+    !isMapFeatureEnabled
+  ) {
     const pricingRoute = availableRoutes.routes.find((r) => r.id === 'pricing');
     if (pricingRoute) {
       initialRedirect = pricingRoute.slug;


### PR DESCRIPTION
## Summary
- avoid redirecting to pricing page if a route already matches during reloads

https://kontur.fibery.io/Tasks/Task/routing-Reloading-the-profile-page-opens-pricing-tab-for-user-with-no-subscription-19964

## Testing
- `pnpm lint` *(fails: npm-run-all not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved redirect behavior for authenticated users without map access, ensuring they are only redirected to the pricing page when no other route is matched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->