### PR TITLE
fix(url_store): 21381 convert coordinates with absolute value < 0.001 to 0.000

### DIFF
--- a/src/core/url_store/dataInURLEncoder.test.ts
+++ b/src/core/url_store/dataInURLEncoder.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, describe } from 'vitest';
 import { URLDataInSearchEncoder } from './dataInURLEncoder';
+import { urlEncoder } from './encoder';
 
 describe('Decode search query components', () => {
   test('With custom transformers', () => {
@@ -91,4 +92,9 @@ test('Work without losses', () => {
   });
 
   expect(codec.decode(codec.encode(data))).toStrictEqual(data);
+});
+
+test('Coordinates with absolute value < 0.001 are converted to 0.000', () => {
+  const data = urlEncoder.encode({ map: [2, -0.0001, 0.00004] });
+  expect(data).toBe('map=3.000/0.000/0.000');
 });

--- a/src/core/url_store/encoder.ts
+++ b/src/core/url_store/encoder.ts
@@ -20,11 +20,14 @@ export const urlEncoder = new URLDataInSearchEncoder({
       encode: (position: MapPosition): string => {
         const [zoom, lat, lng] = position;
         const precision = Math.max(3, Math.ceil(Math.log(zoom) / Math.LN2));
+        const formatCoordinate = (n: number) => {
+          const fixedPointNumber = Number(n.toFixed(precision));
+          return (fixedPointNumber === -0 ? 0 : fixedPointNumber).toFixed(precision);
+        };
         return [
           (zoom + URL_ZOOM_OFFSET).toFixed(3),
-          // Add + 0 to normalize -0/+0 before formatting
-          (lat + 0).toFixed(precision),
-          (lng + 0).toFixed(precision),
+          formatCoordinate(lat),
+          formatCoordinate(lng),
         ].join('/');
       },
     },

--- a/src/core/url_store/encoder.ts
+++ b/src/core/url_store/encoder.ts
@@ -22,7 +22,10 @@ export const urlEncoder = new URLDataInSearchEncoder({
         const precision = Math.max(3, Math.ceil(Math.log(zoom) / Math.LN2));
         const formatCoordinate = (n: number) => {
           const fixedPointNumber = Number(n.toFixed(precision));
-          return (fixedPointNumber === -0 ? 0 : fixedPointNumber).toFixed(precision);
+          // convert -0 to 0 if needed
+          return (Object.is(fixedPointNumber, -0) ? 0 : fixedPointNumber).toFixed(
+            precision,
+          );
         };
         return [
           (zoom + URL_ZOOM_OFFSET).toFixed(3),


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/reopen-routing-oam-url-param-map-2.122--0.000-0.000-is-opened-first-instead-of-map-2.122-0.000-0.000-21381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the formatting of map coordinates in URLs to ensure very small values are rounded and consistently displayed as "0.000" when close to zero, preventing negative zero representations.

- **Tests**
	- Added a test to verify that small coordinate values are correctly rounded and encoded as "0.000" in the URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->