### PR TITLE
fix(draw):  20695 ensure lines visible on mobile

### DIFF
--- a/src/core/draw_tools/configs/drawLine.ts
+++ b/src/core/draw_tools/configs/drawLine.ts
@@ -15,6 +15,7 @@ export const drawLineDeckLayerConfig = {
     guides: {
       getLineWidth: 4,
       getLineColor: [60, 120, 20, 120],
+      lineWidthUnits: 'pixels',
     },
   },
 

--- a/src/core/draw_tools/configs/drawPolyLayer.ts
+++ b/src/core/draw_tools/configs/drawPolyLayer.ts
@@ -16,6 +16,7 @@ export const drawPolyDeckLayerConfig = {
       getFillColor: [40, 150, 20, 70],
       getLineWidth: 3,
       getLineColor: [60, 120, 20, 120],
+      lineWidthUnits: 'pixels',
     },
   },
   modeConfig: {

--- a/src/core/draw_tools/configs/modifyLayer.ts
+++ b/src/core/draw_tools/configs/modifyLayer.ts
@@ -16,6 +16,7 @@ export const modifyDeckLayerConfig = {
       getFillColor: [30, 60, 20, 120],
       getLineWidth: 2,
       getLineColor: [20, 20, 10, 140],
+      lineWidthUnits: 'pixels',
     },
     geojson: {
       getFillColor: (a) => {

--- a/src/core/draw_tools/readme.md
+++ b/src/core/draw_tools/readme.md
@@ -30,6 +30,8 @@ flowchart TD
 - [combinedAtom.addFeature](./atoms/combinedAtom.ts#L93)
 - [drawnGeometryAtom.addFeature](./atoms/drawnGeometryAtom.ts#L19)
 
+All drawing guides use `lineWidthUnits: 'pixels'` to make lines visible on high-resolution mobile screens.
+
 ## v2 (planning)
 
 based on: @deck.gl-community/editable-layers (deck.gl v9+, maplibre v3+, webgl2)

--- a/src/features/map_ruler/readme.md
+++ b/src/features/map_ruler/readme.md
@@ -23,6 +23,6 @@ This features renderer is a custom renderer ([read more about renderers](https:/
 On mount:
 
 1. DeckGl config is used to create new map layer. The point of this is to describe what to draw, which way and how to handle user interaction events. You can read more about [Deck Gl geojson layer props](https://deck.gl/docs/api-reference/layers/geojson-layer), [Composite layer props](https://deck.gl/docs/api-reference/core/composite-layer) to understand configs described in `MapRulerRenderer`. You can also read about [NebulaGl geojson layer](https://nebula.gl/docs/api-reference/layers/editable-geojson-layer) we're alterating and see it's [source code](https://github.com/uber/nebula.gl/blob/master/modules/layers/src/layers/editable-geojson-layer.ts) to see what methods we're changing
-
-2. Map layer being added on the map with a help of `layerByOrder` utility
-3. Map click and move listeners added on top of other following map listeners preventing the latter
+2. Lines are rendered with `lineWidthUnits` set to `pixels` to keep them visible on mobile devices
+3. Map layer being added on the map with a help of `layerByOrder` utility
+4. Map click and move listeners added on top of other following map listeners preventing the latter

--- a/src/features/map_ruler/renderers/MapRulerRenderer.ts
+++ b/src/features/map_ruler/renderers/MapRulerRenderer.ts
@@ -61,6 +61,7 @@ export class MapRulerRenderer extends LogicalLayerDefaultRenderer {
           guides: {
             getFillColor: () => [0xff, 0x66, 0x00, 0xff],
             getLineWidth: () => 2,
+            lineWidthUnits: 'pixels',
             stroked: false,
             pointRadiusMinPixels: 4,
             pointRadiusMaxPixels: 4,


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Ruler-does-not-show-the-line-on-mobile-20695

## Summary
- adjust guide configs to use pixel line width units
- document pixel units for mobile rendering

## Testing
- `pnpm run lint` *(fails: npm-run-all not found)*
- `pnpm run test:unit` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487d431df48324b66295adb8b82a6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved visibility of drawing guides and ruler lines on high-resolution mobile screens by explicitly setting line width units to pixels.

- **Documentation**
  - Updated documentation to clarify that drawing guides and map ruler lines use pixel units for line width, ensuring better visibility on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->