### PR TITLE
fix: 17546 ensure default user profile settings

### DIFF
--- a/src/core/shared_state/currentUser.ts
+++ b/src/core/shared_state/currentUser.ts
@@ -9,7 +9,7 @@ export const currentUserAtom = createAtom(
   ({ onAction }, state: CurrentUser = configRepo.get().initialUser) => {
     onAction('setUser', (usr) => {
       if (usr) {
-        state = usr;
+        state = { ...configRepo.get().initialUser, ...usr };
       } else {
         state = configRepo.get().initialUser;
       }

--- a/src/features/user_profile/atoms/userProfile.ts
+++ b/src/features/user_profile/atoms/userProfile.ts
@@ -25,8 +25,8 @@ export const currentProfileAtom = createAtom(
         const user = await getCurrentUser();
         if (!user) throw new Error(i18n.t('no_data_received'));
         dispatch(pageStatusAtom.set('ready'));
-        state = user;
-        dispatch(currentUserAtom.setUser(user));
+        state = { ...configRepo.get().initialUser, ...user };
+        dispatch(currentUserAtom.setUser(state));
       });
     });
 
@@ -47,7 +47,7 @@ export const currentProfileAtom = createAtom(
 
     onChange('currentUserAtom', async (newUser, prevUser) => {
       const { loading, defaultLayers, ...newState } = newUser;
-      state = newState;
+      state = { ...configRepo.get().initialUser, ...newState };
     });
 
     return state;

--- a/src/features/user_profile/readme.md
+++ b/src/features/user_profile/readme.md
@@ -19,3 +19,10 @@ Import `LoginForm`, `SettingsForm` from feature root
 
 Successful login stores `justLoggedIn` flag in `sessionStorage` and reloads the page.
 If the router reads `justLoggedIn` flag, it redirects the user to the first available route from `DEFAULT_POST_LOGIN_ROUTES` array.
+
+### Default settings
+
+When a newly registered user opens the profile page, missing profile fields are
+automatically populated with defaults from the application configuration. Those
+defaults include `language` (`en`), metric units, the Kontur theme, `JOSM` as the
+OSM editor and `Kontur Public` disaster feed.


### PR DESCRIPTION
Fibery Ticket: [17546](https://kontur.fibery.io/Tasks/Task/17546)

## Summary
- set defaults on user data when fetched
- merge defaults on user atom updates
- document default profile settings

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: watch mode aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6860709e3018832f9dcaa60b094a279c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that missing user profile fields are automatically filled with default values from the application configuration.

* **Documentation**
  * Updated user profile documentation to explain how default settings are applied for new users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->