### PR TITLE
feat(live_sensor): 0000 show stop label while recording

### DIFF
--- a/src/features/live_sensor/index.ts
+++ b/src/features/live_sensor/index.ts
@@ -11,7 +11,11 @@ export const liveSensorsControl = toolbar.setupControl<{
   id: SENSOR_CONTROL_ID,
   type: 'button',
   typeSettings: {
-    name: i18n.t('toolbar.record_sensors'),
+    name: {
+      regular: i18n.t('toolbar.record_sensors'),
+      active: i18n.t('live_sensor.finish'),
+      disabled: i18n.t('toolbar.record_sensors'),
+    },
     hint: {
       regular: i18n.t('live_sensor.start'),
       active: i18n.t('live_sensor.finish'),

--- a/src/features/live_sensor/readme.md
+++ b/src/features/live_sensor/readme.md
@@ -2,6 +2,10 @@
 
 This feature designed to collect user sensor data and send it to remote endpoint
 
+## UI
+
+The toolbar contains **Record sensors** button. Once recording starts the button label changes to **Stop sensor recording**, so pressing it will stop recording.
+
 ## Working logic
 
 The main controller is `LiveSensor`.


### PR DESCRIPTION
Fibery ticket: 0000

## Summary
- show "Stop sensor recording" label when sensor recording is active
- document new toolbar button behaviour

## Testing
- `pnpm test:unit`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68493682c74c8324b7f49ecbfd329d27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Toolbar button for live sensor control now displays different labels depending on its state (e.g., "Record sensors" and "Stop sensor recording") for improved clarity.

- **Documentation**
  - Updated documentation to describe the new toolbar button behavior and label changes for the live sensor feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->