### PR TITLE
feat(layers): 14387 add contextual id handling

### DIFF
--- a/docs/contextual-layer-ids.md
+++ b/docs/contextual-layer-ids.md
@@ -1,0 +1,17 @@
+# Contextual Layer IDs
+
+Some layers depend on additional context like the selected event. To avoid ID collisions these layers now include the context identifier in their `id` value.
+
+The delimiter `__ctx__` separates the original layer id and the context id:
+
+```
+<layerId>__ctx__<contextId>
+```
+
+For example, an event shape layer with id `eventShape` belonging to event `56e8c85a-10e6-44f5-9cf0-51c6016a3e87` becomes:
+
+```
+eventShape__ctx__56e8c85a-10e6-44f5-9cf0-51c6016a3e87
+```
+
+Utility functions `applyContextToId` and `splitContextFromId` help working with these ids.

--- a/src/core/logical_layers/types/source.ts
+++ b/src/core/logical_layers/types/source.ts
@@ -43,6 +43,7 @@ export type LayerSource = LayerGeoJSONSource | LayerTileSource;
 
 export interface LayerSummaryDto {
   id: string;
+  originalId?: string;
   name: string;
   description?: string;
   category?: 'base' | 'overlay';

--- a/src/core/logical_layers/utils/contextualIds.ts
+++ b/src/core/logical_layers/utils/contextualIds.ts
@@ -1,0 +1,13 @@
+export const CONTEXT_DELIMITER = '__ctx__';
+
+export function applyContextToId(id: string, contextId?: string | null): string {
+  return contextId ? `${id}${CONTEXT_DELIMITER}${contextId}` : id;
+}
+
+export function splitContextFromId(id: string): { baseId: string; contextId: string | null } {
+  const parts = id.split(CONTEXT_DELIMITER);
+  if (parts.length > 1) {
+    return { baseId: parts.shift()!, contextId: parts.join(CONTEXT_DELIMITER) };
+  }
+  return { baseId: id, contextId: null };
+}

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsParamsAtom.ts
@@ -1,6 +1,7 @@
 import { createAtom } from '~utils/atoms/createPrimitives';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { focusedGeometryAtom } from '~core/focused_geometry/model';
+import { splitContextFromId } from '~core/logical_layers/utils/contextualIds';
 import { getEventId } from '~core/focused_geometry/utils';
 import { currentEventFeedAtom } from '~core/shared_state/currentEventFeed';
 import { layersGlobalResource } from '../layersGlobalResource';
@@ -65,9 +66,10 @@ export const areaLayersDetailsParamsAtom = createAtom(
       layersToRetrieveWithEventId,
     ] = mustBeRequested.reduce(
       (acc, layer) => {
-        acc[layer.boundaryRequiredForRetrieval ? 0 : 1].add(layer.id);
+        const { baseId } = splitContextFromId(layer.id);
+        acc[layer.boundaryRequiredForRetrieval ? 0 : 1].add(baseId);
         if (layer.eventIdRequiredForRetrieval) {
-          acc[2].add(layer.id);
+          acc[2].add(baseId);
         }
         return acc;
       },

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/areaLayersDetailsResourceAtomCache.ts
@@ -1,5 +1,6 @@
 import { createAtom } from '~utils/atoms/createPrimitives';
 import type { LayerDetailsDto } from '~core/logical_layers/types/source';
+import { splitContextFromId } from '~core/logical_layers/utils/contextualIds';
 import type { DetailsRequestParams } from './types';
 
 type EventId = string | null;
@@ -39,9 +40,10 @@ export const areaLayersDetailsResourceAtomCache = createAtom(
         request.layersToRetrieveWithGeometryFilter,
       );
       response.forEach((layer) => {
+        const { baseId } = splitContextFromId(layer.id);
         const cacheKey: string | null = getLayersDetailsCacheKey({
-          boundaryRequiredForRetrieval: layersToRetrieveWithGeometryFilter.has(layer.id),
-          eventIdRequiredForRetrieval: layersToRetrieveWithEventId.has(layer.id),
+          boundaryRequiredForRetrieval: layersToRetrieveWithGeometryFilter.has(baseId),
+          eventIdRequiredForRetrieval: layersToRetrieveWithEventId.has(baseId),
           eventId: request.eventId,
           hash: request.geoJSON?.hash,
         });

--- a/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
+++ b/src/features/layers_in_area/atoms/areaLayersDetailsResource/types.ts
@@ -1,6 +1,9 @@
 import type { GeometryWithHash } from '~core/focused_geometry/types';
 
 export interface DetailsRequestParams {
+  /**
+   * Layer ids without context suffix
+   */
   layersToRetrieveWithGeometryFilter?: string[];
   layersToRetrieveWithoutGeometryFilter?: string[];
   layersToRetrieveWithEventId?: string[];

--- a/src/features/layers_in_area/atoms/layersInAreaAndEventLayerResource.ts
+++ b/src/features/layers_in_area/atoms/layersInAreaAndEventLayerResource.ts
@@ -4,6 +4,7 @@ import { createAtom } from '~utils/atoms';
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
 import { removeEmpty } from '~utils/common';
 import { filterUnsupportedLayerTypes } from '~core/logical_layers/layerTypes';
+import { applyContextToId } from '~core/logical_layers/utils/contextualIds';
 import { getLayersInArea } from '~core/api/layers';
 import type { LayersInAreaAndEventLayerResourceParameters } from '~core/api/layers';
 import type { FocusedGeometry } from '~core/focused_geometry/types';
@@ -51,7 +52,12 @@ export const layersInAreaAndEventLayerResource = createAsyncAtom(
       layersInAreaAndEventLayerResourceParameters,
       abortController,
     );
-    return filterUnsupportedLayerTypes(layers || []);
+    const eventId = layersInAreaAndEventLayerResourceParameters.eventId;
+    return filterUnsupportedLayerTypes(layers || []).map((layer) => ({
+      ...layer,
+      id: applyContextToId(layer.id, eventId),
+      originalId: layer.id,
+    }));
   },
   'layersInAreaAndEventLayerResource',
 );


### PR DESCRIPTION
Fibery ticket: https://kontur.fibery.io/Tasks/Task/Different-event-shapes-have-same-id-14387

## Summary
- add helper for context-based layer ids
- attach event ID to layers returned from API
- strip context id when requesting layer details
- adjust cache logic for new ids
- document contextual layer id approach

## Testing
- `pnpm run test:unit` *(fails: tsx not found)*
- `pnpm run lint` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_686674a289c0832fb8723928423688a4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced contextual layer IDs, allowing layers to include additional context (such as event identifiers) in their IDs to prevent collisions.
  * Added utility functions for generating and parsing contextual layer IDs.

* **Documentation**
  * Added a new document explaining contextual layer IDs, their format, and usage examples.

* **Bug Fixes**
  * Improved handling of layer IDs in various features to ensure correct identification and prevent ID collisions when context is applied.

* **Style**
  * Enhanced code documentation with additional comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->