### PR TITLE
feat(focused_geometry_layer): 12523 add event info to legend

### DIFF
--- a/src/core/focused_geometry/utils.ts
+++ b/src/core/focused_geometry/utils.ts
@@ -1,5 +1,5 @@
 import type { FocusedGeometry } from './types';
-import type { Severity } from '~core/types';
+import type { Severity, EventType } from '~core/types';
 
 /**
  * Internal helper to safely access meta properties from focused geometry source
@@ -45,6 +45,14 @@ export function isEpisodeGeometry(focusedGeometry: FocusedGeometry | null): bool
  */
 export function getEventName(focusedGeometry: FocusedGeometry | null): string | null {
   return getSourceMetaProperty(focusedGeometry, 'event', 'eventName');
+}
+
+/**
+ * Safely get event type from focused geometry
+ * Handles pattern: focusedGeometry?.source?.type === 'event' ? focusedGeometry.source.meta.eventType : null
+ */
+export function getEventType(focusedGeometry: FocusedGeometry | null): EventType | null {
+  return getSourceMetaProperty<EventType>(focusedGeometry, 'event', 'eventType');
 }
 
 /**

--- a/src/features/focused_geometry_layer/index.ts
+++ b/src/features/focused_geometry_layer/index.ts
@@ -3,6 +3,10 @@ import { registerNewGeometryLayer } from '~core/logical_layers/utils/registerNew
 import { store } from '~core/store/store';
 import { focusedGeometryAtom } from '~core/focused_geometry/model';
 import { applyNewGeometryLayerSource } from '~core/logical_layers/utils/applyNewGeometryLayerSource';
+import { layersSettingsAtom } from '~core/logical_layers/atoms/layersSettings';
+import { layersLegendsAtom } from '~core/logical_layers/atoms/layersLegends';
+import { createAsyncWrapper } from '~utils/atoms/createAsyncWrapper';
+import { getEventName, getEventType } from '~core/focused_geometry/utils';
 import {
   FOCUSED_GEOMETRY_LOGICAL_LAYER_TRANSLATION_KEY,
   FOCUSED_GEOMETRY_COLOR,
@@ -21,6 +25,39 @@ export function initFocusedGeometryLayer() {
       FOCUSED_GEOMETRY_LOGICAL_LAYER_ID,
       focusedGeometry?.geometry ?? null,
     );
+    const eventName = getEventName(focusedGeometry);
+    const eventType = getEventType(focusedGeometry);
+    const name =
+      eventName && eventType
+        ? `${eventType}: ${eventName}`
+        : FOCUSED_GEOMETRY_LOGICAL_LAYER_TRANSLATION_KEY;
+    store.dispatch([
+      layersSettingsAtom.set(
+        FOCUSED_GEOMETRY_LOGICAL_LAYER_ID,
+        createAsyncWrapper({
+          name,
+          id: FOCUSED_GEOMETRY_LOGICAL_LAYER_ID,
+          boundaryRequiredForRetrieval: false,
+          ownedByUser: false,
+        }),
+      ),
+      layersLegendsAtom.set(
+        FOCUSED_GEOMETRY_LOGICAL_LAYER_ID,
+        createAsyncWrapper({
+          type: 'simple',
+          name,
+          steps: [
+            {
+              stepShape: 'circle',
+              stepName: name,
+              style: {
+                color: FOCUSED_GEOMETRY_COLOR,
+              },
+            },
+          ],
+        }),
+      ),
+    ]);
   });
 
   registerNewGeometryLayer(

--- a/src/features/focused_geometry_layer/readme.md
+++ b/src/features/focused_geometry_layer/readme.md
@@ -19,3 +19,4 @@ import('~features/focused_geometry_layer').then(({ initFocusedGeometryLayer }) =
 
 1. create logical layer with it's own legend, and renderer
 2. create atom that watching on the focusedGeometry and set it geometry as geojson source for logical layer created on first step
+3. when focused geometry is an event, update layer name and legend to "<EventType>: <EventName>"


### PR DESCRIPTION
Fibery Ticket: [12523](https://kontur.fibery.io/Tasks/Task/12523)

## Summary
- update focused geometry layer to show event name and type in legend
- add helper to read event type from focused geometry
- document the behavior

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_68616b50d760832fb2c04096c44b7dc2