### PR TITLE
feat(metrics): 22156 add Matomo tag manager

### DIFF
--- a/configs/config.default.json
+++ b/configs/config.default.json
@@ -60,5 +60,6 @@
   "KEYCLOAK_URL": "https://keycloak01.kontur.io",
   "KEYCLOAK_REALM": "kontur",
   "KEYCLOAK_CLIENT_ID": "kontur_platform",
-  "SENTRY_DSN": "https://fixme@dsn.ingest.sentry.io/project-id"
+  "SENTRY_DSN": "https://fixme@dsn.ingest.sentry.io/project-id",
+  "MATOMO_CONTAINER_URL": "https://matomo.kontur.io/js/container_R9VsLLth.js"
 }

--- a/src/core/config/__mocks__/_configMock.ts
+++ b/src/core/config/__mocks__/_configMock.ts
@@ -21,6 +21,7 @@ const _configDataMock = {
   // intercomDefaultName: null,
   intercomAppId: 'e59cl64z',
   intercomSelector: '#kontur_header_chat_btn',
+  matomoContainerUrl: 'https://matomo.kontur.io/js/container_R9VsLLth.js',
   defaultFeed: 'kontur-public',
   osmEditors: [
     {
@@ -351,7 +352,6 @@ const _configDataMock = {
   activeLayers: ['kontur_lines', 'population_density'],
 };
 
-// @ts-ignore
 configRepo.get = () => _configDataMock;
 
 export { configRepo };

--- a/src/core/config/loaders/stageConfigLoader.ts
+++ b/src/core/config/loaders/stageConfigLoader.ts
@@ -19,6 +19,7 @@ export interface StageConfigLegacy {
   INTERCOM_DEFAULT_NAME?: string;
   INTERCOM_APP_ID?: string;
   INTERCOM_SELECTOR?: string;
+  MATOMO_CONTAINER_URL?: string;
   FEATURES_BY_DEFAULT: AppFeatureType[];
   DEFAULT_FEED: string;
   OSM_EDITORS: OsmEditorConfig[];
@@ -45,6 +46,7 @@ export async function getStageConfig(): Promise<StageConfig> {
     intercomDefaultName: c.INTERCOM_DEFAULT_NAME,
     intercomAppId: c.INTERCOM_APP_ID,
     intercomSelector: c.INTERCOM_SELECTOR,
+    matomoContainerUrl: c.MATOMO_CONTAINER_URL,
     defaultFeed: c.DEFAULT_FEED,
     osmEditors: c.OSM_EDITORS,
     autofocusZoom: c.AUTOFOCUS_ZOOM,

--- a/src/core/config/types.ts
+++ b/src/core/config/types.ts
@@ -47,6 +47,7 @@ export interface StageConfig {
   intercomDefaultName?: string;
   intercomAppId?: string;
   intercomSelector?: string;
+  matomoContainerUrl?: string;
   // Event api config
   defaultFeed: string;
   // Map editor config

--- a/src/core/metrics/externalMetrics/README.md
+++ b/src/core/metrics/externalMetrics/README.md
@@ -1,6 +1,6 @@
 # External Metrics
 
-This folder contains implementations used to integrate third party analytics systems.
+This folder contains implementations used to integrate third-party analytics systems.
 
 ## Matomo Tag Manager
 

--- a/src/core/metrics/externalMetrics/README.md
+++ b/src/core/metrics/externalMetrics/README.md
@@ -4,6 +4,6 @@ This folder contains implementations used to integrate third party analytics sys
 
 ## Matomo Tag Manager
 
-`MatomoMetrics` dynamically loads the Matomo Tag Manager container and pushes metric events to the `_mtm` data layer. The container URL is `https://matomo.kontur.io/js/container_R9VsLLth.js`.
+`MatomoMetrics` dynamically loads the Matomo Tag Manager container and pushes metric events to the `_mtm` data layer. The container URL is read from `configRepo.get().matomoContainerUrl`.
 
 The metrics system initializes external trackers only after the user grants the **GTM** cookie permission (see `cookie_settings`). Once enabled, events dispatched via `dispatchMetricsEvent` are forwarded to Google Tag Manager, Yandex Metrica, and Matomo Tag Manager.

--- a/src/core/metrics/externalMetrics/README.md
+++ b/src/core/metrics/externalMetrics/README.md
@@ -1,0 +1,9 @@
+# External Metrics
+
+This folder contains implementations used to integrate third party analytics systems.
+
+## Matomo Tag Manager
+
+`MatomoMetrics` dynamically loads the Matomo Tag Manager container and pushes metric events to the `_mtm` data layer. The container URL is `https://matomo.kontur.io/js/container_R9VsLLth.js`.
+
+The metrics system initializes external trackers only after the user grants the **GTM** cookie permission (see `cookie_settings`). Once enabled, events dispatched via `dispatchMetricsEvent` are forwarded to Google Tag Manager, Yandex Metrica, and Matomo Tag Manager.

--- a/src/core/metrics/externalMetrics/matomoMetrics.test.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.test.ts
@@ -25,7 +25,7 @@ describe('MatomoMetrics', () => {
     prepareDom();
     const baseConfig = configRepo.get();
     const mockConfig: Config = { ...baseConfig, id: 'test_app', matomoContainerUrl: URL };
-    configRepo.get = vi.fn<[], Config>(() => mockConfig);
+    configRepo.get = vi.fn(() => mockConfig);
     const metric = new MatomoMetrics();
     metric.init('app', 'route');
 
@@ -46,7 +46,7 @@ describe('MatomoMetrics', () => {
     prepareDom();
     const baseConfig = configRepo.get();
     const mockConfig: Config = { ...baseConfig, id: 'test_app', matomoContainerUrl: URL };
-    configRepo.get = vi.fn<[], Config>(() => mockConfig);
+    configRepo.get = vi.fn(() => mockConfig);
     const metric = new MatomoMetrics();
     metric.init('a', 'b');
     const scriptsAfterFirst = document.querySelectorAll(`script[src="${URL}"]`).length;
@@ -59,9 +59,9 @@ describe('MatomoMetrics', () => {
 
   test('dispatchEvent handles errors', () => {
     prepareDom();
-    configRepo.get = vi.fn<[], Config>(() => {
+    configRepo.get = vi.fn(() => {
       throw new Error('boom');
-    });
+    }) as unknown as typeof configRepo.get;
     const metric = new MatomoMetrics();
     metric.init('a', 'b');
     (globalThis as any)._mtm = {
@@ -77,7 +77,7 @@ describe('MatomoMetrics', () => {
     prepareDom();
     const baseConfig = configRepo.get();
     const mockConfig: Config = { ...baseConfig, id: 'test_app', matomoContainerUrl: URL };
-    configRepo.get = vi.fn<[], Config>(() => mockConfig);
+    configRepo.get = vi.fn(() => mockConfig);
     const metric = new MatomoMetrics();
     metric.init('a', 'b');
     metric.cleanup();

--- a/src/core/metrics/externalMetrics/matomoMetrics.test.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { test, expect } from 'vitest';
+import { MatomoMetrics } from './matomoMetrics';
+import { METRICS_EVENT } from '../constants';
+import { configRepo } from '~core/config/__mocks__/_configMock';
+
+test('matomo metrics pushes events to _mtm data layer', () => {
+  const metric = new MatomoMetrics();
+  // ensure script insertion does not fail when document has no scripts
+  const dummy = document.createElement('script');
+  document.head.appendChild(dummy);
+  const origCreate = document.createElement.bind(document);
+  document.createElement = (tag: string) => {
+    if (tag === 'script') {
+      const stub = origCreate('script');
+      Object.defineProperty(stub, 'src', { set() {}, get() { return ''; } });
+      return stub as HTMLScriptElement;
+    }
+    return origCreate(tag);
+  };
+  // ensure configRepo returns id
+  // @ts-ignore
+  configRepo.get = () => ({ id: 'test_app' });
+  metric.init();
+  const mtm: any[] = (globalThis as any)._mtm;
+  expect(Array.isArray(mtm)).toBe(true);
+
+  const evt = new CustomEvent(METRICS_EVENT, { detail: { name: 'test_event' } });
+  globalThis.dispatchEvent(evt);
+
+  expect(mtm.some((e) => e.event === 'test_event')).toBe(true);
+});

--- a/src/core/metrics/externalMetrics/matomoMetrics.test.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.test.ts
@@ -1,34 +1,81 @@
 /**
  * @vitest-environment happy-dom
  */
-import { test, expect } from 'vitest';
-import { MatomoMetrics } from './matomoMetrics';
-import { METRICS_EVENT } from '../constants';
+import { describe, test, expect, vi } from 'vitest';
 import { configRepo } from '~core/config/__mocks__/_configMock';
+import { METRICS_EVENT } from '../constants';
+import { MatomoMetrics } from './matomoMetrics';
 
-test('matomo metrics pushes events to _mtm data layer', () => {
-  const metric = new MatomoMetrics();
-  // ensure script insertion does not fail when document has no scripts
+const URL = 'https://matomo.kontur.io/js/container_R9VsLLth.js';
+
+function prepareDom() {
+  document.head.innerHTML = '';
   const dummy = document.createElement('script');
   document.head.appendChild(dummy);
-  const origCreate = document.createElement.bind(document);
-  document.createElement = (tag: string) => {
-    if (tag === 'script') {
-      const stub = origCreate('script');
-      Object.defineProperty(stub, 'src', { set() {}, get() { return ''; } });
-      return stub as HTMLScriptElement;
-    }
-    return origCreate(tag);
-  };
-  // ensure configRepo returns id
-  // @ts-ignore
-  configRepo.get = () => ({ id: 'test_app' });
-  metric.init();
-  const mtm: any[] = (globalThis as any)._mtm;
-  expect(Array.isArray(mtm)).toBe(true);
+  (globalThis as any)._mtm = [];
+}
 
-  const evt = new CustomEvent(METRICS_EVENT, { detail: { name: 'test_event' } });
-  globalThis.dispatchEvent(evt);
+describe('MatomoMetrics', () => {
+  test('pushes events to _mtm data layer', () => {
+    prepareDom();
+    configRepo.get = vi.fn(() => ({ id: 'test_app', matomoContainerUrl: URL })) as any;
+    const origCreate = document.createElement;
+    const createSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tag: string) => origCreate.call(document, tag));
+    const metric = new MatomoMetrics();
+    metric.init('app', 'route');
+    createSpy.mockRestore();
 
-  expect(mtm.some((e) => e.event === 'test_event')).toBe(true);
+    const mtm: any[] = (globalThis as any)._mtm;
+    expect(Array.isArray(mtm)).toBe(true);
+
+    const evt = new CustomEvent(METRICS_EVENT, { detail: { name: 'test_event' } });
+    globalThis.dispatchEvent(evt);
+
+    expect(mtm.some((e) => e.event === 'test_event')).toBe(true);
+    metric.cleanup();
+  });
+
+  test('does not initialize twice', () => {
+    prepareDom();
+    configRepo.get = vi.fn(() => ({ id: 'test_app', matomoContainerUrl: URL })) as any;
+    const metric = new MatomoMetrics();
+    metric.init('a', 'b');
+    const scriptsAfterFirst = document.querySelectorAll(`script[src="${URL}"]`).length;
+    metric.init('a', 'b');
+    const scriptsAfterSecond = document.querySelectorAll(`script[src="${URL}"]`).length;
+    expect(scriptsAfterFirst).toBe(1);
+    expect(scriptsAfterSecond).toBe(1);
+    metric.cleanup();
+  });
+
+  test('dispatchEvent handles errors', () => {
+    prepareDom();
+    configRepo.get = vi.fn(() => {
+      throw new Error('boom');
+    }) as any;
+    const metric = new MatomoMetrics();
+    metric.init('a', 'b');
+    (globalThis as any)._mtm = {
+      push: () => {
+        throw new Error('fail');
+      },
+    };
+    expect(() => metric.dispatchEvent('x')).not.toThrow();
+    metric.cleanup();
+  });
+
+  test('cleanup removes listener', () => {
+    prepareDom();
+    configRepo.get = vi.fn(() => ({ id: 'test_app', matomoContainerUrl: URL })) as any;
+    const metric = new MatomoMetrics();
+    metric.init('a', 'b');
+    metric.cleanup();
+    (globalThis as any)._mtm = [];
+    const evt = new CustomEvent(METRICS_EVENT, { detail: { name: 'after-cleanup' } });
+    globalThis.dispatchEvent(evt);
+    const mtm: any[] = (globalThis as any)._mtm;
+    expect(mtm.some((e) => e.event === 'after-cleanup')).toBe(false);
+  });
 });

--- a/src/core/metrics/externalMetrics/matomoMetrics.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.ts
@@ -1,0 +1,44 @@
+import { METRICS_EVENT } from '~core/metrics/constants';
+import { configRepo } from '~core/config';
+import type { Metric, MetricsEvent } from '../types';
+
+export class MatomoMetrics implements Metric {
+  private ready = false;
+
+  init() {
+    if (this.ready) return;
+    const w = globalThis as any;
+    w._mtm = w._mtm || [];
+    w._mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' });
+    const d = document;
+    const g = d.createElement('script');
+    const s = d.getElementsByTagName('script')[0];
+    g.async = true;
+    g.src = 'https://matomo.kontur.io/js/container_R9VsLLth.js';
+    s.parentNode?.insertBefore(g, s);
+    this.subscribeMetricsEvents();
+    this.ready = true;
+  }
+
+  mark(name: string, payload: unknown) {
+    /* noop */
+  }
+
+  subscribeMetricsEvents() {
+    globalThis.addEventListener(
+      METRICS_EVENT,
+      this.metricsListener.bind(this) as EventListener,
+    );
+  }
+
+  metricsListener(e: MetricsEvent) {
+    const { name } = e.detail;
+    this.dispatchEvent(name);
+  }
+
+  dispatchEvent(name: string) {
+    const w = globalThis as any;
+    w._mtm = w._mtm || [];
+    w._mtm.push({ event: name, app_id: configRepo.get().id });
+  }
+}

--- a/src/core/metrics/externalMetrics/matomoMetrics.ts
+++ b/src/core/metrics/externalMetrics/matomoMetrics.ts
@@ -1,11 +1,14 @@
 import { METRICS_EVENT } from '~core/metrics/constants';
 import { configRepo } from '~core/config';
+import type { AppFeatureType } from '~core/app/types';
 import type { Metric, MetricsEvent } from '../types';
 
 export class MatomoMetrics implements Metric {
   private ready = false;
+  private listener?: EventListener;
+  private scriptUrl = '';
 
-  init() {
+  init(_appId: string, _route: string, _hasFeature?: (f: AppFeatureType) => boolean) {
     if (this.ready) return;
     const w = globalThis as any;
     w._mtm = w._mtm || [];
@@ -14,8 +17,16 @@ export class MatomoMetrics implements Metric {
     const g = d.createElement('script');
     const s = d.getElementsByTagName('script')[0];
     g.async = true;
-    g.src = 'https://matomo.kontur.io/js/container_R9VsLLth.js';
-    s.parentNode?.insertBefore(g, s);
+    try {
+      this.scriptUrl = configRepo.get().matomoContainerUrl;
+      g.src = this.scriptUrl;
+      g.addEventListener('error', (err) => {
+        console.error('Matomo script failed to load', err);
+      });
+      s.parentNode?.insertBefore(g, s);
+    } catch (e) {
+      console.error('Matomo script injection error', e);
+    }
     this.subscribeMetricsEvents();
     this.ready = true;
   }
@@ -25,10 +36,15 @@ export class MatomoMetrics implements Metric {
   }
 
   subscribeMetricsEvents() {
-    globalThis.addEventListener(
-      METRICS_EVENT,
-      this.metricsListener.bind(this) as EventListener,
-    );
+    this.listener = this.metricsListener.bind(this) as EventListener;
+    globalThis.addEventListener(METRICS_EVENT, this.listener);
+  }
+
+  cleanup() {
+    if (this.listener) {
+      globalThis.removeEventListener(METRICS_EVENT, this.listener);
+      this.listener = undefined;
+    }
   }
 
   metricsListener(e: MetricsEvent) {
@@ -37,8 +53,12 @@ export class MatomoMetrics implements Metric {
   }
 
   dispatchEvent(name: string) {
-    const w = globalThis as any;
-    w._mtm = w._mtm || [];
-    w._mtm.push({ event: name, app_id: configRepo.get().id });
+    try {
+      const w = globalThis as any;
+      w._mtm = w._mtm || [];
+      w._mtm.push({ event: name, app_id: configRepo.get().id });
+    } catch (e) {
+      console.error('Matomo dispatch failed', e);
+    }
   }
 }

--- a/src/core/metrics/index.ts
+++ b/src/core/metrics/index.ts
@@ -3,11 +3,13 @@ import { cookieManagementService, permissionStatuses } from '~core/cookie_settin
 import { AppMetrics } from './app-metrics';
 import { GoogleMetrics } from './externalMetrics/googleMetrics';
 import { YandexMetrics } from './externalMetrics/yandexMetrics';
+import { MatomoMetrics } from './externalMetrics/matomoMetrics';
 import { addAllSequences } from './sequences';
 
 const appMetrics = AppMetrics.getInstance();
 const googleMetrics = new GoogleMetrics();
 export const yandexMetrics = new YandexMetrics();
+const matomoMetrics = new MatomoMetrics();
 
 addAllSequences(appMetrics);
 
@@ -16,7 +18,7 @@ export const initMetricsOnce = once(async (appId: string, routeId: string) => {
 
   /* Enabling / Disabling GTM */
   if (import.meta.env.MODE !== 'development') {
-    const externalMetrics = [googleMetrics, yandexMetrics];
+    const externalMetrics = [googleMetrics, yandexMetrics, matomoMetrics];
     const gtmPermission = cookieManagementService.requestPermission('GTM');
     gtmPermission.onStatusChange((status) => {
       if (status === permissionStatuses.granted) {


### PR DESCRIPTION
## Summary
- integrate Matomo Tag Manager alongside existing metrics
- push metric events to Matomo data layer
- document external metrics and add unit tests

## Testing
- `pnpm coverage`

------
https://chatgpt.com/codex/tasks/task_b_68776bbbfbfc8324a5cd861a52594042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integration with Matomo Tag Manager for analytics, alongside existing Google Tag Manager and Yandex Metrica support.

* **Documentation**
  * Introduced a README file detailing the external metrics integrations and Matomo Tag Manager setup.

* **Tests**
  * Added tests to verify correct event dispatching and script injection for Matomo integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->