### PR TITLE
fix(mcda): 18758 sort dropdown search results alphabetically

### DIFF
--- a/src/features/mcda/components/MCDAForm/index.tsx
+++ b/src/features/mcda/components/MCDAForm/index.tsx
@@ -101,7 +101,15 @@ export function MCDAForm({
   const sortDropdownItems = useCallback(
     (items: SelectableItem[], search: string): SelectableItem[] => {
       if (search) {
+        sortByAlphabet(items, (item) => item.title);
         sortByWordOccurrence(items, (item) => item.title, search);
+        const exactIndex = items.findIndex(
+          (item) => item.title.toLowerCase() === search.toLowerCase(),
+        );
+        if (exactIndex > 0) {
+          const [exact] = items.splice(exactIndex, 1);
+          items.unshift(exact);
+        }
       }
       return items;
     },

--- a/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
+++ b/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
@@ -246,7 +246,15 @@ export function MultivariateAnalysisForm({
   const sortDropdownItems = useCallback(
     (items: SelectableItem[], search: string): SelectableItem[] => {
       if (search) {
+        sortByAlphabet(items, (item) => item.title);
         sortByWordOccurrence(items, (item) => item.title, search);
+        const exactIndex = items.findIndex(
+          (item) => item.title.toLowerCase() === search.toLowerCase(),
+        );
+        if (exactIndex > 0) {
+          const [exact] = items.splice(exactIndex, 1);
+          items.unshift(exact);
+        }
       }
       return items;
     },


### PR DESCRIPTION
## Summary
- ensure MCDA dropdown search results are alphabetically ordered after substring matches
- apply the same logic in Multivariate analysis form

Fibery ticket: [18758](https://kontur.fibery.io/Tasks/Task/18758)


------
https://chatgpt.com/codex/tasks/task_e_6861670a40bc832fa0d752c7228eb785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dropdown search experience by prioritizing exact matches at the top of the results and enhancing sorting logic for more relevant and organized suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->