### PR TITLE
feat(layer_features_panel): 18001 show archived label

### DIFF
--- a/src/features/layer_features_panel/atoms/helpers/hotProjects_outlines.ts
+++ b/src/features/layer_features_panel/atoms/helpers/hotProjects_outlines.ts
@@ -69,6 +69,7 @@ function sortByProjectId(a, b) {
 export function getHotProjectsPanelData(featuresListHOT: object) {
   const featuresList: FeatureCardCfg[] = Object.values(featuresListHOT).map((f) => {
     const { properties: p } = f;
+    const isArchived = (p.status ?? p.projectStatus)?.toUpperCase() === 'ARCHIVED';
     return {
       id: f.id,
       focus: p.aoiBBOX,
@@ -78,7 +79,7 @@ export function getHotProjectsPanelData(featuresListHOT: object) {
           type: 'label',
           items: [
             { value: '#' + p.projectId },
-            ...(p.status == 'ARCHIVED'
+            ...(isArchived
               ? [
                   {
                     value: 'Archived',

--- a/src/features/layer_features_panel/readme.md
+++ b/src/features/layer_features_panel/readme.md
@@ -68,6 +68,8 @@ function transformFeaturesToPanelData(featuresList: object): FeatureCardCfg[] {
 }
 ```
 
+Archived HOT Tasking Manager projects are displayed with a grey `Archived` label next to the project number in the feature card.
+
 ### Bbox filter
 
 If `showBboxFilterToggle` is enabled, the Bbox filter toggle button (`BBoxFilterToggle` component) is displayed.


### PR DESCRIPTION
Fibery Ticket: [18001](https://kontur.fibery.io/Tasks/Task/18001)

## Summary
- show 'Archived' tag on HOT task cards when project is archived
- document how archived HOT projects are displayed

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails to exit watch mode, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68616b7aad54832f8bd8684c1cc46c7a