### PR TITLE
feat(toolbar): 13320 add zoom to selected area button

### DIFF
--- a/src/core/app/types.ts
+++ b/src/core/app/types.ts
@@ -43,6 +43,7 @@ export const AppFeature = {
   USE_3RDPARTY_ANALYTICS: 'use_3rdparty_analytics',
   LIVE_SENSOR: 'live_sensor',
   MCDA: 'mcda',
+  ZOOM_TO: 'zoom_to',
   TOOLBAR: 'toolbar',
   LAYER_FEATURES_PANEL: 'layer_features_panel',
   REFERENCE_AREA: 'reference_area',

--- a/src/core/localization/gettext/ar/common.po
+++ b/src/core/localization/gettext/ar/common.po
@@ -141,6 +141,10 @@ msgid "Selected area"
 msgstr "منطقة مختارة"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr ""
 

--- a/src/core/localization/gettext/be/common.po
+++ b/src/core/localization/gettext/be/common.po
@@ -130,6 +130,10 @@ msgid "Selected area"
 msgstr "Вылучаная вобласць"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr "Загрузіць аналіз"
 

--- a/src/core/localization/gettext/de/common.po
+++ b/src/core/localization/gettext/de/common.po
@@ -141,6 +141,10 @@ msgid "Selected area"
 msgstr "Ausgewähltes Gebiet"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr ""
 

--- a/src/core/localization/gettext/es/common.po
+++ b/src/core/localization/gettext/es/common.po
@@ -141,6 +141,10 @@ msgid "Selected area"
 msgstr "Área seleccionada"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr ""
 

--- a/src/core/localization/gettext/id/common.po
+++ b/src/core/localization/gettext/id/common.po
@@ -141,6 +141,10 @@ msgid "Selected area"
 msgstr "Area Pilihan"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr ""
 

--- a/src/core/localization/gettext/ko/common.po
+++ b/src/core/localization/gettext/ko/common.po
@@ -141,6 +141,10 @@ msgid "Selected area"
 msgstr "선택된 영역"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr ""
 

--- a/src/core/localization/gettext/ru/common.po
+++ b/src/core/localization/gettext/ru/common.po
@@ -131,6 +131,10 @@ msgid "Selected area"
 msgstr "Выделенная область"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr "Загрузить анализ"
 

--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -140,6 +140,10 @@ msgstr ""
 msgid "Upload MCDA"
 msgstr ""
 
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 #: layer_actions##tooltips##erase
 msgid "Erase"
 msgstr ""

--- a/src/core/localization/gettext/uk/common.po
+++ b/src/core/localization/gettext/uk/common.po
@@ -131,6 +131,10 @@ msgid "Selected area"
 msgstr "Вибрана область"
 
 #: toolbar##upload_mcda
+#: toolbar##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 msgid "Upload MCDA"
 msgstr "Завантажити MCDA"
 

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -33,7 +33,8 @@
     "record_sensors": "Record sensors",
     "tools_label": "Tools",
     "selected_area_label": "Selected area",
-    "upload_mcda": "Upload MCDA"
+    "upload_mcda": "Upload MCDA",
+    "zoom_to": "Zoom to"
   },
   "layer_actions": {
     "tooltips": {

--- a/src/core/toolbar/index.ts
+++ b/src/core/toolbar/index.ts
@@ -4,6 +4,7 @@ import { i18n } from '~core/localization';
 import { MCDA_CONTROL_ID, UPLOAD_MCDA_CONTROL_ID } from '~features/mcda/constants';
 import { SENSOR_CONTROL_ID } from '~features/live_sensor/constants';
 import { SAVE_AS_REFERENCE_AREA_CONTROL_ID } from '~features/reference_area/constants';
+import { ZOOM_TO_CONTROL_ID } from '~features/zoom_to/constants';
 import { FOCUSED_GEOMETRY_EDITOR_CONTROL_ID } from '~widgets/FocusedGeometryEditor/constants';
 import { BOUNDARY_SELECTOR_CONTROL_ID } from '~features/boundary_selector/constants';
 import {
@@ -74,6 +75,7 @@ class ToolbarImpl implements Toolbar {
           BOUNDARY_SELECTOR_CONTROL_ID,
           'UploadFile',
           FOCUSED_GEOMETRY_EDITOR_CONTROL_ID,
+          ZOOM_TO_CONTROL_ID,
           SAVE_AS_REFERENCE_AREA_CONTROL_ID,
         ],
       },

--- a/src/features/zoom_to/constants.ts
+++ b/src/features/zoom_to/constants.ts
@@ -1,0 +1,4 @@
+import { i18n } from '~core/localization';
+
+export const ZOOM_TO_CONTROL_ID = 'ZoomTo';
+export const ZOOM_TO_CONTROL_NAME = i18n.t('toolbar.zoom_to');

--- a/src/features/zoom_to/index.tsx
+++ b/src/features/zoom_to/index.tsx
@@ -1,0 +1,62 @@
+import { toolbar } from '~core/toolbar';
+import { store } from '~core/store/store';
+import { focusedGeometryAtom as focusedGeometryAtomV2 } from '~core/focused_geometry/model';
+import { setCurrentMapBbox } from '~core/shared_state/currentMapPosition';
+import { getBboxForGeometry } from '~utils/map/camera';
+import { isGeoJSONEmpty } from '~utils/geoJSON/helpers';
+import { i18n } from '~core/localization';
+import { ZOOM_TO_CONTROL_ID, ZOOM_TO_CONTROL_NAME } from './constants';
+import type { Unsubscribe } from '@reatom/framework';
+
+let focusedGeometryUnsubscribe: Unsubscribe | null;
+const focusedGeometryAtom = focusedGeometryAtomV2.v3atom;
+
+export const zoomToControl = toolbar.setupControl({
+  id: ZOOM_TO_CONTROL_ID,
+  type: 'button',
+  typeSettings: {
+    name: ZOOM_TO_CONTROL_NAME,
+    hint: i18n.t('toolbar.zoom_to'),
+    icon: 'ZoomTo16',
+    preferredSize: 'tiny',
+  },
+});
+
+function geometryExists(geometry: GeoJSON.GeoJSON | null | undefined) {
+  return !isGeoJSONEmpty(geometry);
+}
+
+zoomToControl.onStateChange((ctx, state) => {
+  if (state === 'active') {
+    const geometry = store.v3ctx.get(focusedGeometryAtom)?.geometry;
+    if (geometryExists(geometry)) {
+      const bbox = getBboxForGeometry(geometry!);
+      if (bbox) setCurrentMapBbox(store.v3ctx, bbox);
+    }
+    store.dispatch(zoomToControl.setState('regular'));
+  }
+  if (state === 'regular') {
+    if (!geometryExists(store.v3ctx.get(focusedGeometryAtom)?.geometry)) {
+      store.dispatch(zoomToControl.setState('disabled'));
+    }
+  }
+});
+
+zoomToControl.onInit(() => {
+  focusedGeometryUnsubscribe = store.v3ctx.subscribe(focusedGeometryAtom, (st) => {
+    if (geometryExists(st?.geometry)) {
+      store.dispatch(zoomToControl.setState('regular'));
+    } else {
+      store.dispatch(zoomToControl.setState('disabled'));
+    }
+  });
+});
+
+zoomToControl.onRemove(() => {
+  focusedGeometryUnsubscribe?.();
+  focusedGeometryUnsubscribe = null;
+});
+
+export function initZoomTo() {
+  zoomToControl.init();
+}

--- a/src/features/zoom_to/readme.md
+++ b/src/features/zoom_to/readme.md
@@ -1,0 +1,15 @@
+## Zoom to selected area
+
+This feature adds a button to the toolbar that zooms the map to the currently selected area.
+
+### How to use
+
+```ts
+import('~features/zoom_to').then(({ initZoomTo }) => {
+  initZoomTo();
+});
+```
+
+### How it works
+
+The feature reads geometry from `focusedGeometryAtom`. When the button is pressed it calculates a bounding box for this geometry and fits the map to it. The button is disabled when there is no selected area.

--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -109,6 +109,11 @@ export function MapPage() {
         initLocateMe();
       });
     }
+    if (featureFlags[AppFeature.ZOOM_TO]) {
+      import('~features/zoom_to').then(({ initZoomTo }) => {
+        initZoomTo();
+      });
+    }
     if (featureFlags[AppFeature.LIVE_SENSOR]) {
       import('~features/live_sensor').then(({ initSensor }) => {
         initSensor();


### PR DESCRIPTION
Fibery Task: [13320](https://kontur.fibery.io/Tasks/Task/13320)

Adds a new **Zoom to** button to the toolbar. The control zooms the map to the currently selected area (focused geometry) and is disabled when no area is selected. Translations and toolbar settings were updated accordingly.

------
https://chatgpt.com/codex/tasks/task_e_68616b672da8832f948ea8cbd492ca3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Zoom to" button in the toolbar, allowing users to zoom the map to the currently selected area.
  * The "Zoom to" control is enabled only when an area is selected.
  * Localization support for "Zoom to" has been added across multiple languages (translations pending in some languages).

* **Documentation**
  * Added a README describing the new "Zoom to" feature and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->