### PR TITLE
feat(toolbar): #17353 disable uploader when editing

### DIFF
--- a/src/features/geometry_uploader/index.tsx
+++ b/src/features/geometry_uploader/index.tsx
@@ -1,5 +1,11 @@
 import { currentMapAtom } from '~core/shared_state';
 import { toolbar } from '~core/toolbar';
+import { mapRulerControl } from '~features/map_ruler';
+import { MAP_RULER_CONTROL_ID } from '~features/map_ruler/constants';
+import { boundarySelectorControl } from '~features/boundary_selector/control';
+import { BOUNDARY_SELECTOR_CONTROL_ID } from '~features/boundary_selector/constants';
+import { focusedGeometryControl } from '~widgets/FocusedGeometryEditor';
+import { FOCUSED_GEOMETRY_EDITOR_CONTROL_ID } from '~widgets/FocusedGeometryEditor/constants';
 import { focusedGeometryAtom } from '~core/focused_geometry/model';
 import { configRepo } from '~core/config';
 import { i18n } from '~core/localization';
@@ -36,6 +42,26 @@ const fileUploaderControl = toolbar.setupControl({
       el?.addEventListener('click', uploadClickListener);
     },
   },
+});
+
+function updateFileUploaderState() {
+  const isMapRulerActive =
+    toolbar.getControlState(MAP_RULER_CONTROL_ID)?.getState() === 'active';
+  const isBoundarySelectorActive =
+    toolbar.getControlState(BOUNDARY_SELECTOR_CONTROL_ID)?.getState() === 'active';
+  const isGeometryEditorActive =
+    toolbar.getControlState(FOCUSED_GEOMETRY_EDITOR_CONTROL_ID)?.getState() === 'active';
+  const shouldDisable =
+    isMapRulerActive || isBoundarySelectorActive || isGeometryEditorActive;
+  store.dispatch(fileUploaderControl.setState(shouldDisable ? 'disabled' : 'regular'));
+}
+
+mapRulerControl.onStateChange(updateFileUploaderState);
+boundarySelectorControl.onStateChange(updateFileUploaderState);
+focusedGeometryControl.onStateChange(updateFileUploaderState);
+
+fileUploaderControl.onInit(() => {
+  updateFileUploaderState();
 });
 
 fileUploaderControl.onStateChange((ctx, state) => {

--- a/src/features/geometry_uploader/readme.md
+++ b/src/features/geometry_uploader/readme.md
@@ -17,3 +17,9 @@ On button click function `askGeoJSONFile` executed. It shows error toast if erro
 Success callback passes the uploaded geometry to apps `focusedGeometryAtom` and focuses on on it.
 
 The implementation might look quirky, it's done this way to support Safari browsers.
+
+### Interactions with other tools
+
+The upload button becomes disabled while map ruler, boundary selector or focused
+geometry editing tools are active. It returns to regular state once those tools
+are deactivated.


### PR DESCRIPTION
Fibery#17353 https://kontur.fibery.io/Tasks/Task/Conditionally-disable-Upload-GeoJSON-on-toolbar-17353

Implemented automatic disabling of the **Upload GeoJSON** tool when map ruler, boundary selector or focused geometry editor are active. Added listeners in the uploader feature and updated documentation.


------
https://chatgpt.com/codex/tasks/task_e_686183b3b044832fa6e90f77d263974b