### PR TITLE
feat(mcda): 18104 place mcda layers at top

### DIFF
--- a/src/core/logical_layers/atoms/layersHierarchy.ts
+++ b/src/core/logical_layers/atoms/layersHierarchy.ts
@@ -9,7 +9,7 @@ import type { LayerAtom } from '../types/logicalLayer';
  * */
 export type LogicalLayersHierarchy = Record<
   string,
-  { id: string; atom: LayerAtom; group?: string; category?: string }
+  { id: string; atom: LayerAtom; group?: string; category?: string; order?: number }
 >;
 export const logicalLayersHierarchyAtom = createAtom(
   {
@@ -28,6 +28,7 @@ export const logicalLayersHierarchyAtom = createAtom(
         atom: layer,
         group: settingsData?.group,
         category: settingsData?.category,
+        order: settingsData?.order,
       };
     });
 

--- a/src/core/logical_layers/atoms/layersTree/sortTree.test.ts
+++ b/src/core/logical_layers/atoms/layersTree/sortTree.test.ts
@@ -197,3 +197,17 @@ test('Not loose layers after sort', () => {
   const sorted = sortChildren(children, getTestContext().sorterSettings);
   expect(countChildren(children)).toEqual(countChildren(sorted));
 });
+
+test('Layers with order go first inside group', () => {
+  const children: TreeChildren[] = [
+    {
+      id: 'group',
+      isGroup: true,
+      children: [{ id: 'layer_2' }, { id: 'layer_1', order: 0 }],
+    },
+  ] as TreeChildren[];
+
+  const sorted = sortChildren(children, getTestContext().sorterSettings);
+  const groupChildren = (sorted[0] as any).children;
+  expect(getTestContext().getIds(groupChildren)[0]).toEqual('layer_1');
+});

--- a/src/core/logical_layers/atoms/layersTree/sortTree.ts
+++ b/src/core/logical_layers/atoms/layersTree/sortTree.ts
@@ -35,7 +35,11 @@ function clusterSort(
   order.forEach((o) => {
     if (clusters[o]) {
       result = result.concat(
-        clusters[o].sort((a, b) => a[inClusterSortField] - b[inClusterSortField]),
+        clusters[o].sort((a, b) => {
+          const orderA = a[inClusterSortField] ?? Number.POSITIVE_INFINITY;
+          const orderB = b[inClusterSortField] ?? Number.POSITIVE_INFINITY;
+          return orderA - orderB;
+        }),
       );
     }
   });

--- a/src/core/logical_layers/types/settings.ts
+++ b/src/core/logical_layers/types/settings.ts
@@ -5,4 +5,9 @@ export interface LayerSettings {
   group?: string;
   boundaryRequiredForRetrieval?: boolean;
   ownedByUser: boolean;
+  /**
+   * Optional order value used to sort layers inside a group.
+   * Layers with lower values appear before those without or with higher order.
+   */
+  order?: number;
 }

--- a/src/features/mcda/atoms/mcdaLayer.ts
+++ b/src/features/mcda/atoms/mcdaLayer.ts
@@ -38,6 +38,7 @@ export const mcdaLayerAtom = createAtom(
             category: 'overlay' as const,
             group: 'bivariate',
             ownedByUser: true,
+            order: 0,
           }),
         ),
 

--- a/src/features/mcda/readme.md
+++ b/src/features/mcda/readme.md
@@ -75,3 +75,7 @@ V_total = Σ(V_norm(1) · weight(1), V_norm(2) · weight(2), V_norm(n) · weight
 
 V_total is a result value of MCDA analysis (it's >=0 and <= 1), it's interpolated in color from colors field of JSON, where 0 is bad color, 1 is good color.
 If value is out of [0,1] range, it's painted as transparent.
+
+### Layers panel placement
+
+MCDA layers are automatically placed at the top of the **Kontur analytics** group in the Layers panel so newly created analyses are easy to find.


### PR DESCRIPTION
Fibery ticket: https://kontur.fibery.io/Tasks/Task/Place-MCDA-layers-at-the-top-of-Kontur-Analytics-18104

## Summary
- allow layers to specify an order value
- propagate order through logicalLayersHierarchy
- sort layers by order, undefined values go last
- ensure new MCDA layers use order `0`
- document MCDA layer placement
- test that sorting respects layer order

## Testing
- `pnpm exec npm-run-all lint:js lint:css depcruise`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686167344694832fa11c4f81bb590018