### PR TITLE
fix(links): 17603 add protocol to link without scheme

### DIFF
--- a/src/components/LinkRenderer/LinkRenderer.test.tsx
+++ b/src/components/LinkRenderer/LinkRenderer.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { LinkRenderer } from './LinkRenderer';
+
+describe('LinkRenderer', () => {
+  it('adds https scheme when missing', () => {
+    const { container } = render(
+      <LinkRenderer href="cycling.waymarkedtrails.org/#?map=3">link</LinkRenderer>,
+    );
+    const anchor = container.querySelector('a');
+    expect(anchor?.getAttribute('href')).toBe(
+      'https://cycling.waymarkedtrails.org/#?map=3',
+    );
+  });
+});

--- a/src/components/LinkRenderer/LinkRenderer.tsx
+++ b/src/components/LinkRenderer/LinkRenderer.tsx
@@ -9,8 +9,12 @@ type ElementWrapProps = React.DetailedHTMLProps<
 >;
 
 export const LinkRenderer = memo(function (props: ElementWrapProps) {
+  let href = props.href;
+  if (href && !/^[a-zA-Z]+:\/\//.test(href)) {
+    href = `https://${href}`;
+  }
   return (
-    <a href={props.href} target="_blank" rel="noreferrer" onClick={stopPropagation}>
+    <a href={href} target="_blank" rel="noreferrer" onClick={stopPropagation}>
       {props.children}
     </a>
   );

--- a/src/components/LinkRenderer/README.md
+++ b/src/components/LinkRenderer/README.md
@@ -1,0 +1,5 @@
+# LinkRenderer Component
+
+Renders markdown links inside tooltips and other content. If a link is provided
+without a protocol (e.g. `cycling.waymarkedtrails.org`) the component
+automatically prefixes it with `https://` so it opens correctly.


### PR DESCRIPTION
Fibery ticket: [Wrong link in a tooltip for Waymarket overlays on DN2](https://kontur.fibery.io/Tasks/Task/17603)

- prepend `https://` to markdown links missing a protocol
- document LinkRenderer behavior
- add unit test for new scheme handling


------
https://chatgpt.com/codex/tasks/task_e_68606e355f4c832f922d930bff93d030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Links without a specified protocol are now automatically opened as secure "https://" links.

* **Documentation**
  * Added documentation for the LinkRenderer component, including its behavior for handling links.

* **Tests**
  * Introduced tests to verify that links missing a protocol are correctly prefixed with "https://".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->