### PR TITLE
20437 fix outdated disaster card

### DIFF
--- a/src/features/events_list/atoms/eventListResource.ts
+++ b/src/features/events_list/atoms/eventListResource.ts
@@ -3,7 +3,6 @@ import { AppFeature } from '~core/app/types';
 import { autoRefreshService } from '~core/autoRefreshServiceInstance';
 import { i18n } from '~core/localization';
 import { dispatchMetricsEventOnce } from '~core/metrics/dispatch';
-import { currentEventAtom } from '~core/shared_state/currentEvent';
 import { currentEventFeedAtom } from '~core/shared_state/currentEventFeed';
 import { combineAtoms } from '~utils/atoms';
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
@@ -40,13 +39,7 @@ export const eventListResourceAtom = createAsyncAtom(
       throw new Error(i18n.t('event_list.no_disasters'));
     }
 
-    const currentEvent = currentEventAtom.getState();
-    if (currentEvent?.id) {
-      if (responseData.findIndex((d) => d.eventId === currentEvent?.id) === -1) {
-        // selected event is not in list, reset selection
-        currentEventAtom.setCurrentEventId.dispatch(null);
-      }
-    }
+
 
     return responseData;
   },

--- a/src/features/events_list/atoms/sortedEventList.ts
+++ b/src/features/events_list/atoms/sortedEventList.ts
@@ -1,6 +1,5 @@
 import { atom } from '@reatom/framework';
 import { isNumber } from '~utils/common';
-import { currentEventAtom } from '~core/shared_state/currentEvent';
 import { i18n } from '~core/localization';
 import { sortEventsBySingleProperty } from '../helpers/singlePropertySort';
 import { sortEventsByMcda } from '../helpers/eventsMcdaSort';
@@ -94,13 +93,6 @@ export const sortedEventListAtom = atom<SortedEventListAtom>((ctx) => {
       data = sortEvents(data, eventsSortingConfig);
     }
 
-    const currentEvent = currentEventAtom.getState();
-    if (currentEvent?.id) {
-      if (data.findIndex((d) => d.eventId === currentEvent?.id) === -1) {
-        // selected event is not in the sorted list, reset selection
-        currentEventAtom.setCurrentEventId.dispatch(null);
-      }
-    }
 
     if (!data.length) {
       error = i18n.t('event_list.no_feed_disasters_matching_your_filters');

--- a/src/features/events_list/components/FullState/FullState.tsx
+++ b/src/features/events_list/components/FullState/FullState.tsx
@@ -9,10 +9,12 @@ export function FullState({
   eventsList,
   currentEventId,
   renderEventCard,
+  unlistedEvent,
 }: {
   eventsList: Event[] | null;
   currentEventId: string | null;
   renderEventCard: (event: Event, isActive: boolean) => JSX.Element;
+  unlistedEvent?: Event | null;
 }) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
@@ -27,25 +29,28 @@ export function FullState({
     [renderEventCard, currentEventId],
   );
 
-  if (!eventsList) return null;
+  const hasEvents = eventsList && eventsList.length > 0;
 
   return (
     <div className={s.panelBody}>
+      {unlistedEvent && renderEventCard(unlistedEvent, true)}
       <EventsPanelSettings />
-      <div className={s.scrollable}>
-        <Virtuoso
-          ref={virtuosoRef}
-          data={eventsList}
-          totalCount={eventsList.length}
-          initialTopMostItemIndex={{
-            index: currentEventIndex || 0,
-            align: 'center',
-            behavior: 'auto',
-          }}
-          itemContent={itemContent}
-        />
-        <div className={s.height100vh} />
-      </div>
+      {hasEvents && (
+        <div className={s.scrollable}>
+          <Virtuoso
+            ref={virtuosoRef}
+            data={eventsList}
+            totalCount={eventsList.length}
+            initialTopMostItemIndex={{
+              index: currentEventIndex || 0,
+              align: 'center',
+              behavior: 'auto',
+            }}
+            itemContent={itemContent}
+          />
+          <div className={s.height100vh} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/events_list/readme.md
+++ b/src/features/events_list/readme.md
@@ -19,7 +19,7 @@ It can also contains a show timeline button, if the episodes timeline feature is
 
 ### CurrentEvent
 
-The `CurrentEvent` component displays details for the currently selected unlisted event. Unlisted event it is an event that is not in the list of events, nut it comes from the URL.
+When a disaster is opened via a direct link and is not included in the current feed, the events panel still shows its card. The unlisted event card is rendered above the filters inside the `FullState` component.
 
 ### FeedSelector
 
@@ -39,7 +39,7 @@ The `EventListSettingsRow` component is a container for the `FeedSelector` and `
 
 ### FullState
 
-The `FullState` component is the main component that displays the event list. It includes sub-components such as `CurrentEvent`, `FeedSelector`, and `BBoxFilter`. It also includes a `Virtuoso` component to efficiently render large lists of events.
+The `FullState` component is the main component that displays the event list. It includes the optional unlisted event card described above, as well as sub-components like `FeedSelector` and `BBoxFilter`. It also includes a `Virtuoso` component to efficiently render large lists of events.
 
 ### ShortState
 


### PR DESCRIPTION
## Summary
- keep current event when it's missing from feed
- show unlisted disaster card above filters
- document how FullState handles unlisted events

Fibery task: [20437](https://kontur.fibery.io/Tasks/Task/20437)

## Testing
- `pnpm exec npm-run-all lint:js lint:css depcruise` *(fails: command not found)*
- `pnpm exec vitest run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686046c21c0c832fbff891d77dbb89cd