### PR TITLE
fix(21474): Gray elements disappeared after glass theme implementation

### DIFF
--- a/src/styles/glass-theme.css
+++ b/src/styles/glass-theme.css
@@ -12,7 +12,7 @@
     box-shadow: var(--shadow-small);
     border-radius: 8px;
 
-    --faint-weak: none;
+    --faint-weak: #eceeef;
     --accent-weak: #0516260f;
     --base-weak-up: #0516260f;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated background color for certain panels and the search bar on large screens to a light gray shade for improved visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->