### PR TITLE
fix(map): handle missing tile urls for multivariate

### DIFF
--- a/src/core/logical_layers/renderers/ClickableFeaturesRenderer/ClickableFeaturesRenderer.tsx
+++ b/src/core/logical_layers/renderers/ClickableFeaturesRenderer/ClickableFeaturesRenderer.tsx
@@ -69,8 +69,12 @@ export abstract class ClickableFeaturesRenderer extends LogicalLayerDefaultRende
   private createTileSource(
     map: ApplicationMap,
     layer: LayerTileSource,
-  ): VectorSourceSpecification {
-    /* Create source */
+  ): VectorSourceSpecification | null {
+    if (!layer.source?.urls?.length) {
+      console.error(`[${this.id} layer renderer]: no tile URLs provided for source`);
+      return null;
+    }
+
     const mapSource: VectorSourceSpecification = {
       type: 'vector',
       tiles: layer.source.urls.map((url) => adaptTileUrl(url)),
@@ -175,10 +179,8 @@ export abstract class ClickableFeaturesRenderer extends LogicalLayerDefaultRende
     style: LayerStyle | null,
   ) {
     if (layerData == null) return;
-    const tileSourceSpec: VectorSourceSpecification = this.createTileSource(
-      map,
-      layerData,
-    );
+    const tileSourceSpec = this.createTileSource(map, layerData);
+    if (!tileSourceSpec) return;
     await mapLoaded(map);
     if (map.getSource(this._sourceId) === undefined) {
       map.addSource(this._sourceId, tileSourceSpec);


### PR DESCRIPTION
Fibery#TEST-DISASTER-NINJA-FE-4

## Summary
- prevent crash when multivariate layer source lacks tile URLs

## Testing
- `pnpm coverage`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_686562d17c5883248598352e15933235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing or empty tile URLs, preventing map layers from being added when required data is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->