### PR TITLE
feat(popup): 21712 show "Normalized value" in hex popups for normalized/transformed layers

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -180,7 +180,7 @@
     "labels": "Labels"
   },
   "map_popup": {
-    "value": "value",
+    "value": "Value",
     "range": "Range",
     "coefficient": "Coefficient",
     "normalized_value": "Normalized value"

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -18,6 +18,7 @@
   "horizontal_direction": "Horizontal direction",
   "legend_presentation": "Legend presentation",
   "layers": "Layers",
+  "layer": "Layer",
   "toolbar": {
     "map_ruler": "Measure distance",
     "locate_me": "Locate me",
@@ -177,6 +178,12 @@
     "compare": "Compare",
     "hide_area": "Hide area",
     "labels": "Labels"
+  },
+  "map_popup": {
+    "value": "value",
+    "range": "Range",
+    "coefficient": "Coefficient",
+    "normalized_value": "Normalized value"
   },
   "search": {
     "search_location": "Search location",

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 import { capitalize } from '~utils/common';
 import { roundNumberToPrecision } from '~utils/common/roundNumberToPrecision';
+import { i18n } from '~core/localization';
 import s from './PopupMCDA.module.css';
+import type { MCDALayer } from '../../stylesConfigs/mcda/types';
 import type { PopupMCDAProps } from '../types';
 
-export function OneLayerPopup({
+function OneLayerPopup({
   layer,
   normalized,
   resultMCDA,
@@ -18,32 +20,29 @@ export function OneLayerPopup({
     };
   };
   resultMCDA: number;
-  layer: {
-    axis: [string, string];
-    range: [number, number];
-    sentiment: [string, string];
-    coefficient: number;
-  };
+  layer: MCDALayer;
 }) {
   const key = `${layer.axis[0]}-${layer.axis[1]}`;
-  const [num, den] = useMemo(
+  const [numLabel, denLabel] = useMemo(
     () => layer.axis.map((ax) => capitalize(ax.replaceAll('_', ' '))),
     [layer],
   );
+  const resultLabel =
+    layer.normalization === 'no' && layer.transformation?.transformation === 'no'
+      ? `${numLabel} / ${denLabel}`
+      : i18n.t('map_popup.normalized_value');
   return (
     <ul className={s.list}>
       <li>
-        <span className={s.entryName}>{num}:</span>{' '}
+        <span className={s.entryName}>{numLabel}:</span>{' '}
         {roundNumberToPrecision(normalized[key].numValue, 3, false, 2)}
       </li>
       <li>
-        <span className={s.entryName}>{den}:</span>{' '}
+        <span className={s.entryName}>{denLabel}:</span>{' '}
         {roundNumberToPrecision(normalized[key].denValue, 3, false, 2)}
       </li>
       <li>
-        <span className={s.entryName}>
-          {num} / {den}:
-        </span>{' '}
+        <span className={s.entryName}>{resultLabel}:</span>{' '}
         {roundNumberToPrecision(resultMCDA, 2, true)}
       </li>
     </ul>
@@ -51,16 +50,16 @@ export function OneLayerPopup({
 }
 
 type MultiLayerPopup = PopupMCDAProps;
-export function MultiLayerPopup({ layers, normalized, resultMCDA }: MultiLayerPopup) {
+function MultiLayerPopup({ layers, normalized, resultMCDA }: MultiLayerPopup) {
   return (
     <table>
       <thead>
         <tr>
-          <th>Layer</th>
-          <th>Range</th>
-          <th>Coefficient</th>
-          <th>Value</th>
-          <th>Normalized Value</th>
+          <th>{i18n.t('layer')}</th>
+          <th>{i18n.t('map_popup.range')}</th>
+          <th>{i18n.t('map_popup.coefficient')}</th>
+          <th>{i18n.t('map_popup.value')}</th>
+          <th>{i18n.t('map_popup.normalized_value')}</th>
         </tr>
       </thead>
       <tbody className={s.tableBody}>

--- a/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
+++ b/src/core/logical_layers/renderers/MCDARenderer/components/PopupMCDA.tsx
@@ -23,14 +23,18 @@ function OneLayerPopup({
   layer: MCDALayer;
 }) {
   const key = `${layer.axis[0]}-${layer.axis[1]}`;
-  const [numLabel, denLabel] = useMemo(
-    () => layer.axis.map((ax) => capitalize(ax.replaceAll('_', ' '))),
-    [layer],
-  );
-  const resultLabel =
-    layer.normalization === 'no' && layer.transformation?.transformation === 'no'
-      ? `${numLabel} / ${denLabel}`
-      : i18n.t('map_popup.normalized_value');
+
+  const { numLabel, denLabel, resultLabel } = useMemo(() => {
+    const [numLabel, denLabel] = layer.axis.map((ax) =>
+      capitalize(ax.replaceAll('_', ' ')),
+    );
+    const resultLabel =
+      layer.normalization === 'no' && layer.transformation?.transformation === 'no'
+        ? `${numLabel} / ${denLabel}`
+        : i18n.t('map_popup.normalized_value');
+    return { numLabel, denLabel, resultLabel };
+  }, [layer]);
+
   return (
     <ul className={s.list}>
       <li>


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/MCDA-popup-show-Normalized-value-label-for-normalized-layers-21712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved map popup interface with newly localized labels for values, ranges, coefficients, and normalized values.
  - Added support for singular and plural forms of "layer" in the user interface.

- **Style**
  - Enhanced clarity of popup labels for map layers.

- **Bug Fixes**
  - Replaced hardcoded popup text with localized translations for better internationalization support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->