### PR TITLE
feat(analytics): export panel data to csv

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -250,7 +250,8 @@
   "analytics_panel": {
     "header_title": "Analytics",
     "error_loading": "Failed receiving data about selected area. It may be too large.",
-    "info_short": "Calculations are made for selected area"
+    "info_short": "Calculations are made for selected area",
+    "download_csv": "Download CSV"
   },
   "advanced_analytics_panel": {
     "header_title": "Advanced analytics",

--- a/src/features/analytics_panel/components/DownloadCSVControl/DownloadCSVControl.module.css
+++ b/src/features/analytics_panel/components/DownloadCSVControl/DownloadCSVControl.module.css
@@ -1,0 +1,5 @@
+.download {
+  cursor: pointer;
+  display: flex;
+  color: var(--faint-strong);
+}

--- a/src/features/analytics_panel/components/DownloadCSVControl/DownloadCSVControl.tsx
+++ b/src/features/analytics_panel/components/DownloadCSVControl/DownloadCSVControl.tsx
@@ -1,0 +1,29 @@
+import { Download16 } from '@konturio/default-icons';
+import { useAtom } from '@reatom/react-v2';
+import { LayerActionIcon } from '~components/LayerActionIcon/LayerActionIcon';
+import { i18n } from '~core/localization';
+import { downloadCsv } from '~utils/file/download';
+import { analyticsResourceAtom } from '../../atoms/analyticsResource';
+import { analyticsToCsv } from '../../utils/toCsv';
+import s from './DownloadCSVControl.module.css';
+import type { AnalyticsData } from '~core/types';
+
+export function DownloadCSVControl() {
+  const [{ data }] = useAtom(analyticsResourceAtom);
+  if (!data) return null;
+
+  function handleClick() {
+    const csv = analyticsToCsv(data as AnalyticsData[]);
+    downloadCsv(csv, `analytics_${new Date().toISOString()}.csv`);
+  }
+
+  return (
+    <LayerActionIcon
+      onClick={handleClick}
+      hint={i18n.t('analytics_panel.download_csv')}
+      className={s.download}
+    >
+      <Download16 />
+    </LayerActionIcon>
+  );
+}

--- a/src/features/analytics_panel/components/PanelContent/PanelContent.module.css
+++ b/src/features/analytics_panel/components/PanelContent/PanelContent.module.css
@@ -4,6 +4,12 @@
   padding-bottom: var(--half-unit);
 }
 
+.controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--double-unit);
+}
+
 /* mobile */
 @media screen and (max-width: 960px) {
   .panelBody {

--- a/src/features/analytics_panel/components/PanelContent/PanelContent.tsx
+++ b/src/features/analytics_panel/components/PanelContent/PanelContent.tsx
@@ -1,9 +1,13 @@
 import { AnalyticsContainer } from '../AnalyticsContainer/AnalyticsContainer';
+import { DownloadCSVControl } from '../DownloadCSVControl/DownloadCSVControl';
 import styles from './PanelContent.module.css';
 
 export function PanelContent() {
   return (
     <div className={styles.panelBody}>
+      <div className={styles.controls}>
+        <DownloadCSVControl />
+      </div>
       <AnalyticsContainer />
     </div>
   );

--- a/src/features/analytics_panel/readme.md
+++ b/src/features/analytics_panel/readme.md
@@ -30,6 +30,10 @@ This component displays a message when no analytics data is available for the se
 
 This component is the main container for the analytics panel feature. It renders the `AnalyticsContainer` component inside a scrollable div.
 
+### DownloadCSVControl
+
+Provides a button that allows users to export the current analytics data as a CSV file.
+
 ## Constants
 
 `MIN_HEIGHT` and `MAX_HEIGHT`

--- a/src/features/analytics_panel/utils/toCsv.test.ts
+++ b/src/features/analytics_panel/utils/toCsv.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { analyticsToCsv } from './toCsv';
+import type { AnalyticsData } from '~core/types';
+
+test('analyticsToCsv converts analytics data to csv', () => {
+  const data: AnalyticsData[] = [
+    {
+      formula: 'f1',
+      value: 10,
+      unit: { id: 'u1', shortName: 'km', longName: 'kilometers' },
+      prefix: '',
+      xlabel: 'Population',
+      ylabel: 'people',
+    },
+  ];
+  const csv = analyticsToCsv(data);
+  expect(csv).toContain('xlabel,ylabel,prefix,value,unit,formula');
+  expect(csv).toContain('Population,people,,10,km,f1');
+});

--- a/src/features/analytics_panel/utils/toCsv.ts
+++ b/src/features/analytics_panel/utils/toCsv.ts
@@ -1,0 +1,14 @@
+import papa from 'papaparse';
+import type { AnalyticsData } from '~core/types';
+
+export function analyticsToCsv(data: AnalyticsData[]): string {
+  const rows = data.map((d) => ({
+    xlabel: d.xlabel,
+    ylabel: d.ylabel,
+    prefix: d.prefix,
+    value: d.value,
+    unit: d.unit.shortName,
+    formula: d.formula,
+  }));
+  return papa.unparse(rows);
+}

--- a/src/utils/file/download.ts
+++ b/src/utils/file/download.ts
@@ -17,3 +17,23 @@ export function downloadObject(
     }, 0),
   );
 }
+
+export function downloadText(content: string, fileName: string, mimeType = 'text/plain') {
+  const file = new Blob([content], { type: mimeType });
+  const a = document.createElement('a');
+  const url = URL.createObjectURL(file);
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  clearTimeout(
+    setTimeout(function () {
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    }, 0),
+  );
+}
+
+export function downloadCsv(content: string, fileName: string) {
+  downloadText(content, fileName, 'text/csv');
+}


### PR DESCRIPTION
## Summary
- add DownloadCSVControl component to analytics panel
- implement analytics to CSV conversion
- document export control
- update translations
- extend download utilities
- test CSV conversion utility

## Testing
- `npm run typecheck`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68628cc1b304832fabf4698527a65ed9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to download analytics data as a CSV file directly from the analytics panel.
  * Introduced a new download button with an icon and tooltip in the analytics panel interface.

* **Documentation**
  * Updated documentation to describe the new CSV download feature in the analytics panel.

* **Style**
  * Added and updated styles for the new download control and panel controls.

* **Tests**
  * Added tests to verify correct CSV conversion of analytics data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->