### PR TITLE
feat(toolbar): #12702 add Reset north control

### DIFF
--- a/src/core/app/types.ts
+++ b/src/core/app/types.ts
@@ -40,6 +40,7 @@ export const AppFeature = {
   BIVARIATE_COLOR_MANAGER: 'bivariate_color_manager',
   EPISODES_TIMELINE: 'episodes_timeline',
   LOCATE_ME: 'locate_me',
+  RESET_NORTH: 'reset_north',
   USE_3RDPARTY_ANALYTICS: 'use_3rdparty_analytics',
   LIVE_SENSOR: 'live_sensor',
   MCDA: 'mcda',

--- a/src/core/localization/gettext/ar/common.po
+++ b/src/core/localization/gettext/ar/common.po
@@ -89,6 +89,9 @@ msgstr ""
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "حدد موقعي"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/gettext/be/common.po
+++ b/src/core/localization/gettext/be/common.po
@@ -84,6 +84,9 @@ msgstr "Вымераць адлегласць"
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "Вызначыць маё месцазнаходжанне"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/gettext/de/common.po
+++ b/src/core/localization/gettext/de/common.po
@@ -89,6 +89,9 @@ msgstr ""
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "Standort finden"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/gettext/es/common.po
+++ b/src/core/localization/gettext/es/common.po
@@ -89,6 +89,9 @@ msgstr ""
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "Localizarme"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/gettext/id/common.po
+++ b/src/core/localization/gettext/id/common.po
@@ -89,6 +89,9 @@ msgstr ""
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "Temukan saya"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/gettext/ko/common.po
+++ b/src/core/localization/gettext/ko/common.po
@@ -89,6 +89,9 @@ msgstr ""
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "내 위치 확인"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/gettext/ru/common.po
+++ b/src/core/localization/gettext/ru/common.po
@@ -85,6 +85,9 @@ msgstr "Измерить расстояние"
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "Определить моё местоположение"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -31,7 +31,6 @@ msgid "Save"
 msgstr ""
 
 #: cancel
-#: mcda##btn_cancel
 msgid "Cancel"
 msgstr ""
 
@@ -49,6 +48,10 @@ msgstr ""
 
 #: loading
 msgid "Loading..."
+msgstr ""
+
+#: preparing_data
+msgid "Preparing data"
 msgstr ""
 
 #: loading_events
@@ -81,6 +84,10 @@ msgstr ""
 msgid "Layers"
 msgstr ""
 
+#: layer
+msgid "Layer"
+msgstr ""
+
 #: toolbar##map_ruler
 msgid "Measure distance"
 msgstr ""
@@ -88,6 +95,11 @@ msgstr ""
 #: toolbar##locate_me
 #: locate_me##feature_title
 msgid "Locate me"
+msgstr ""
+
+#: toolbar##reset_north
+#: reset_north##feature_title
+msgid "Reset north"
 msgstr ""
 
 #: toolbar##panel_title
@@ -100,6 +112,7 @@ msgid "Download"
 msgstr ""
 
 #: toolbar##delete
+#: layer_actions##tooltips##delete
 msgid "Delete"
 msgstr ""
 
@@ -175,6 +188,18 @@ msgstr ""
 
 #: started
 msgid "Started"
+msgstr ""
+
+#: created
+msgid "Created"
+msgstr ""
+
+#: mapping_types
+msgid "Mapping types"
+msgstr ""
+
+#: osm_gaps
+msgid "OSM gaps"
 msgstr ""
 
 #: no_data_received
@@ -360,10 +385,6 @@ msgstr ""
 
 #: mcda##error_analysis_name_cannot_be_empty
 msgid "Analysis name cannot be empty"
-msgstr ""
-
-#: mcda##error_bad_layer_data
-msgid "Invalid MCDA layer data"
 msgstr ""
 
 #: mcda##error_invalid_file
@@ -553,6 +574,14 @@ msgstr ""
 msgid "Good"
 msgstr ""
 
+#: multivariate##multivariate_analysis
+msgid "Multivariate Analysis"
+msgstr ""
+
+#: multivariate##create_analysis_layer
+msgid "Create analysis layer"
+msgstr ""
+
 #: multivariate##upload_analysis_layer
 msgid "Upload analysis layer"
 msgstr ""
@@ -561,8 +590,44 @@ msgstr ""
 msgid "Score {{level}}"
 msgstr ""
 
-#: multivariate##popup##base_header
-msgid "Base {{level}}"
+#: multivariate##popup##compare_header
+msgid "Compare {{level}}"
+msgstr ""
+
+#: multivariate##score
+msgid "Score"
+msgstr ""
+
+#: multivariate##compare
+msgid "Compare"
+msgstr ""
+
+#: multivariate##hide_area
+msgid "Hide area"
+msgstr ""
+
+#: multivariate##labels
+msgid "Labels"
+msgstr ""
+
+#: multivariate##3d
+msgid "3D"
+msgstr ""
+
+#: map_popup##value
+msgid "Value"
+msgstr ""
+
+#: map_popup##range
+msgid "Range"
+msgstr ""
+
+#: map_popup##coefficient
+msgid "Coefficient"
+msgstr ""
+
+#: map_popup##normalized_value
+msgid "Normalized value"
 msgstr ""
 
 #: search##search_location
@@ -690,6 +755,10 @@ msgstr ""
 #: event_list##open_timeline_button
 #: episode
 msgid "Timeline"
+msgstr ""
+
+#: create_layer##save_and_draw
+msgid "Save and draw"
 msgstr ""
 
 #: create_layer##edit_layer
@@ -859,10 +928,6 @@ msgstr ""
 
 #: draw_tools##overlap_error
 msgid "Polygon should not overlap itself"
-msgstr ""
-
-#: draw_tools##save_features
-msgid "Save features"
 msgstr ""
 
 #: boundary_selector##title
@@ -1213,86 +1278,12 @@ msgstr ""
 msgid "User guide"
 msgstr ""
 
-#: about##title
-msgid "Welcome to Disaster Ninja!"
+#: modes##external##upload_imagery
+msgid "Upload imagery"
 msgstr ""
 
-#: about##intro
-msgid ""
-"Do you want to be notified about ongoing disasters? Are you interested in "
-"instant population data and other analytics for any region in the world? "
-"Disaster Ninja showcases some of <2>Kontur</2>’s capabilities in addressing "
-"these needs.<br/><br/>We initially designed it as a decision support tool "
-"for humanitarian mappers. Now it has grown in functionality and use cases. "
-"Whether you work in disaster management, build a smart city, or perform "
-"research on climate change, Disaster Ninja can help you to:"
-msgstr ""
-
-#: about##l1
-msgid "1. Stay up to date with the latest hazard events globally."
-msgstr ""
-
-#: about##p1
-msgid ""
-"The Disasters panel continually refreshes to inform you about ongoing "
-"events. It consumes data from the <2>Kontur Event Feed</2>, which you can "
-"also access via an API."
-msgstr ""
-
-#: about##l2
-msgid "2. Focus on your area of interest."
-msgstr ""
-
-#: about##p2
-msgid ""
-"The Drawing Tools panel allows you to draw or upload your own geometry on "
-"the map. You can also focus on a disaster-exposed area or an administrative "
-"unit — a country, city, or region."
-msgstr ""
-
-#: about##l3
-msgid "3. Get analytics for the focused area."
-msgstr ""
-
-#: about##p3
-msgid ""
-"The Analytics panel shows the number of people living in that area per "
-"<2>Kontur Population</2> and estimated mapping gaps in OpenStreetMap. "
-"Kontur’s customers have access to hundreds of other indicators through "
-"Advanced Analytics."
-msgstr ""
-
-#: about##l4
-msgid "4. Explore data on the map and make conclusions."
-msgstr ""
-
-#: about##p4
-msgid ""
-"The Layers panel gives you various options to display two indicators "
-"simultaneously on a bivariate map, e.g., population density and distance to "
-"the nearest fire station. Use the color legend to assess which areas "
-"require attention. <br/>Hint: in general, green indicates low risk / few "
-"gaps, red — high risk / many gaps."
-msgstr ""
-
-#: about##p5
-msgid ""
-"In addition, you can switch to Reports in the left panel to access data on "
-"potential errors and inconsistencies in OpenStreetMap and help fix them by "
-"mapping the respective area with the JOSM editor."
-msgstr ""
-
-#: about##goToMap
-msgid "Go to the map now"
-msgstr ""
-
-#: about##p6
-msgid ""
-"We hope you find this tool valuable. Use the chatbox on Disaster Ninja for "
-"any questions about the functionality, and we will be happy to guide you. "
-"You can also contact us by email at <1>hello@kontur.io</1> if you have "
-"feedback or suggestions on improving the tool.<br/><br/>Disaster Ninja is "
-"an open-source project. Find the code in <8>Kontur’s GitHub account</8>."
+#: modes##external##imagery_catalog
+msgid "Imagery catalog"
 msgstr ""
 
 #: profile##interfaceTheme
@@ -1482,7 +1473,9 @@ msgstr ""
 #: profile##reference_area##tooltip_text
 msgid ""
 "1.Select an area of interest on the map using the Admin Boundary or Draw "
-"Geometry tool. <br/> 2. Click the 'Save as Reference' button on the toolbar."
+"Geometry tool.\n"
+"\n"
+" 2. Click the 'Save as Reference' button on the toolbar."
 msgstr ""
 
 #: profile##reference_area##accessing_location
@@ -1587,4 +1580,8 @@ msgstr ""
 
 #: reference_area##selected_area_saved_as_reference_area
 msgid "Selected area has been saved as reference area in your profile"
+msgstr ""
+
+#: oam_auth##login_button
+msgid "Login with Google"
 msgstr ""

--- a/src/core/localization/gettext/uk/common.po
+++ b/src/core/localization/gettext/uk/common.po
@@ -85,6 +85,9 @@ msgstr "Виміряти відстань"
 #: toolbar##locate_me locate_me##feature_title
 msgid "Locate me"
 msgstr "Знайти мене"
+#: toolbar##reset_north reset_north##feature_title
+msgid "Reset north"
+msgstr ""
 
 #: toolbar##panel_title
 msgid "Toolbar"

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -22,6 +22,7 @@
   "toolbar": {
     "map_ruler": "Measure distance",
     "locate_me": "Locate me",
+    "reset_north": "Reset north",
     "panel_title": "Toolbar",
     "download": "Download",
     "delete": "Delete",
@@ -490,6 +491,9 @@
   "locate_me": {
     "get_location_error": "Error while getting location",
     "feature_title": "Locate me"
+  },
+  "reset_north": {
+    "feature_title": "Reset north"
   },
   "episode": "Timeline",
   "loading_episodes": "Loading Episodes",

--- a/src/core/toolbar/index.ts
+++ b/src/core/toolbar/index.ts
@@ -55,6 +55,7 @@ class ToolbarImpl implements Toolbar {
       {
         name: i18n.t('toolbar.tools_label'),
         controls: [
+          'ResetNorth',
           'LocateMe',
           'MapRuler',
           'EditInOsm',

--- a/src/features/reset_north/constants.ts
+++ b/src/features/reset_north/constants.ts
@@ -1,0 +1,4 @@
+import { i18n } from '~core/localization';
+
+export const RESET_NORTH_CONTROL_ID = 'ResetNorth' as const;
+export const RESET_NORTH_CONTROL_NAME = i18n.t('toolbar.reset_north');

--- a/src/features/reset_north/index.tsx
+++ b/src/features/reset_north/index.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useAtom } from '@reatom/react-v2';
+import { currentMapAtom } from '~core/shared_state';
+import { toolbar } from '~core/toolbar';
+import { i18n } from '~core/localization';
+import { ToolbarIcon } from '~features/toolbar/components/ToolbarIcon';
+import { RESET_NORTH_CONTROL_ID, RESET_NORTH_CONTROL_NAME } from './constants';
+import type { WidgetProps } from '~core/toolbar/types';
+
+function ResetNorthWidget({
+  controlComponent: ControlComponent,
+  state,
+  onClick,
+  id,
+}: WidgetProps) {
+  const [map] = useAtom(currentMapAtom);
+  const [bearing, setBearing] = useState(0);
+
+  useEffect(() => {
+    if (!map) return;
+    const update = () => setBearing(map.getBearing());
+    map.on('rotate', update);
+    update();
+    return () => {
+      map.off('rotate', update);
+    };
+  }, [map]);
+
+  if (state === 'disabled') return null;
+
+  const handleClick = () => {
+    map?.resetNorth();
+    onClick();
+  };
+
+  return (
+    <ControlComponent
+      id={id}
+      icon={
+        <span style={{ display: 'inline-block', transform: `rotate(${-bearing}deg)` }}>
+          <ToolbarIcon icon="North16" width={16} height={16} />
+        </span>
+      }
+      size="tiny"
+      onClick={handleClick}
+      disabled={state === 'disabled'}
+    >
+      {RESET_NORTH_CONTROL_NAME}
+    </ControlComponent>
+  );
+}
+
+export const resetNorthControl = toolbar.setupControl({
+  id: RESET_NORTH_CONTROL_ID,
+  type: 'widget',
+  typeSettings: {
+    component: ResetNorthWidget,
+  },
+});
+
+export function initResetNorth() {
+  resetNorthControl.init();
+}

--- a/src/features/reset_north/readme.md
+++ b/src/features/reset_north/readme.md
@@ -1,0 +1,12 @@
+## Reset north
+
+This feature adds a button to the toolbar that resets the map orientation.
+The icon rotates together with the map bearing.
+
+### How to use
+
+Call `initResetNorth` once after the toolbar is mounted.
+
+```ts
+import('~features/reset_north').then(({ initResetNorth }) => initResetNorth());
+```

--- a/src/views/Map/Map.tsx
+++ b/src/views/Map/Map.tsx
@@ -109,6 +109,9 @@ export function MapPage() {
         initLocateMe();
       });
     }
+    if (featureFlags[AppFeature.RESET_NORTH]) {
+      import('~features/reset_north').then(({ initResetNorth }) => initResetNorth());
+    }
     if (featureFlags[AppFeature.LIVE_SENSOR]) {
       import('~features/live_sensor').then(({ initSensor }) => {
         initSensor();


### PR DESCRIPTION
## Summary
- add Reset North toolbar button feature with rotating icon
- include Reset North in toolbar configuration and map feature initialization
- provide translations for Reset North
- document feature usage

## Testing
- `pnpm test:unit`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68616b7169e4832fbd2623eb4dfa4c39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Reset north" toolbar button that allows users to reset the map orientation so that north is facing up. The icon visually rotates to match the current map bearing.
* **Localization**
  * Added "Reset north" translation keys and placeholders in multiple languages, with English translation provided.
* **Documentation**
  * Added user documentation describing the "Reset north" toolbar feature and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->