### PR TITLE
fix(Layers panel): 21754 Fix enabling/disabling different layers with the same name

### DIFF
--- a/src/components/Layer/index.tsx
+++ b/src/components/Layer/index.tsx
@@ -83,6 +83,7 @@ export function Layer({
       onChange={onChange}
       enabled={layerState.isEnabled}
       hidden={!layerState.isVisible}
+      id={layerState.id}
       name={layerState.settings?.name || layerState.id}
       icon={
         // Add inline legend

--- a/src/components/LayerControl/LayerControl.tsx
+++ b/src/components/LayerControl/LayerControl.tsx
@@ -5,6 +5,7 @@ import type { LayerLegend } from '~core/logical_layers/types/legends';
 
 interface LayerControl {
   inputType: 'radio' | 'checkbox' | 'not-interactive';
+  id: string;
   name: string;
   icon?: JSX.Element | false;
   isLoading?: boolean;
@@ -19,6 +20,7 @@ interface LayerControl {
 
 export function LayerControl({
   inputType,
+  id,
   icon,
   hidden,
   name,
@@ -49,7 +51,7 @@ export function LayerControl({
       )}
     >
       <LayerInput
-        id={name}
+        id={id}
         type={inputType}
         enabled={enabled}
         label={Label}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Layers-are-identified-by-name-instead-of-id-when-enabled-disabled-in-Layers-panel-21754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated layer controls to use a unique identifier for each input element, improving accessibility and interaction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->