### PR TITLE
feat(event_episodes): 16890 close timeline for single episode

### DIFF
--- a/src/features/event_episodes/atoms/autoCloseEpisodesPanel.ts
+++ b/src/features/event_episodes/atoms/autoCloseEpisodesPanel.ts
@@ -1,0 +1,26 @@
+import { createAtom } from '~utils/atoms';
+import { episodesPanelState } from '~core/shared_state/episodesPanelState';
+import { episodesResource } from './episodesResource';
+
+/**
+ * Close episodes timeline when selected event has one or no episodes.
+ */
+export const autoCloseEpisodesPanel = createAtom(
+  {
+    episodesResource,
+  },
+  ({ onChange, get, getUnlistedState, schedule }) => {
+    onChange('episodesResource', () => {
+      const resource = get('episodesResource');
+      if (resource.loading || resource.error) return;
+      const episodes = resource.data || [];
+      const panelState = getUnlistedState(episodesPanelState);
+      if (panelState.isOpen && episodes.length <= 1) {
+        schedule((dispatch) => {
+          dispatch(episodesPanelState.close());
+        });
+      }
+    });
+  },
+  'autoCloseEpisodesPanel',
+);

--- a/src/features/event_episodes/index.tsx
+++ b/src/features/event_episodes/index.tsx
@@ -8,5 +8,6 @@ export function EventEpisodes() {
   const [panelState] = useAtom(eventEpisodesModel.episodesPanelState);
   useAtom(episodeToFocusedGeometry);
   useAtom(episodesPanelStateHandler);
+  useAtom(eventEpisodesModel.autoCloseEpisodesPanel);
   return panelState.isOpen ? <EpisodesTimelinePanel /> : null;
 }

--- a/src/features/event_episodes/model.ts
+++ b/src/features/event_episodes/model.ts
@@ -3,6 +3,7 @@ import { episodesPanelState } from '~core/shared_state';
 import { episodesResource } from './atoms/episodesResource';
 import { episodesTimeline } from './atoms/episodesTimeline';
 import { autoClearCurrentEpisode } from './atoms/autoClearCurrentEpisode';
+import { autoCloseEpisodesPanel } from './atoms/autoCloseEpisodesPanel';
 
 export const eventEpisodesModel = {
   currentEventEpisodes: episodesResource, // List of episodes
@@ -10,4 +11,5 @@ export const eventEpisodesModel = {
   episodesPanelState: episodesPanelState, // Panel settings
   episodesTimelineState: episodesTimeline, // Timeline settings
   autoClearCurrentEpisode: autoClearCurrentEpisode,
+  autoCloseEpisodesPanel: autoCloseEpisodesPanel,
 };

--- a/src/features/event_episodes/readme.md
+++ b/src/features/event_episodes/readme.md
@@ -41,6 +41,13 @@ Then it merges the episode geometry feature collection to single geometry, using
 **Behavior**
 The `autoClearCurrentEpisode` function subscribes to the `episodesResource` atom. When the `episodesResource` changes, the function checks if the current episode is associated with the selected disaster. If it is not, the function updates the `currentEpisodeAtom` with a null value, effectively clearing the current episode selection.
 
+### autoCloseEpisodesPanel
+
+`autoCloseEpisodesPanel` closes the EpisodesTimelinePanel when the selected event has only one or no episodes.
+
+**Behavior**
+The atom listens to `episodesResource`. Once the resource is loaded and the panel is open, if the number of episodes is less than two the atom dispatches the `close` action of `episodesPanelState`.
+
 ## Controller
 
 ### eventEpisodesController


### PR DESCRIPTION
Fibery Task: [DN FE] episode timeline displayed for event with only 1 episode when switched from event with many episodes (https://kontur.fibery.io/Tasks/Task/16890)

## Summary
- introduce `autoCloseEpisodesPanel` atom to close timeline when new event has <=1 episodes
- wire up auto closing atom in `EventEpisodes`
- export atom via `eventEpisodesModel`
- document the new behaviour

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` *(fails to terminate watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68604d24382c832f9ac69f05f013a2c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The episodes timeline panel now automatically closes when the selected event has one or no episodes.

* **Documentation**
  * Updated documentation to describe the new automatic closing behavior of the episodes timeline panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->