### PR TITLE
fix(current-event): 18555 reset focused geometry when deselecting event

### DIFF
--- a/src/core/shared_state/currentEvent.ts
+++ b/src/core/shared_state/currentEvent.ts
@@ -14,7 +14,10 @@ export const currentEventAtom = createAtom(
     setCurrentEventId: (eventId: string | null) => eventId,
     focusedGeometryAtom,
   },
-  ({ onAction, onChange }, state: CurrentEventAtomState = null) => {
+  (
+    { onAction, onChange, schedule, getUnlistedState },
+    state: CurrentEventAtomState = null,
+  ) => {
     onChange('focusedGeometryAtom', (focusedGeometry) => {
       const currentGeometrySource = focusedGeometry?.source;
       if (
@@ -28,7 +31,15 @@ export const currentEventAtom = createAtom(
       }
     });
 
-    onAction('setCurrentEventId', (eventId) => (state = { id: eventId }));
+    onAction('setCurrentEventId', (eventId) => {
+      state = { id: eventId };
+      if (eventId === null) {
+        schedule((dispatch) => {
+          const focusedGeometry = getUnlistedState(focusedGeometryAtom);
+          if (isEventGeometry(focusedGeometry)) dispatch(focusedGeometryAtom.reset());
+        });
+      }
+    });
 
     return state;
   },

--- a/src/features/current_event/atoms/currentEventGeometry.ts
+++ b/src/features/current_event/atoms/currentEventGeometry.ts
@@ -36,6 +36,12 @@ export const currentEventGeometryAtom = createAtom(
       // Case resource didn't call for event because event id or feed id was absent
       else if (!loading && !error && data === null) {
         state = null;
+        schedule((dispatch) => {
+          const focusedGeometry = getUnlistedState(focusedGeometryAtom);
+          if (focusedGeometry?.source?.type === 'event') {
+            dispatch(focusedGeometryAtom.reset());
+          }
+        });
       }
 
       // Feature considered ready after loading event or getting error when event not found

--- a/src/features/current_event/readme.md
+++ b/src/features/current_event/readme.md
@@ -13,7 +13,7 @@ If the current event geometry has changed, the atom uses `getCameraForGeometry` 
 
 The `currentEventGeometryAtom` holds the information about the current selected event with geometry. It subscribes to changes in the `currentEventResourceAtom`. If `currentEventResourceAtom` has changed, and it is fully loaded and contains data, the `currentEventGeometryAtom` checks the source of the geometry. If the source is not an episode, the `currentEventGeometryAtom` sets the `focusedGeometryAtom` to the geometry value from the `currentEventResourceAtom` object, with a reference to the original event data as `meta`.
 
-If `currentEventResourceAtom` is fully loaded but does not contain data, the atom's value is set to `null`.
+If `currentEventResourceAtom` is fully loaded but does not contain data, the atom's value is set to `null` and the `focusedGeometryAtom` is reset to remove the event shape from the map.
 
 After the `currentEventResourceAtom` is fully loaded, the `currentEventGeometryAtom` sends a metric about the result of loading the `CURRENT_EVENT` feature once.
 


### PR DESCRIPTION
## Summary
- clear event geometry when deselecting an event
- remove geometry when current event resource is empty
- document geometry reset behaviour in the current_event README

## Testing
- `pnpm lint`
- `pnpm test:unit` *(tests ran and were cancelled after completion)*

------
https://chatgpt.com/codex/tasks/task_e_68606f7a50ac832fa2a3c50b7e70a7e0