### PR TITLE
fix(router): 19964 prevent pricing redirect on profile reload

### DIFF
--- a/e2e/reloadWithUser.spec.ts
+++ b/e2e/reloadWithUser.spec.ts
@@ -40,10 +40,6 @@ for (const project of projects) {
     }
     test('My profile has the same data', async ({ pageManager }) => {
       test.fixme(
-        project.name === 'atlas',
-        'Fix https://kontur.fibery.io/Tasks/Task/routing-Reloading-the-profile-page-opens-pricing-tab-for-user-with-no-subscription-19964 to unblock atlas test',
-      );
-      test.fixme(
         project.name === 'oam',
         'Fix https://kontur.fibery.io/Tasks/Task/reopen-routing-oam-url-param-map-2.122--0.000-0.000-is-opened-first-instead-of-map-2.122-0.000-0.000-21381 to unblock oam test',
       );

--- a/src/core/router/components/Router.tsx
+++ b/src/core/router/components/Router.tsx
@@ -111,8 +111,13 @@ function initRouter() {
 
   // if landing redirect is not needed
   // check if user is logged in and doesn't have access to map (means no subscription)
-  // and redirect to pricing page
-  if (initialRedirect === false && isAuthenticated && !isMapFeatureEnabled) {
+  // and redirect to pricing page only if user opened the root page
+  if (
+    initialRedirect === false &&
+    router.state.matches.length < 2 &&
+    isAuthenticated &&
+    !isMapFeatureEnabled
+  ) {
     const pricingRoute = availableRoutes.routes.find((r) => r.id === 'pricing');
     if (pricingRoute) {
       initialRedirect = pricingRoute.slug;


### PR DESCRIPTION
## Summary
- avoid redirecting to pricing on profile reload
- re-enable profile reload test for user with no subscription

Fibery link: https://kontur.fibery.io/Tasks/Task/19964


------
https://chatgpt.com/codex/tasks/task_e_683d99dd9cd883248803768c56079c38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the redirect behavior for authenticated users without map access, ensuring they are only redirected to the pricing page when opening the root page.

- **Tests**
  - Unblocked the test for verifying profile data consistency after reload for one user project, while keeping it marked as needing a fix for another project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->