### PR TITLE
fix(preview): 21126 Fix screenshot readiness event

### DIFF
--- a/src/core/metrics/app-metrics.ts
+++ b/src/core/metrics/app-metrics.ts
@@ -177,27 +177,25 @@ export class AppMetrics implements Metric {
 
       if (Object.values(this.watchList).every(Boolean)) {
         // watchList completed
-        if (name !== EVENT_MAP_IDLE) {
-          if (KONTUR_METRICS_DEBUG) {
-            console.warn('metrics waitForMapFullyRendered', this.watchList);
-          }
-          waitForMapFullyRendered(globalThis?.KONTUR_MAP, { timeout: 30000 })
-            .then(() => {
-              const timing = performance.now();
-              this.report('ready', timing);
-              const eventReadyEvent = new Event('event_ready_for_screenshot');
-              globalThis.dispatchEvent(eventReadyEvent);
-            })
-            .catch((error) => {
-              console.error('Map render detection failed:', error);
-            })
-            .finally(() => {
-              this.cleanup();
-              this.sendReports();
-            });
-
-          globalThis?.KONTUR_MAP?.triggerRepaint();
+        if (KONTUR_METRICS_DEBUG) {
+          console.warn('metrics waitForMapFullyRendered', this.watchList);
         }
+        waitForMapFullyRendered(globalThis?.KONTUR_MAP, { timeout: 30000 })
+          .then(() => {
+            const timing = performance.now();
+            this.report('ready', timing);
+            const eventReadyEvent = new Event('event_ready_for_screenshot');
+            globalThis.dispatchEvent(eventReadyEvent);
+          })
+          .catch((error) => {
+            console.error('Map render detection failed:', error);
+          })
+          .finally(() => {
+            this.cleanup();
+            this.sendReports();
+          });
+
+        globalThis?.KONTUR_MAP?.triggerRepaint();
       }
       this.report(name, timing);
     }

--- a/src/features/layers_in_area/atoms/areaLayersControls.ts
+++ b/src/features/layers_in_area/atoms/areaLayersControls.ts
@@ -4,6 +4,7 @@ import { getLayerRenderer } from '~core/logical_layers/utils/getLayerRenderer';
 import { createUpdateActionsFromLayersDTO } from '~core/logical_layers/utils/createUpdateActionsFromLayersDTO';
 import { layersInAreaAndEventLayerResource } from './layersInAreaAndEventLayerResource';
 import { layersGlobalResource } from './layersGlobalResource';
+import { dispatchMetricsEventOnce } from '~core/metrics/dispatch';
 import type { LayerSummaryDto } from '~core/logical_layers/types/source';
 import type { Action } from '@reatom/core-v2';
 
@@ -104,6 +105,8 @@ export const areaLayersControlsAtom = createAtom(
           dispatch(actions);
         });
       }
+
+      dispatchMetricsEventOnce('allLayers', nextLayers.length > 0);
     });
   },
   'areaLayersControlsAtom',

--- a/src/features/layers_in_area/atoms/layersGlobalResource.ts
+++ b/src/features/layers_in_area/atoms/layersGlobalResource.ts
@@ -1,12 +1,15 @@
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
 import { filterUnsupportedLayerTypes } from '~core/logical_layers/layerTypes';
 import { getGlobalLayers } from '~core/api/layers';
+import { dispatchMetricsEventOnce } from '~core/metrics/dispatch';
 
 export const layersGlobalResource = createAsyncAtom(
   null,
   async (_, abortController) => {
     const layers = await getGlobalLayers(abortController);
-    return filterUnsupportedLayerTypes(layers || []);
+    const filteredLayers = filterUnsupportedLayerTypes(layers || []);
+    dispatchMetricsEventOnce('layersGlobalResource', filteredLayers.length > 0);
+    return filteredLayers;
   },
   'layersGlobalResource',
 );


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Event-Preview-Image-Generator-Map-takes-not-all-size-of-the-preview-21126

## Summary
- fire screenshot readiness even when map idle finishes
- report when global layers are loaded
- report when map layers list is ready

## Testing
- `pnpm test:unit --run` *(fails: tsx not found)*
- `pnpm lint` *(fails: npm-run-all not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Metrics events are now dispatched to track the presence of layers and global resources in the application.
- **Other Changes**
	- Map rendering readiness and related metrics reporting now occur consistently, regardless of specific event names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->