### PR TITLE
fix(event-episodes): 16725 auto-fit timeline on event switch

### DIFF
--- a/src/features/event_episodes/atoms/autoFitEpisodesTimeline.ts
+++ b/src/features/event_episodes/atoms/autoFitEpisodesTimeline.ts
@@ -1,0 +1,24 @@
+import { createAtom } from '~utils/atoms';
+import { episodesTimeline } from './episodesTimeline';
+import { episodesResource } from './episodesResource';
+
+export const autoFitEpisodesTimeline = createAtom(
+  {
+    episodesTimeline,
+    episodesResource,
+  },
+  ({ onChange, schedule }) => {
+    const fit = () => {
+      schedule((dispatch) => {
+        dispatch(episodesTimeline.resetZoom());
+      });
+    };
+    onChange('episodesTimeline', fit);
+    onChange('episodesResource', (resource) => {
+      if (!resource.loading && !resource.error) {
+        fit();
+      }
+    });
+  },
+  'autoFitEpisodesTimeline',
+);

--- a/src/features/event_episodes/atoms/episodesTimeline.test.ts
+++ b/src/features/event_episodes/atoms/episodesTimeline.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { store } from '~core/store/store';
+import { episodesTimeline } from './episodesTimeline';
+
+beforeEach(() => {
+  // metrics dispatch relies on dispatchEvent existing
+  if (typeof globalThis.dispatchEvent !== 'function') {
+    // @ts-ignore
+    globalThis.dispatchEvent = vi.fn();
+  }
+});
+
+describe('episodesTimeline', () => {
+  test('resetZoom triggers fit on imperative api', () => {
+    const api = { fit: vi.fn() };
+    store.dispatch(episodesTimeline.setImperativeApi(api));
+    store.dispatch(episodesTimeline.resetZoom());
+    expect(api.fit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/event_episodes/atoms/episodesTimeline.ts
+++ b/src/features/event_episodes/atoms/episodesTimeline.ts
@@ -18,7 +18,7 @@ export const episodesTimeline = createAtom(
     setData: (data: unknown) => data,
   },
   (
-    { onAction },
+    { onAction, schedule },
     state: EpisodesTimeline = {
       [timelineKey]: null,
       settings: {
@@ -28,6 +28,12 @@ export const episodesTimeline = createAtom(
     },
   ) => {
     onAction('setImperativeApi', (api) => (state = { ...state, [timelineKey]: api }));
+    onAction('resetZoom', () => {
+      const api = state[timelineKey] as { fit?: () => void } | null;
+      if (api?.fit) {
+        schedule(() => api.fit!());
+      }
+    });
     onAction(
       'patchSettings',
       (patch) =>

--- a/src/features/event_episodes/index.tsx
+++ b/src/features/event_episodes/index.tsx
@@ -3,10 +3,12 @@ import { episodesPanelStateHandler } from '~core/focused_geometry/controllers';
 import { eventEpisodesModel } from './model';
 import { EpisodesTimelinePanel } from './components/EpisodesTimelinePanel/EpisodesTimelinePanel';
 import { episodeToFocusedGeometry } from './atoms/episodeToFocusedGeometry';
+import { autoFitEpisodesTimeline } from './atoms/autoFitEpisodesTimeline';
 
 export function EventEpisodes() {
   const [panelState] = useAtom(eventEpisodesModel.episodesPanelState);
   useAtom(episodeToFocusedGeometry);
+  useAtom(autoFitEpisodesTimeline);
   useAtom(episodesPanelStateHandler);
   return panelState.isOpen ? <EpisodesTimelinePanel /> : null;
 }

--- a/src/features/event_episodes/model.ts
+++ b/src/features/event_episodes/model.ts
@@ -3,6 +3,7 @@ import { episodesPanelState } from '~core/shared_state';
 import { episodesResource } from './atoms/episodesResource';
 import { episodesTimeline } from './atoms/episodesTimeline';
 import { autoClearCurrentEpisode } from './atoms/autoClearCurrentEpisode';
+import { autoFitEpisodesTimeline } from './atoms/autoFitEpisodesTimeline';
 
 export const eventEpisodesModel = {
   currentEventEpisodes: episodesResource, // List of episodes
@@ -10,4 +11,5 @@ export const eventEpisodesModel = {
   episodesPanelState: episodesPanelState, // Panel settings
   episodesTimelineState: episodesTimeline, // Timeline settings
   autoClearCurrentEpisode: autoClearCurrentEpisode,
+  autoFitEpisodesTimeline: autoFitEpisodesTimeline,
 };

--- a/src/features/event_episodes/readme.md
+++ b/src/features/event_episodes/readme.md
@@ -41,6 +41,10 @@ Then it merges the episode geometry feature collection to single geometry, using
 **Behavior**
 The `autoClearCurrentEpisode` function subscribes to the `episodesResource` atom. When the `episodesResource` changes, the function checks if the current episode is associated with the selected disaster. If it is not, the function updates the `currentEpisodeAtom` with a null value, effectively clearing the current episode selection.
 
+### autoFitEpisodesTimeline
+
+`autoFitEpisodesTimeline` keeps the timeline view in sync with the loaded episodes. It listens to changes of `episodesResource` and the timeline itself and automatically triggers a zoom-to-fit via the timeline imperative API when episodes are loaded or the timeline component mounts.
+
 ## Controller
 
 ### eventEpisodesController


### PR DESCRIPTION
Fibery ticket: [16725](https://kontur.fibery.io/Tasks/Task/16725)

Added automatic timeline fit when switching events and timeline mounts. Timeline atom now invokes `fit()` via imperative API upon `resetZoom`. New `autoFitEpisodesTimeline` atom dispatches this action whenever episodes data or timeline instance changes. Updated docs and added unit test.

------
https://chatgpt.com/codex/tasks/task_e_6860467d9eec832fb9178ab7d71b95c8