### PR TITLE
fix(reports): 19207 open josm links via window

### DIFF
--- a/src/features/reports/components/ReportTable/TableCell.tsx
+++ b/src/features/reports/components/ReportTable/TableCell.tsx
@@ -8,7 +8,7 @@ import { PREFIX } from './constants';
 /* This method must redirect user to application. Used for JOSM links */
 function sendRequest(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>, link: string) {
   e.preventDefault();
-  fetch(link, { method: 'GET' });
+  window.open(link, '_blank')?.focus();
 }
 
 const mdLinks = /(\w+)_\[([^\]]+)\]\((https?:\/\/[\w\d:./?=/#/\-&_]+)\)/gm;

--- a/src/features/reports/readme.md
+++ b/src/features/reports/readme.md
@@ -85,3 +85,11 @@ There are 2 dynamic configs we receive from the back-end.
 `<ReportInfo />` is also subscribed on `reportResourceAtom` that provides `"Report Content"` based on `reportId`.
 Once `"Report Content"` received `tableAtom` transfroms the data from `.csv` format and provides actions for sorting and filtering.
 So `<ReportTable />` shows data and hooks with actions from `tableAtom`
+
+### Opening territories in JOSM
+
+Backend responses may contain links pointing to the JOSM remote control
+(`http://127.0.0.1:8111`). These are rendered with a JOSM icon in the table.
+To avoid mixed content errors in modern browsers, such links are opened in a new
+window using `window.open`.
+Ensure JOSM is running with remote control enabled to receive these requests.


### PR DESCRIPTION
## Summary
- send JOSM requests using `window.open`
- document JOSM link handling in reports feature

## Testing
- `pnpm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68604670e5b4832fbc7c7f306d5ab231