### PR TITLE
Fix markdown media overflow on mobile

### DIFF
--- a/src/core/pages/pages.css
+++ b/src/core/pages/pages.css
@@ -135,6 +135,17 @@
     -webkit-user-drag: none;
   }
 
+  /* Ensure media fits within the viewport */
+  & img,
+  & iframe {
+    max-width: 100%;
+  }
+
+  & iframe {
+    width: 100%;
+    height: auto;
+  }
+
   /* button-like appearance inside Hx STRONG: # **[]()** */
   & :where(h1, h2, h3, h4, h5, h6) strong {
     & a {


### PR DESCRIPTION
## Summary
- ensure images and iframes scale to fit viewport within markdown pages

## Testing
- `pnpm lint:css` *(fails: stylelint not found)*
- `pnpm test:unit` *(fails: tsx not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the responsiveness of images and iframes within markdown content, ensuring they scale properly and do not exceed the viewport width for a better viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->