### PR TITLE
feat(metrics): 22156 embed Matomo Tag Manager

### DIFF
--- a/configs/config.default.json
+++ b/configs/config.default.json
@@ -60,5 +60,6 @@
   "KEYCLOAK_URL": "https://keycloak01.kontur.io",
   "KEYCLOAK_REALM": "kontur",
   "KEYCLOAK_CLIENT_ID": "kontur_platform",
-  "SENTRY_DSN": "https://fixme@dsn.ingest.sentry.io/project-id"
+  "SENTRY_DSN": "https://fixme@dsn.ingest.sentry.io/project-id",
+  "MATOMO_CONTAINER_URL": "https://matomo.kontur.io/js/container_R9VsLLth.js"
 }

--- a/src/core/config/loaders/stageConfigLoader.ts
+++ b/src/core/config/loaders/stageConfigLoader.ts
@@ -14,6 +14,7 @@ export interface StageConfigLegacy {
   KEYCLOAK_REALM: string;
   KEYCLOAK_CLIENT_ID: string;
   YANDEX_METRICA_ID?: number[];
+  MATOMO_CONTAINER_URL?: string;
   MAP_BLANK_SPACE_ID: string;
   AUTOFOCUS_ZOOM: number;
   INTERCOM_DEFAULT_NAME?: string;
@@ -42,6 +43,7 @@ export async function getStageConfig(): Promise<StageConfig> {
     keycloakRealm: c.KEYCLOAK_REALM,
     keycloakClientId: c.KEYCLOAK_CLIENT_ID,
     yandexMetricaId: c.YANDEX_METRICA_ID,
+    matomoContainerUrl: c.MATOMO_CONTAINER_URL,
     intercomDefaultName: c.INTERCOM_DEFAULT_NAME,
     intercomAppId: c.INTERCOM_APP_ID,
     intercomSelector: c.INTERCOM_SELECTOR,

--- a/src/core/config/types.ts
+++ b/src/core/config/types.ts
@@ -44,6 +44,7 @@ export interface StageConfig {
   keycloakClientId: string;
   // Third-party services
   yandexMetricaId?: number[];
+  matomoContainerUrl?: string;
   intercomDefaultName?: string;
   intercomAppId?: string;
   intercomSelector?: string;

--- a/src/core/metrics/externalMetrics/matomoMetrics.test.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, test, vi } from 'vitest';
+import { configRepo } from '~core/config';
+import { METRICS_EVENT } from '../constants';
+import { MatomoMetrics } from './matomoMetrics';
+
+describe('MatomoMetrics', () => {
+  test('injects script using config url', () => {
+    vi.spyOn(configRepo, 'get').mockReturnValue({
+      id: 'atlas',
+      matomoContainerUrl: 'https://matomo.example.com/container.js',
+    } as any);
+    document.head.innerHTML = '<script></script>';
+    const metrics = new MatomoMetrics();
+    metrics.init('atlas', 'home', () => true);
+    const scripts = document.getElementsByTagName('script');
+    expect(scripts[0]?.getAttribute('src')).toBe(
+      'https://matomo.example.com/container.js',
+    );
+  });
+
+  test('dispatches events to data layer', () => {
+    const pushSpy = vi.fn();
+    (globalThis as any)._mtm = { push: pushSpy };
+    vi.spyOn(configRepo, 'get').mockReturnValue({
+      id: 'atlas',
+      matomoContainerUrl: 'https://matomo.example.com/container.js',
+    } as any);
+    document.head.innerHTML = '<script></script>';
+    const metrics = new MatomoMetrics();
+    metrics.init('atlas', 'home', () => true);
+    metrics['ready'] = true;
+    globalThis.dispatchEvent(
+      new CustomEvent(METRICS_EVENT, { detail: { name: 'test' } }),
+    );
+    expect(pushSpy).toHaveBeenCalledWith({ event: 'test', app_id: 'atlas' });
+  });
+});

--- a/src/core/metrics/externalMetrics/matomoMetrics.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.ts
@@ -1,28 +1,40 @@
 import { METRICS_EVENT } from '~core/metrics/constants';
 import { configRepo } from '~core/config';
 import type { Metric, MetricsEvent } from '../types';
+import type { AppFeatureType } from '~core/app/types';
 
 export class MatomoMetrics implements Metric {
   private ready = false;
+  private appId = '';
 
-  init() {
-    // inject Matomo Tag Manager script dynamically
-    const _mtm = (globalThis._mtm = globalThis._mtm || []);
-    _mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' });
+  init(appId: string, _route: string, _hasFeature: (f: AppFeatureType) => boolean) {
+    this.appId = appId;
     const d = globalThis.document;
     if (d) {
-      const g = d.createElement('script');
-      g.async = true;
-      g.src = 'https://matomo.kontur.io/js/container_R9VsLLth.js';
-      const s = d.getElementsByTagName('script')[0];
-      s?.parentNode?.insertBefore(g, s);
+      try {
+        const _mtm = (globalThis._mtm = globalThis._mtm || []);
+        _mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' });
+        const g = d.createElement('script');
+        g.async = true;
+        g.src = configRepo.get().matomoContainerUrl ?? '';
+        g.addEventListener('load', () => {
+          this.ready = true;
+        });
+        g.addEventListener('error', (err) => {
+          console.error('Matomo script failed to load', err);
+        });
+        const s = d.getElementsByTagName('script')[0];
+        s?.parentNode?.insertBefore(g, s);
+      } catch (e) {
+        console.error('Failed to inject Matomo script', e);
+      }
     }
     this.subscribeMetricsEvents();
-    this.ready = true;
   }
 
+  // Matomo integration does not require manual marks
   mark(name: string, payload: unknown) {
-    /* Noop */
+    /* intentionally empty */
   }
 
   private subscribeMetricsEvents() {
@@ -38,7 +50,7 @@ export class MatomoMetrics implements Metric {
   }
 
   private dispatchEvent(name: string) {
-    if (!this.ready) return;
-    globalThis._mtm.push({ event: name, app_id: configRepo.get().id });
+    if (!this.ready || typeof globalThis._mtm?.push !== 'function') return;
+    globalThis._mtm.push({ event: name, app_id: this.appId });
   }
 }

--- a/src/core/metrics/externalMetrics/matomoMetrics.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.ts
@@ -1,0 +1,44 @@
+import { METRICS_EVENT } from '~core/metrics/constants';
+import { configRepo } from '~core/config';
+import type { Metric, MetricsEvent } from '../types';
+
+export class MatomoMetrics implements Metric {
+  private ready = false;
+
+  init() {
+    // inject Matomo Tag Manager script dynamically
+    const _mtm = (globalThis._mtm = globalThis._mtm || []);
+    _mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' });
+    const d = globalThis.document;
+    if (d) {
+      const g = d.createElement('script');
+      g.async = true;
+      g.src = 'https://matomo.kontur.io/js/container_R9VsLLth.js';
+      const s = d.getElementsByTagName('script')[0];
+      s?.parentNode?.insertBefore(g, s);
+    }
+    this.subscribeMetricsEvents();
+    this.ready = true;
+  }
+
+  mark(name: string, payload: unknown) {
+    /* Noop */
+  }
+
+  private subscribeMetricsEvents() {
+    globalThis.addEventListener(
+      METRICS_EVENT,
+      this.metricsListener.bind(this) as EventListener,
+    );
+  }
+
+  private metricsListener(e: MetricsEvent) {
+    const { name } = e.detail;
+    this.dispatchEvent(name);
+  }
+
+  private dispatchEvent(name: string) {
+    if (!this.ready) return;
+    globalThis._mtm.push({ event: name, app_id: configRepo.get().id });
+  }
+}

--- a/src/core/metrics/externalMetrics/matomoMetrics.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.ts
@@ -24,7 +24,11 @@ export class MatomoMetrics implements Metric {
           console.error('Matomo script failed to load', err);
         });
         const s = d.getElementsByTagName('script')[0];
-        s?.parentNode?.insertBefore(g, s);
+        if (s?.parentNode) {
+          s.parentNode.insertBefore(g, s);
+        } else {
+          d.head.appendChild(g);
+        }
       } catch (e) {
         console.error('Failed to inject Matomo script', e);
       }

--- a/src/core/metrics/index.ts
+++ b/src/core/metrics/index.ts
@@ -2,12 +2,15 @@ import { once } from '~utils/common';
 import { cookieManagementService, permissionStatuses } from '~core/cookie_settings';
 import { AppMetrics } from './app-metrics';
 import { GoogleMetrics } from './externalMetrics/googleMetrics';
+import { MatomoMetrics } from './externalMetrics/matomoMetrics';
 import { YandexMetrics } from './externalMetrics/yandexMetrics';
 import { addAllSequences } from './sequences';
 
 const appMetrics = AppMetrics.getInstance();
 const googleMetrics = new GoogleMetrics();
+const matomoMetrics = new MatomoMetrics();
 export const yandexMetrics = new YandexMetrics();
+export const matomo = matomoMetrics;
 
 addAllSequences(appMetrics);
 
@@ -16,7 +19,7 @@ export const initMetricsOnce = once(async (appId: string, routeId: string) => {
 
   /* Enabling / Disabling GTM */
   if (import.meta.env.MODE !== 'development') {
-    const externalMetrics = [googleMetrics, yandexMetrics];
+    const externalMetrics = [googleMetrics, matomoMetrics, yandexMetrics];
     const gtmPermission = cookieManagementService.requestPermission('GTM');
     gtmPermission.onStatusChange((status) => {
       if (status === permissionStatuses.granted) {

--- a/src/core/metrics/readme.md
+++ b/src/core/metrics/readme.md
@@ -1,0 +1,14 @@
+# Metrics System
+
+This module collects application events and forwards them to external analytics providers.
+Currently supported providers are Google Tag Manager, Yandex Metrica and Matomo Tag Manager.
+
+External metrics are initialized only when the user grants the `GTM` cookie permission.
+`initMetricsOnce` in `src/core/metrics/index.ts` wires all providers together.
+
+## Matomo integration
+
+`MatomoMetrics` dynamically injects the Matomo container script and listens for
+internal `METRICS` events. Every event is pushed to Matomo's data layer
+including the current `app_id` from configuration. The implementation resides in
+`src/core/metrics/externalMetrics/matomoMetrics.ts`.

--- a/src/core/metrics/readme.md
+++ b/src/core/metrics/readme.md
@@ -1,14 +1,12 @@
 # Metrics System
 
 This module collects application events and forwards them to external analytics providers.
-Currently supported providers are Google Tag Manager, Yandex Metrica and Matomo Tag Manager.
+Currently supported providers are Google Tag Manager, Yandex.Metrica, and Matomo Tag Manager.
 
 External metrics are initialized only when the user grants the `GTM` cookie permission.
 `initMetricsOnce` in `src/core/metrics/index.ts` wires all providers together.
 
 ## Matomo integration
 
-`MatomoMetrics` dynamically injects the Matomo container script and listens for
-internal `METRICS` events. Every event is pushed to Matomo's data layer
-including the current `app_id` from configuration. The implementation resides in
+`MatomoMetrics` injects the Matomo container script and listens for internal `METRICS` events, pushing each one to Matomo's data layer with the current `app_id` from configuration. The implementation resides in
 `src/core/metrics/externalMetrics/matomoMetrics.ts`.


### PR DESCRIPTION
Fibery ticket: [22156](https://kontur.fibery.io/Tasks/Task/22156)

## Summary
- integrate Matomo Tag Manager alongside Google Tag Manager
- initialize Matomo only when GTM cookies are granted
- document metrics module

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_b_6870e57a0f308324a44c46e8e8e54bf5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integration with Matomo analytics, allowing event tracking via Matomo Tag Manager after user consent.
* **Documentation**
  * Introduced documentation outlining the metrics system and detailing the new Matomo analytics integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->