### PR TITLE
fix(legend): 21473 respect fill-opacity in simple legend icons

### DIFF
--- a/src/components/SimpleLegend/icons/CircleIcon.tsx
+++ b/src/components/SimpleLegend/icons/CircleIcon.tsx
@@ -31,6 +31,7 @@ export function CircleIcon({
         cy="9"
         r="7"
         fill={fill || styles['fill-color'] || styles['circle-color'] || 'none'}
+        fillOpacity={styles['fill-opacity'] || 1}
         stroke={
           stroke ||
           styles['circle-stroke-color'] ||

--- a/src/components/SimpleLegend/icons/HexIcon.tsx
+++ b/src/components/SimpleLegend/icons/HexIcon.tsx
@@ -53,6 +53,7 @@ export function HexIcon({
       <path
         d="M2.70577 5.36603L9 1.73205L15.2942 5.36602V12.634L9 16.268L2.70577 12.634V5.36603Z"
         fill={fill || styles['fill-color'] || 'white'}
+        fillOpacity={styles['fill-opacity'] || 1}
         stroke={fill || styles['fill-color'] || 'white'}
         strokeWidth="3"
       />
@@ -86,6 +87,7 @@ export function HexIcon({
       <path
         d="M9 6L11.5981 7.5V10.5L9 12L6.40192 10.5V7.5L9 6Z"
         fill={fill || styles['fill-color'] || 'white'}
+        fillOpacity={styles['fill-opacity'] || 1}
       />
     </svg>
   );

--- a/src/components/SimpleLegend/icons/SquareIcon.tsx
+++ b/src/components/SimpleLegend/icons/SquareIcon.tsx
@@ -32,6 +32,7 @@ export function SquareIcon({
         width="12"
         height="12"
         fill={fill || styles['fill-color'] || 'none'}
+        fillOpacity={styles['fill-opacity'] || 1}
         stroke={stroke || styles.color || '#000000'}
         strokeWidth={styles.width || 3}
       />

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -118,6 +118,7 @@ export type LegendStepStyle = {
   'casing-opacity'?: string;
   'casing-width'?: string;
   'fill-color'?: string;
+  'fill-opacity'?: string;
   color?: string;
   width?: string;
   offset?: string;

--- a/src/features/legend_panel/readme.md
+++ b/src/features/legend_panel/readme.md
@@ -25,3 +25,4 @@ import { FullAndShortStatesPanelWidget } from '~widgets/FullAndShortStatesPanelW
 
 `<PanelContent />` renders the list of layers based on `mountedLayersAtom`.
 Legends can either be bivariate [BivariateLegend](github.com/konturio/disaster-ninja-fe/blob/main/src/components/BivariateLegend/BivariateLegend.tsx) or "simple" [SimpleLegend](https://github.com/konturio/disaster-ninja-fe/blob/main/src/components/SimpleLegend/SimpleLegend.tsx).
+Simple legends respect a `fill-opacity` style property which controls the opacity of the icon fill. This is used for event shape layers like Alert Area or volcano forecasts.


### PR DESCRIPTION
## Summary
- handle `fill-opacity` in SimpleLegend icons so event shape legends display opacity
- document `fill-opacity` usage in legend panel docs

## Testing
- `pnpm coverage`

------
https://chatgpt.com/codex/tasks/task_e_68606f725194832fad8e178892bb0d1b