### PR TITLE
feat(ui): 18136 persist panel and layer states

### DIFF
--- a/docs/investigations/panels-report.md
+++ b/docs/investigations/panels-report.md
@@ -44,6 +44,8 @@ Most Panel implementations use a shared pattern for state management:
 - **State Types**: `'closed'`, `'short'`, and `'full'`
 - **Hooks**: `useShortPanelState()` provides standardized panel state handling
 - **Responsive Behavior**: Different content rendering based on panel state
+- **Persistence**: When a `persistKey` is provided to `useShortPanelState`, panel
+  state is stored in `localStorage` and restored on reload
 
 #### Common Props
 

--- a/src/core/logical_layers/atoms/enabledLayers.ts
+++ b/src/core/logical_layers/atoms/enabledLayers.ts
@@ -1,3 +1,23 @@
 import { createSetAtom } from '~utils/atoms/createPrimitives';
+import { localStorage } from '~utils/storage';
+import { store } from '~core/store/store';
 
-export const enabledLayersAtom = createSetAtom(new Set<string>(), 'enabledLayers');
+export const ENABLED_LAYERS_LS_KEY = 'enabled_layers';
+
+function readInitialState() {
+  try {
+    const raw = localStorage.getItem(ENABLED_LAYERS_LS_KEY);
+    if (!raw) return new Set<string>();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set<string>(parsed);
+  } catch {}
+  return new Set<string>();
+}
+
+export const enabledLayersAtom = createSetAtom(readInitialState(), 'enabledLayers');
+
+store.v3ctx.subscribe(enabledLayersAtom, (layers) => {
+  try {
+    localStorage.setItem(ENABLED_LAYERS_LS_KEY, JSON.stringify(Array.from(layers)));
+  } catch {}
+});

--- a/src/features/events_list/components/EventsPanel/EventsPanel.tsx
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.tsx
@@ -66,7 +66,7 @@ export function EventsPanel({
     togglePanel,
     isOpen,
     isShort,
-  } = useShortPanelState({ isMobile });
+  } = useShortPanelState({ isMobile, persistKey: 'panel-state-events' });
 
   const [focusedGeometry] = useAtom(focusedGeometryAtom);
   const [{ data: eventsList, error, loading }] = useAtomV3(sortedEventListAtom);

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
@@ -82,7 +82,7 @@ export function LayerFeaturesPanel() {
     togglePanel,
     closePanel,
     setPanelState,
-  } = useShortPanelState({ isMobile });
+  } = useShortPanelState({ isMobile, persistKey: 'panel-state-layer-features' });
 
   const isOpen = panelState !== 'closed';
   const isShort = panelState === 'short';

--- a/src/features/layers_panel/readme.md
+++ b/src/features/layers_panel/readme.md
@@ -3,6 +3,8 @@
 This feature adds layers panel UI with layers tree, generated from layers that was added to layers registry.
 Currently it's used as part of combined LayersAndLegends panel, rendered inside [FullAndShortStatesPanelWidget](/src/widgets/FullAndShortStatesPanelWidget/index.tsx) container in fullState.
 
+Enabled layers are saved to `localStorage` and restored on the next visit so the panel state persists between sessions.
+
 ### Feature Flag
 
 AppFeature.MAP_LAYERS_PANEL

--- a/src/features/search/index.tsx
+++ b/src/features/search/index.tsx
@@ -12,6 +12,7 @@ import s from './styles.module.css';
 export function Search() {
   const { isOpen, closePanel, openFullState } = useShortPanelState({
     skipShortState: true,
+    persistKey: 'panel-state-search',
   });
   useAutoCollapsePanel(isOpen, closePanel);
 

--- a/src/utils/hooks/useShortPanelState.tsx
+++ b/src/utils/hooks/useShortPanelState.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown24, ChevronUp24 } from '@konturio/default-icons';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { localStorage } from '~utils/storage';
 
 export type PanelState = 'full' | 'short' | 'closed';
 
@@ -7,13 +8,29 @@ interface UseShortPanelStateProps {
   initialState?: PanelState | null;
   skipShortState?: boolean;
   isMobile?: boolean;
+  persistKey?: string;
 }
 
 export const useShortPanelState = (props?: UseShortPanelStateProps) => {
   const initialState = props?.initialState ?? 'full';
   const skipShortState = props?.skipShortState ?? false;
   const isMobile = props?.isMobile ?? false;
-  const [panelState, setPanelState] = useState<PanelState>(initialState);
+  const persistKey = props?.persistKey;
+  const [panelState, setPanelState] = useState<PanelState>(() => {
+    if (persistKey) {
+      const stored = localStorage.getItem(persistKey) as PanelState | null;
+      if (stored === 'full' || stored === 'short' || stored === 'closed') {
+        return stored;
+      }
+    }
+    return initialState;
+  });
+
+  useEffect(() => {
+    if (persistKey) {
+      localStorage.setItem(persistKey, panelState);
+    }
+  }, [persistKey, panelState]);
 
   const panelControls = useMemo(() => {
     if (isMobile) {

--- a/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
@@ -52,6 +52,7 @@ export function FullAndShortStatesPanelWidget({
     initialState,
     skipShortState: Boolean(!fullState || !shortState),
     isMobile: isMobile,
+    persistKey: id ? `panel-state-${id}` : undefined,
   });
 
   const getProperty = useCallback(

--- a/src/widgets/FullAndShortStatesPanelWidget/components/readme.md
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/readme.md
@@ -3,3 +3,7 @@
 This widget allows to merge 2 panels into single panel with full and short state.
 Since each panels content represented as a feature, widget has a logic when one or both panels aren't available.
 It expects panels contents to follow [PanelFeatureInterface](https://github.com/konturio/disaster-ninja-fe/blob/main/src/types/featuresTypes.ts)
+
+### Panel State Persistence
+
+When `id` prop is provided, the widget stores current panel state (`full`, `short`, or `closed`) in `localStorage` using the key `panel-state-<id>`. The saved state is loaded on the next application start.


### PR DESCRIPTION
## Summary
- load panel state from local storage through `useShortPanelState`
- persist panel states in `FullAndShortStatesPanelWidget`, search panel, events panel and layer features panel
- store enabled layer IDs in local storage
- document panel state persistence and layer state saving

Fibery ticket: [18136](https://kontur.fibery.io/Tasks/Task/18136)

## Testing
- `pnpm test:unit` *(fails: tsx not found)*
- `pnpm lint:js` *(fails: cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_686075f27838832fb2a13a7dc7509582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panel state (open/closed/short) is now persisted across sessions for supported panels, restoring your previous view when you return.
  * Enabled layers are now saved and restored automatically, maintaining your preferences between visits.

* **Documentation**
  * Updated documentation to reflect new panel state and enabled layer persistence features, including details on how state is saved and restored using localStorage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->