### PR TITLE
chore(codecov): 00000 enforce non-regressive coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,11 +8,11 @@ component_management:
         - src/views/**
       statuses:
         - type: project
-          target: 8%
-          threshold: 1%
+          target: auto
+          threshold: 0%
         - type: patch
-          target: 15%
-          threshold: 2%
+          target: auto
+          threshold: 0%
 
     - component_id: core
       name: Core Logic
@@ -20,11 +20,11 @@ component_management:
         - src/core/**
       statuses:
         - type: project
-          target: 25%
-          threshold: 1%
+          target: auto
+          threshold: 0%
         - type: patch
-          target: 35%
-          threshold: 2%
+          target: auto
+          threshold: 0%
 
     - component_id: features
       name: Features
@@ -32,11 +32,11 @@ component_management:
         - src/features/**
       statuses:
         - type: project
-          target: 15%
-          threshold: 1%
+          target: auto
+          threshold: 0%
         - type: patch
-          target: 25%
-          threshold: 2%
+          target: auto
+          threshold: 0%
 
     - component_id: utils
       name: Utilities
@@ -44,11 +44,11 @@ component_management:
         - src/utils/**
       statuses:
         - type: project
-          target: 20%
-          threshold: 1%
+          target: auto
+          threshold: 0%
         - type: patch
-          target: 30%
-          threshold: 2%
+          target: auto
+          threshold: 0%
 
 github_checks:
   annotations: false


### PR DESCRIPTION
Fibery Ticket: 00000

## Summary
- use `target: auto` for all codecov component statuses
- set `threshold: 0%` so coverage cannot regress

## Testing
- `pnpm run coverage`
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686586ed75048324a286fc0ab5905d50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage settings to use automatic target detection and set thresholds to 0% for all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->