### PR TITLE
feat(toolbar): 17353 disable Upload GeoJSON during tools usage

### DIFF
--- a/src/features/geometry_uploader/index.tsx
+++ b/src/features/geometry_uploader/index.tsx
@@ -22,6 +22,7 @@ const uploadClickListener = (e) => {
 
 const fileUploaderControl = toolbar.setupControl({
   id: GEOMETRY_UPLOADER_CONTROL_ID,
+  borrowMapInteractions: true,
   type: 'button',
   typeSettings: {
     name: GEOMETRY_UPLOADER_CONTROL_NAME,

--- a/src/features/mcda/index.ts
+++ b/src/features/mcda/index.ts
@@ -6,6 +6,10 @@ import { applyNewLayerStyle } from '~core/logical_layers/utils/applyNewLayerStyl
 import { mcdaLayerAtom } from './atoms/mcdaLayer';
 import { createMCDAConfig, editMCDAConfig } from './mcdaConfig';
 import { MCDA_CONTROL_ID, UPLOAD_MCDA_CONTROL_ID } from './constants';
+import { GEOMETRY_UPLOADER_CONTROL_ID } from '~features/geometry_uploader/constants';
+import { MAP_RULER_CONTROL_ID } from '~features/map_ruler/constants';
+import { BOUNDARY_SELECTOR_CONTROL_ID } from '~features/boundary_selector/constants';
+import { FOCUSED_GEOMETRY_EDITOR_CONTROL_ID } from '~widgets/FocusedGeometryEditor/constants';
 import { askMcdaJSONFile } from './utils/openMcdaFile';
 import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 import type { LogicalLayerActions } from '~core/logical_layers/types/logicalLayer';
@@ -69,6 +73,27 @@ function uploadOnClick() {
 uploadMcdaControl.onStateChange((ctx, state) => {
   if (state === 'active') {
     store.dispatch(uploadMcdaControl.setState('regular'));
+  }
+});
+
+mcdaControl.onStateChange((ctx, state) => {
+  const uploaderState = toolbar.getControlState(GEOMETRY_UPLOADER_CONTROL_ID);
+  if (!uploaderState) return;
+
+  if (state === 'active') {
+    store.dispatch(uploaderState.set('disabled'));
+    return;
+  }
+
+  const mapRulerActive =
+    toolbar.getControlState(MAP_RULER_CONTROL_ID)?.getState() === 'active';
+  const boundaryActive =
+    toolbar.getControlState(BOUNDARY_SELECTOR_CONTROL_ID)?.getState() === 'active';
+  const focusedGeomActive =
+    toolbar.getControlState(FOCUSED_GEOMETRY_EDITOR_CONTROL_ID)?.getState() === 'active';
+
+  if (!mapRulerActive && !boundaryActive && !focusedGeomActive) {
+    store.dispatch(uploaderState.set('regular'));
   }
 });
 


### PR DESCRIPTION
Fibery Ticket: [17353](https://kontur.fibery.io/Tasks/Task/17353)

## Summary
- mark geometry uploader as borrowing map interactions so it is disabled when other map tools are active
- disable geometry uploader while MCDA is running and re-enable when appropriate

## Testing
- `pnpm test:unit` *(fails: tsx not found)*
- `pnpm lint` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_686169569934832fb1961751df0cdabe