### PR TITLE
fix(21755): Fix OSM editor field visibility

### DIFF
--- a/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
+++ b/src/features/user_profile/components/SettingsForm/SettingsForm.tsx
@@ -277,16 +277,18 @@ function SettingsFormGen({ userProfile, updateUserProfile }) {
                   />
                 )}
 
-                <Select
-                  data-testid="osmEditor"
-                  alwaysShowPlaceholder
-                  value={localSettings.osmEditor || DEFAULT_OSM_EDITOR}
-                  items={OPTIONS_OSM}
-                  withResetButton={false}
-                  onSelect={onChange('osmEditor')}
-                >
-                  {i18n.t('profile.defaultOSMeditor')}
-                </Select>
+                {featureFlags[AppFeature.OSM_EDIT_LINK] && (
+                  <Select
+                    data-testid="osmEditor"
+                    alwaysShowPlaceholder
+                    value={localSettings.osmEditor || DEFAULT_OSM_EDITOR}
+                    items={OPTIONS_OSM}
+                    withResetButton={false}
+                    onSelect={onChange('osmEditor')}
+                  >
+                    {i18n.t('profile.defaultOSMeditor')}
+                  </Select>
+                )}
 
                 <div>
                   <Text type="short-l" className={stylesV1.smallTitle}>


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Default-OSM-editor-selector-is-present-on-apps-without-osm_edit_link-feature-21755

## Summary
- hide default OSM editor field on profile page when `osm_edit_link` feature is disabled

## Testing
- `pnpm lint` *(fails: npm-run-all not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The option to select an OpenStreetMap editor in the settings form is now only visible when the related feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->