### PR TITLE
fix(locate-me): 15482 cancel event autofocus

### DIFF
--- a/e2e/location.spec.ts
+++ b/e2e/location.spec.ts
@@ -36,10 +36,6 @@ for (const project of projects) {
   test(`As Guest, I can click Locate me button at ${project.title} and get zoomed to my location`, async ({
     pageManager,
   }) => {
-    test.skip(
-      project.name === 'disaster-ninja',
-      'Fix https://kontur.fibery.io/Tasks/Task/Locate-me-is-not-working-if-it-has-been-pressed-before-the-event-is-zoomed-in-15482 issue to unblock this test for disaster-ninja',
-    );
     await testLocation(pageManager, project);
   });
 }

--- a/e2e/locationWithPro.spec.ts
+++ b/e2e/locationWithPro.spec.ts
@@ -34,10 +34,6 @@ for (const project of projects) {
   test(`As PRO User, I can click Locate me button at ${project.title} and get zoomed to my location`, async ({
     pageManager,
   }) => {
-    test.skip(
-      project.name === 'disaster-ninja',
-      'Fix https://kontur.fibery.io/Tasks/Task/Locate-me-is-not-working-if-it-has-been-pressed-before-the-event-is-zoomed-in-15482 issue to unblock this test for disaster-ninja',
-    );
     await testLocation(pageManager, project);
   });
 }

--- a/e2e/locationWithUser.spec.ts
+++ b/e2e/locationWithUser.spec.ts
@@ -21,10 +21,6 @@ for (const project of projects) {
   test(`As User, I can click Locate me button at ${project.title} and see coordinates of my location in url`, async ({
     pageManager,
   }) => {
-    test.skip(
-      project.name === 'disaster-ninja',
-      'Fix https://kontur.fibery.io/Tasks/Task/Locate-me-is-not-working-if-it-has-been-pressed-before-the-event-is-zoomed-in-15482 issue to unblock this test for disaster-ninja',
-    );
     await pageManager.atBrowser.openProject(project, { skipCookieBanner: true });
     await pageManager.atNavigationMenu.clickButtonToOpenPage('Map');
     await pageManager.atToolBar.getButtonByText('Locate me').click({ timeout: 15000 });

--- a/src/features/locate_me/index.tsx
+++ b/src/features/locate_me/index.tsx
@@ -3,6 +3,7 @@ import { toolbar } from '~core/toolbar';
 import { i18n } from '~core/localization';
 import { store } from '~core/store/store';
 import { setCurrentMapPosition } from '~core/shared_state/currentMapPosition';
+import { scheduledAutoFocus } from '~core/shared_state/currentEvent';
 import {
   LOCATE_ME_CONTROL_ID,
   LOCATE_ME_CONTROL_NAME,
@@ -22,6 +23,7 @@ export const locateMeControl = toolbar.setupControl({
 
 locateMeControl.onStateChange((ctx, state) => {
   if (state === 'active') {
+    scheduledAutoFocus.setFalse.dispatch();
     const geolocation = navigator.geolocation;
     // Location dialogue should appear for the user
     geolocation.getCurrentPosition(successCb, errorCb);

--- a/src/features/locate_me/readme.md
+++ b/src/features/locate_me/readme.md
@@ -14,4 +14,6 @@ import('~features/locate_me').then(({ initLocateMe }) => {
 
 It uses `navigator.geolocation.getCurrentPosition` method to ask for user position once and then updates `currentMapPositionAtom` in case of success. Shows error message in case of errors/denial.
 
+Requesting location also disables automatic focusing on the current event so that the map respects the user's intention to view their own location.
+
 If you need to use the feature in the IFRAME embedded mode, make sure to pass `allow="geolocation"` to pass the persmissions from root window to the iframe.


### PR DESCRIPTION
Fibery Ticket: https://kontur.fibery.io/Tasks/Task/15482

## Summary
- stop event auto focus when pressing **Locate me**
- document canceling auto focus in locate me readme
- enable locate-me e2e tests

## Testing
- `pnpm lint:js`
- `pnpm lint:css`
- `pnpm typecheck`
- `pnpm coverage` *(fails: coverage summary shown)*

------
https://chatgpt.com/codex/tasks/task_e_68606f6528c8832fb2e350626bba2031