### PR TITLE
fix(toolbar): 21487 shrink toolbar width

### DIFF
--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
@@ -5,6 +5,7 @@
   flex-flow: row nowrap;
   gap: var(--unit);
   overflow-x: auto;
+  width: max-content;
 }
 
 .sectionDivider {

--- a/src/features/toolbar/readme.md
+++ b/src/features/toolbar/readme.md
@@ -1,0 +1,5 @@
+# Toolbar
+
+This feature renders the set of tool controls that can be displayed in a panel.
+The layout is defined in `~core/toolbar`. The toolbar panel can shrink to fit its
+content so it doesn't leave unused whitespace.


### PR DESCRIPTION
## Summary
- shrink toolbar width so it fits its content
- document toolbar feature

Fibery ticket: [21487](https://kontur.fibery.io/Tasks/Task/21487)


------
https://chatgpt.com/codex/tasks/task_e_6860470f52c0832f8f907968a8e70293