### PR TITLE
fix(breadcrumbs): add shadow when toolbar is absent

### DIFF
--- a/src/features/breadcrumbs/BreadcrumbsPanel.module.css
+++ b/src/features/breadcrumbs/BreadcrumbsPanel.module.css
@@ -6,6 +6,11 @@
   min-height: 40px;
 }
 
+/* Add shadow when toolbar is not displayed */
+.noToolbar {
+  box-shadow: var(--shadow-small);
+}
+
 .content {
   overflow: visible;
 }

--- a/src/features/breadcrumbs/BreadcrumbsPanel.tsx
+++ b/src/features/breadcrumbs/BreadcrumbsPanel.tsx
@@ -1,4 +1,5 @@
 import { Panel } from '@konturio/ui-kit';
+import clsx from 'clsx';
 import { useAction } from '@reatom/npm-react';
 import { constructOptionsFromBoundaries } from '~utils/map/boundaries';
 import { i18n } from '~core/localization';
@@ -12,7 +13,7 @@ const noBreadcrumbsOption = {
   value: 'zoom to world',
 };
 
-export function BreadcrumbsPanel() {
+export function BreadcrumbsPanel({ hasToolbar = true }: { hasToolbar?: boolean }) {
   const items = useBreadcrumbsItems();
   const breadcrumbItemClick = useAction(onBreadcrumbClick);
   const zoomToTheWorld = useAction(onZoomToWholeWorld);
@@ -23,7 +24,11 @@ export function BreadcrumbsPanel() {
   const clickHandler = items?.length ? breadcrumbItemClick : zoomToTheWorld;
 
   return (
-    <Panel resize="none" className={s.breadcrumbsPanel} contentClassName={s.content}>
+    <Panel
+      resize="none"
+      className={clsx(s.breadcrumbsPanel, !hasToolbar && s.noToolbar)}
+      contentClassName={s.content}
+    >
       <Breadcrumbs items={options} onClick={clickHandler} />
     </Panel>
   );

--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -162,7 +162,9 @@ export function MapPage() {
           matrix={<></>}
           timeline={featureFlags[AppFeature.EPISODES_TIMELINE] && <EventEpisodes />}
           breadcrumbs={
-            featureFlags[AppFeature.ADMIN_BOUNDARY_BREADCRUMBS] && <BreadcrumbsPanel />
+            featureFlags[AppFeature.ADMIN_BOUNDARY_BREADCRUMBS] && (
+              <BreadcrumbsPanel hasToolbar={Boolean(featureFlags[AppFeature.TOOLBAR])} />
+            )
           }
           toolbar={featureFlags[AppFeature.TOOLBAR] && <Toolbar />}
           layerFeaturesPanel={


### PR DESCRIPTION
Fibery ticket: [20418](https://kontur.fibery.io/Tasks/Task/20418)

## Summary
- show a shadow for breadcrumbs panel when the toolbar feature is missing

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: watch mode cancelled)*
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68604c1ae1f8832faf84ae76ca2899fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breadcrumbs panel now visually adapts when the toolbar is hidden, providing a subtle box shadow for improved appearance.
* **Style**
  * Added new styling to enhance the breadcrumbs panel when the toolbar is not displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->