### PR TITLE
Add Google login

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -364,6 +364,8 @@
     "log_in": "Log in",
     "forgot_password": "Forgot password?",
     "description": "Please log in to change your settings",
+    "google_login": "Sign in with Google",
+    "use_email": "Use email",
     "error": {
       "email_empty": "Email cannot be empty",
       "email_invalid": "Email has to be valid",

--- a/src/core/metrics/externalMetrics/googleEventsList.ts
+++ b/src/core/metrics/externalMetrics/googleEventsList.ts
@@ -4,6 +4,7 @@ export const GA4_EVENTS = [
   'login_success',
   'login_failure',
   'sign_up',
+  'google_login',
 
   // Profile management events
   'profile_save',

--- a/src/features/user_profile/components/LoginForm/LoginForm.tsx
+++ b/src/features/user_profile/components/LoginForm/LoginForm.tsx
@@ -17,6 +17,12 @@ const registrationUrlEncoded = encodeURIComponent(
 );
 const registrationUrl = `${configRepo.get().keycloakUrl}/realms/${configRepo.get().keycloakRealm}/protocol/openid-connect/logout?client_id=account&redirect_uri=${registrationUrlEncoded}`;
 const resetUrl = `${configRepo.get().keycloakUrl}/realms/${configRepo.get().keycloakRealm}/login-actions/reset-credentials?client_id=account`;
+const googleRedirectUri = encodeURIComponent(
+  `${window.location.origin}${configRepo
+    .get()
+    .baseUrl.replace(/\/$/, '')}/profile`,
+);
+const googleLoginUrl = `${configRepo.get().keycloakUrl}/realms/${configRepo.get().keycloakRealm}/protocol/openid-connect/auth?client_id=${configRepo.get().keycloakClientId}&redirect_uri=${googleRedirectUri}&response_type=code&scope=openid&kc_idp_hint=google`;
 
 export function LoginForm() {
   const [error, setError] = useState<{
@@ -56,6 +62,10 @@ export function LoginForm() {
     [],
   );
   const onSignUpClick = useCallback(() => dispatchMetricsEvent('sign_up'), []);
+  const onGoogleLoginClick = useCallback(
+    () => dispatchMetricsEvent('google_login'),
+    [],
+  );
 
   const onLoginClick = useCallback(async () => {
     const err: { email?: string; password?: string; general?: string } = {};
@@ -116,6 +126,20 @@ export function LoginForm() {
       <Heading type="heading-01">{i18n.t('login.log_in')}</Heading>
       <div className={s.loginDescription}>
         <Text type="short-m">{i18n.t('login.description')}</Text>
+      </div>
+      <div className={s.socialLoginContainer}>
+        <a
+          href={googleLoginUrl}
+          onClick={onGoogleLoginClick}
+          className={s.socialButton}
+        >
+          {i18n.t('login.google_login')}
+        </a>
+      </div>
+      <div className={s.useEmailLabelContainer}>
+        <Text type="short-s" className={s.useEmailLabel}>
+          {i18n.t('login.use_email')}
+        </Text>
       </div>
       <div className={s.inputsContainer}>
         <Input


### PR DESCRIPTION
## Summary
- add Google login URL in LoginForm
- add GA4 event for `google_login`
- expose Google login text in i18n

## Testing
- `pnpm test:unit` *(fails: tsx not found)*
- `pnpm lint` *(fails: npm-run-all not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Sign in with Google" option to the login form, allowing users to log in using their Google account.
  - Introduced a clear "Use email" label to distinguish between Google login and email/password login methods.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->