### PR TITLE
fix(user_profile): 17738 disable select with single option

### DIFF
--- a/src/features/user_profile/components/SettingsForm/SelectFeeds.tsx
+++ b/src/features/user_profile/components/SettingsForm/SelectFeeds.tsx
@@ -4,7 +4,7 @@ import { eventFeedsAtom } from '~core/shared_state/eventFeeds';
 export function SelectFeeds({ value, title, onChange }) {
   const [eventFeeds] = useAtom(eventFeedsAtom);
 
-  const OPTIONS_FEED = eventFeeds.data.map((o) => ({
+  const optionsFeed = eventFeeds.data.map((o) => ({
     title: o.name,
     value: o.feed,
   }));
@@ -13,9 +13,10 @@ export function SelectFeeds({ value, title, onChange }) {
     <Select
       alwaysShowPlaceholder
       value={value}
-      items={OPTIONS_FEED}
+      items={optionsFeed}
       withResetButton={false}
       onSelect={onChange}
+      disabled={optionsFeed.length <= 1}
     >
       {title}
     </Select>

--- a/src/features/user_profile/readme.md
+++ b/src/features/user_profile/readme.md
@@ -19,3 +19,5 @@ Import `LoginForm`, `SettingsForm` from feature root
 
 Successful login stores `justLoggedIn` flag in `sessionStorage` and reloads the page.
 If the router reads `justLoggedIn` flag, it redirects the user to the first available route from `DEFAULT_POST_LOGIN_ROUTES` array.
+
+Settings form also disables dropdowns when there is only a single option. For example, the default disaster feed selector is inactive when a user has access to only one feed.


### PR DESCRIPTION
Fibery ticket: [Disable fields with one option in DN2 user profile](https://kontur.fibery.io/Tasks/Task/17738)

## Summary
- disable SelectFeeds dropdown when only one feed is available
- document dropdown disabling in user profile feature

## Testing
- `pnpm test:unit`
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68616b41ad04832fb29d0885cbd16ee5