### PR TITLE
fix: 18918 AI Insights h1/h2 font size

### DIFF
--- a/src/core/pages/pages.css
+++ b/src/core/pages/pages.css
@@ -168,8 +168,7 @@
 }
 
 /* Normalize AI Insights heading sizes */
-#app-pages-docid-llm_analytics .app-pages-element-markdown h1,
-#app-pages-docid-llm_analytics .app-pages-element-markdown h2 {
+#app-pages-docid-llm_analytics .app-pages-element-markdown :is(h1, h2) {
   font-size: 1.17em;
   line-height: 1.4;
 }

--- a/src/core/pages/pages.css
+++ b/src/core/pages/pages.css
@@ -166,3 +166,10 @@
     }
   }
 }
+
+/* Normalize AI Insights heading sizes */
+#app-pages-docid-llm_analytics .app-pages-element-markdown h1,
+#app-pages-docid-llm_analytics .app-pages-element-markdown h2 {
+  font-size: 1.17em;
+  line-height: 1.4;
+}


### PR DESCRIPTION
Fibery ticket: [18918](https://kontur.fibery.io/Tasks/Task/18918)

## Summary
- clamp H1/H2 fonts for LLM analytics markdown so headers stay consistent

## Testing
- `pnpm install`
- `pnpm test:unit` *(fails: watch mode ended via Ctrl+C but all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_686045e28f10832fbb6c0743e81bf3dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated heading styles for improved consistency within specific documentation pages. H1 and H2 headings now have a uniform font size and line height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->