### PR TITLE
fix(layers): 21898 Don't pull layers from layers/search/user endpoint into areaLayersControls

### DIFF
--- a/src/features/layers_in_area/atoms/areaLayersControls.ts
+++ b/src/features/layers_in_area/atoms/areaLayersControls.ts
@@ -2,7 +2,6 @@ import { createAtom } from '~utils/atoms/createPrimitives';
 import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
 import { getLayerRenderer } from '~core/logical_layers/utils/getLayerRenderer';
 import { createUpdateActionsFromLayersDTO } from '~core/logical_layers/utils/createUpdateActionsFromLayersDTO';
-import { editableLayersListResource } from '~features/create_layer/atoms/editableLayersListResource';
 import { layersInAreaAndEventLayerResource } from './layersInAreaAndEventLayerResource';
 import { layersGlobalResource } from './layersGlobalResource';
 import type { LayerSummaryDto } from '~core/logical_layers/types/source';
@@ -12,13 +11,11 @@ const allLayers = createAtom(
   {
     layersGlobalResource,
     layersInAreaAndEventLayerResource,
-    editableLayersListResource,
   },
   ({ get }) => {
     return [
       ...(get('layersGlobalResource').data ?? []),
       ...(get('layersInAreaAndEventLayerResource').data ?? []),
-      ...(get('editableLayersListResource').data ?? []),
     ];
   },
   'allLayers',


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Layers-from-search-user-are-displayed-in-Layers-panel-on-Disaster-Ninja-21898

Pulling user layers was added in recent User Layers flow PR, seemingly by mistake:
https://github.com/konturio/disaster-ninja-fe/pull/1049/files#diff-a351537e74f7d2d47b829ee27a202c6d3d0cde0b7626c6c451fed888844cda3d

![image](https://github.com/user-attachments/assets/3500cb01-c96f-4cb0-acde-10d3356e626d)