### PR TITLE
fix(state): 18076 apply user default feed

### DIFF
--- a/src/core/config/__mocks__/_configMock.ts
+++ b/src/core/config/__mocks__/_configMock.ts
@@ -353,5 +353,7 @@ const _configDataMock = {
 
 // @ts-ignore
 configRepo.get = () => _configDataMock;
+// @ts-ignore
+configRepo.getUserDefaultFeed = () => _configDataMock.initialUser.defaultFeed;
 
 export { configRepo };

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -51,6 +51,10 @@ class ConfigRepository {
     return this.#config!;
   }
 
+  getUserDefaultFeed() {
+    return this.#config!.initialUser.defaultFeed ?? this.#config!.defaultFeed;
+  }
+
   /* -- Intercom staff -- */
 
   #readSessionIntercomSetting = (key: string) =>

--- a/src/core/shared_state/currentEventFeed.test.ts
+++ b/src/core/shared_state/currentEventFeed.test.ts
@@ -1,0 +1,16 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { expect, test } from 'vitest';
+import { configRepo } from '~core/config/__mocks__/_configMock';
+import { currentEventFeedAtom } from './currentEventFeed';
+
+test('currentEventFeedAtom uses user default feed', () => {
+  const customFeed = 'user-feed';
+  // override mocked default feed
+  configRepo.getUserDefaultFeed = () => customFeed;
+
+  const state = currentEventFeedAtom.getState();
+
+  expect(state?.id).toBe(customFeed);
+});

--- a/src/core/shared_state/currentEventFeed.ts
+++ b/src/core/shared_state/currentEventFeed.ts
@@ -16,7 +16,7 @@ export const currentEventFeedAtom = createAtom(
   },
   (
     { onAction, onChange, schedule, getUnlistedState },
-    state: CurrentEventFeedAtomState = { id: configRepo.get().defaultFeed },
+    state: CurrentEventFeedAtomState = { id: configRepo.getUserDefaultFeed() },
   ) => {
     onAction('setCurrentFeed', (feedId) => {
       if (state?.id !== feedId) {
@@ -49,7 +49,7 @@ export const currentEventFeedAtom = createAtom(
 );
 
 function checkFeed(eventFeeds: EventFeedConfig[], feedId?: string) {
-  if (!feedId) return configRepo.get().defaultFeed;
+  if (!feedId) return configRepo.getUserDefaultFeed();
   const feed = eventFeeds?.find((fd) => fd.feed === feedId);
-  return feed ? feed.feed : configRepo.get().defaultFeed;
+  return feed ? feed.feed : configRepo.getUserDefaultFeed();
 }

--- a/src/core/shared_state/eventFeeds.ts
+++ b/src/core/shared_state/eventFeeds.ts
@@ -7,7 +7,7 @@ import {
 import { i18n } from '~core/localization';
 import { currentEventFeedAtom } from './currentEventFeed';
 
-const defaultFeeds: EventFeed[] = [getDefaultFeedObject(configRepo.get().defaultFeed)];
+const defaultFeeds: EventFeed[] = [getDefaultFeedObject(configRepo.getUserDefaultFeed())];
 
 export const eventFeedsAtom = createAtom(
   {
@@ -19,7 +19,7 @@ export const eventFeedsAtom = createAtom(
     if (!loading && !error) {
       if (data) {
         console.assert(
-          data.map((d) => d.feed).includes(configRepo.get().defaultFeed),
+          data.map((d) => d.feed).includes(configRepo.getUserDefaultFeed()),
           'default feed not included in response',
         );
         state = { data, loading };

--- a/src/features/events_list/components/FeedSelector/FeedSelector.tsx
+++ b/src/features/events_list/components/FeedSelector/FeedSelector.tsx
@@ -44,7 +44,7 @@ export function FeedSelector() {
         label={i18n.t('feed')}
         items={mappedItems}
         onSelect={handleSelect}
-        value={currentFeed?.id || configRepo.get().defaultFeed}
+        value={currentFeed?.id || configRepo.getUserDefaultFeed()}
         type="inline"
         showSelectedIcon={false}
         className={s.feedsSelect}

--- a/src/features/events_list/readme.md
+++ b/src/features/events_list/readme.md
@@ -23,7 +23,7 @@ The `CurrentEvent` component displays details for the currently selected unliste
 
 ### FeedSelector
 
-The `FeedSelector` component allows users to filter the event list by feed. It displays a list of available feeds and allows the user to select one or more to filter the event list. Will be displayed if feedSelector feature is enabled.
+The `FeedSelector` component allows users to filter the event list by feed. It displays a list of available feeds and allows the user to select one or more to filter the event list. When the component mounts, it selects the default feed from the user profile settings. Will be displayed if feedSelector feature is enabled.
 
 ### BBoxFilter
 


### PR DESCRIPTION
## Summary
- read user default feed on startup
- sync default feed in disasters list
- test default feed initialization
- document FeedSelector default behaviour

Fibery ticket: [18076](https://kontur.fibery.io/Tasks/Task/18076)


------
https://chatgpt.com/codex/tasks/task_e_68606ea4a6ac832fb4a0e437975dcc7b