### PR TITLE
fix(draw): 16285 prevent errors when finishing without pointer move

### DIFF
--- a/src/core/draw_tools/customDrawModes/CustomDrawPolygonMode.ts
+++ b/src/core/draw_tools/customDrawModes/CustomDrawPolygonMode.ts
@@ -161,11 +161,10 @@ export class CustomDrawPolygonMode extends GeoJsonEditMode {
     switch (event.key) {
       case 'Enter':
         if (clickSequenceLength >= 2) {
-          const polygonCoords = [
-            ...clickSequence,
-            props.lastPointerMoveEvent.mapCoords,
-            clickSequence[0],
-          ];
+          const lastCoord =
+            props.lastPointerMoveEvent?.mapCoords ||
+            clickSequence[clickSequenceLength - 1];
+          const polygonCoords = [...clickSequence, lastCoord, clickSequence[0]];
           if (this.intersectionsTest(props, polygonCoords)) {
             this['resetClickSequence']();
             return;

--- a/src/core/draw_tools/modes/drawLine.ts
+++ b/src/core/draw_tools/modes/drawLine.ts
@@ -12,9 +12,12 @@ export class LocalDrawLineStringMode extends DrawLineStringMode {
     if (key === 'Enter') {
       const clickSequence = this.getClickSequence();
       if (clickSequence.length > 1) {
+        const lastCoord =
+          props.lastPointerMoveEvent?.mapCoords ||
+          clickSequence[clickSequence.length - 1];
         const lineStringToAdd: LineString = {
           type: 'LineString',
-          coordinates: [...clickSequence, props.lastPointerMoveEvent.mapCoords],
+          coordinates: [...clickSequence, lastCoord],
         };
 
         this.resetClickSequence();

--- a/src/core/draw_tools/modes/drawPolygon.ts
+++ b/src/core/draw_tools/modes/drawPolygon.ts
@@ -20,11 +20,10 @@ export class LocalDrawPolygonMode extends CustomDrawPolygonMode {
     switch (event.key) {
       case 'Enter':
         if (clickSequenceLength >= 2) {
-          const polygonCoords = [
-            ...clickSequence,
-            props.lastPointerMoveEvent.mapCoords,
-            clickSequence[0],
-          ];
+          const lastCoord =
+            props.lastPointerMoveEvent?.mapCoords ||
+            clickSequence[clickSequenceLength - 1];
+          const polygonCoords = [...clickSequence, lastCoord, clickSequence[0]];
           if (this.intersectionsTest(props, polygonCoords)) {
             currentNotificationAtom.showNotification.dispatch(
               'error',


### PR DESCRIPTION
Fibery ticket: [16285](https://kontur.fibery.io/Tasks/Task/16285)

## Summary
- avoid undefined pointer coordinates when closing polygons or lines

## Testing
- `pnpm run typecheck`
- `pnpm vitest run` *(fails: SensorRecorder.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_686167e417b8832fb3cc7857745fbba0