### PR TITLE
fix(layers): 15478 remember collapsed group state

### DIFF
--- a/src/features/layers_panel/atoms/openState.ts
+++ b/src/features/layers_panel/atoms/openState.ts
@@ -1,0 +1,4 @@
+import { createMapAtom } from '~utils/atoms/createPrimitives';
+
+// Map of tree element id to open state
+export const layersTreeOpenStateAtom = createMapAtom<string, boolean>(new Map(), 'layersTreeOpenStateAtom');

--- a/src/features/layers_panel/components/Category/Category.tsx
+++ b/src/features/layers_panel/components/Category/Category.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useAtom } from '@reatom/react-v2';
 import { useAction } from '@reatom/react-v2';
 import { FoldingWrap } from '~components/FoldingWrap/FoldingWrap';
@@ -6,6 +6,7 @@ import { mountedLayersByCategoryAtom } from '~features/layers_panel/atoms/mounte
 import { Group } from '../Group/Group';
 import { categoryDeselection } from '../../atoms/categoryDeselection';
 import { DeselectControl } from '../DeselectControl/DeselectControl';
+import { layersTreeOpenStateAtom } from '../../atoms/openState';
 import s from './Category.module.css';
 import type { CategoryWithSettings } from '~core/types/layers';
 
@@ -15,14 +16,17 @@ function CategoryMountedLayersCounter({ categoryId }: { categoryId: string }) {
 }
 
 export function Category({ category }: { category: CategoryWithSettings }) {
-  // Temporary solution before redisign according to task 11553-unfold-all-layers-tree-in-layers-panel-by-default
-  // const [isOpen, setOpenState] = useState(category.openByDefault ?? false);
-  const [isOpen, setOpenState] = useState(true);
+  const [openMap] = useAtom(layersTreeOpenStateAtom);
+  const isOpen = openMap.get(category.id) ?? true;
+  const setOpen = useAction(layersTreeOpenStateAtom.set);
   const onCategoryDeselect = useAction(
     () => categoryDeselection.deselect(category.id),
     [category.id],
   );
-  const toggleOpenState = useCallback(() => setOpenState((state) => !state), []);
+  const toggleOpenState = useCallback(
+    () => setOpen(category.id, !isOpen),
+    [setOpen, category.id, isOpen],
+  );
   return (
     <div className={s.category}>
       <FoldingWrap

--- a/src/features/layers_panel/components/Group/Group.tsx
+++ b/src/features/layers_panel/components/Group/Group.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from 'react';
-import { useAction } from '@reatom/react-v2';
+import { useCallback } from 'react';
+import { useAction, useAtom } from '@reatom/react-v2';
 import { FoldingWrap } from '~components/FoldingWrap/FoldingWrap';
 import { Layer } from '../Layer/Layer';
 import { groupDeselection } from '../../atoms/groupDeselection';
+import { layersTreeOpenStateAtom } from '../../atoms/openState';
 import { DeselectControl } from '../DeselectControl/DeselectControl';
 import s from './Group.module.css';
 import type { GroupWithSettings } from '~core/types/layers';
@@ -14,14 +15,17 @@ export function Group({
   group: GroupWithSettings;
   mutuallyExclusive?: boolean;
 }) {
-  // Temporary solution before redisign according to task 11553-unfold-all-layers-tree-in-layers-panel-by-default
-  // const [isOpen, setOpenState] = useState(group.openByDefault);
-  const [isOpen, setOpenState] = useState(true);
+  const [openMap] = useAtom(layersTreeOpenStateAtom);
+  const isOpen = openMap.get(group.id) ?? true;
+  const setOpen = useAction(layersTreeOpenStateAtom.set);
   const groupDeselectAction = useAction(
     () => groupDeselection.deselect(group.id),
     [group.id],
   );
-  const toggleOpenState = useCallback(() => setOpenState((state) => !state), []);
+  const toggleOpenState = useCallback(
+    () => setOpen(group.id, !isOpen),
+    [setOpen, group.id, isOpen],
+  );
 
   return (
     <div className={s.group}>

--- a/src/features/layers_panel/readme.md
+++ b/src/features/layers_panel/readme.md
@@ -25,3 +25,5 @@ Tree data structure generated in [createTree](/src/core/logical_layers/atoms/lay
 Tree can contain `Category`, `Group` and `Layer` items.
 
 Additional settings for Categories will be merged from `layersCategoriesSettingsAtom` and for Groups from `layersGroupsSettingsAtom`
+
+Current open state of groups and categories is stored in `layersTreeOpenStateAtom`. It remembers user folding choices within a session so that collapsed subgroups remain collapsed when their parent group is toggled.


### PR DESCRIPTION
Fibery Ticket: [Remember if layer group is collapsed](https://kontur.fibery.io/Tasks/Task/15478)

## Summary
- preserve folding state for category and group nodes using `layersTreeOpenStateAtom`
- document open state handling in layers panel feature

## Testing
- `pnpm lint` *(fails: npm-run-all not found)*
- `pnpm test:unit` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861673cdfd0832f87151ed8ad1ce4c6