### PR TITLE
fix(toolbar): 17452 hide tooltips in expanded state

### DIFF
--- a/e2e/page-objects/toolBar.ts
+++ b/e2e/page-objects/toolBar.ts
@@ -58,24 +58,23 @@ export class ToolBar extends HelperBase {
   }
 
   /**
-   * This method checks that there are some texts/tooltips that should be visible in big toolbar and also some texts that should not be visible there
+   * This method checks that there are some texts visible in the expanded toolbar
+   * and some texts that should be hidden.
    * @param visibleTexts - array of visible texts
    * @param hiddenTexts - array of hidden texts
    */
 
   @step(
     (args) =>
-      `Check that the following texts in toolbar are visible: ${args[0].join(', ')} and the following texts are hidden: ${args[1].join(', ')}. Check tooltips for visible texts.`,
+      `Check that the following texts in toolbar are visible: ${args[0].join(', ')} and the following texts are hidden: ${args[1].join(', ')}.`,
   )
-  async checkTextsAndTooltipsInToolbar(visibleTexts: string[], hiddenTexts: string[]) {
+  async checkTextsInToolbar(visibleTexts: string[], hiddenTexts: string[]) {
     for (const text of visibleTexts) {
       const element = await this.getButtonByText(text);
       await expect(
         element,
         `Expect element with text '${text}' to be visible on the map side of app`,
       ).toBeVisible();
-      if (text !== 'Save as reference area')
-        await this.hoverElAndCheckTooltip(element, text);
     }
     await Promise.all(
       hiddenTexts.map(async (text) => {

--- a/e2e/toolBarTexts.spec.ts
+++ b/e2e/toolBarTexts.spec.ts
@@ -46,7 +46,7 @@ for (const project of projects) {
     }
 
     if (project.name !== 'atlas') {
-      await pageManager.atToolBar.checkTextsAndTooltipsInToolbar(
+      await pageManager.atToolBar.checkTextsInToolbar(
         visibleTexts,
         hiddenToolbarFeaturesGuest,
       );
@@ -56,7 +56,7 @@ for (const project of projects) {
         pageManager.atToolBar.getToolBarData(hiddenToolbarFeaturesGuest),
       );
       await pageManager.atToolBar.resizeToolbar({ collapse: false });
-      await pageManager.atToolBar.checkTextsAndTooltipsInToolbar(
+      await pageManager.atToolBar.checkTextsInToolbar(
         visibleTexts,
         hiddenToolbarFeaturesGuest,
       );

--- a/e2e/toolBarTextsWithPro.spec.ts
+++ b/e2e/toolBarTextsWithPro.spec.ts
@@ -111,13 +111,13 @@ for (const project of projects) {
 
     await pageManager.atBrowser.openProject(project, { skipCookieBanner: true });
     await pageManager.atNavigationMenu.clickButtonToOpenPage('Map');
-    await pageManager.atToolBar.checkTextsAndTooltipsInToolbar(visibleTexts, hiddenTexts);
+    await pageManager.atToolBar.checkTextsInToolbar(visibleTexts, hiddenTexts);
     await pageManager.atToolBar.resizeToolbar({ collapse: true });
     await pageManager.atToolBar.checkTooltipsInShortToolbar(
       pageManager.atToolBar.getToolBarData(visibleTexts),
       pageManager.atToolBar.getToolBarData(hiddenTexts),
     );
     await pageManager.atToolBar.resizeToolbar({ collapse: false });
-    await pageManager.atToolBar.checkTextsAndTooltipsInToolbar(visibleTexts, hiddenTexts);
+    await pageManager.atToolBar.checkTextsInToolbar(visibleTexts, hiddenTexts);
   });
 }

--- a/e2e/toolBarTextsWithUser.spec.ts
+++ b/e2e/toolBarTextsWithUser.spec.ts
@@ -74,20 +74,14 @@ for (const project of projects) {
     }
 
     if (project.name !== 'atlas') {
-      await pageManager.atToolBar.checkTextsAndTooltipsInToolbar(
-        visibleTexts,
-        hiddenTexts,
-      );
+      await pageManager.atToolBar.checkTextsInToolbar(visibleTexts, hiddenTexts);
       await pageManager.atToolBar.resizeToolbar({ collapse: true });
       await pageManager.atToolBar.checkTooltipsInShortToolbar(
         pageManager.atToolBar.getToolBarData(visibleTexts),
         pageManager.atToolBar.getToolBarData(hiddenTexts),
       );
       await pageManager.atToolBar.resizeToolbar({ collapse: false });
-      await pageManager.atToolBar.checkTextsAndTooltipsInToolbar(
-        visibleTexts,
-        hiddenTexts,
-      );
+      await pageManager.atToolBar.checkTextsInToolbar(visibleTexts, hiddenTexts);
     } else {
       await expect(
         pageManager.atToolBar.getButtonByText('Measure distance'),

--- a/src/features/toolbar/components/ToolbarButton/ToolbarButton.tsx
+++ b/src/features/toolbar/components/ToolbarButton/ToolbarButton.tsx
@@ -35,7 +35,7 @@ export const ToolbarButton = forwardRef(function ToolbarButton(
   ref: React.Ref<HTMLButtonElement>,
 ) {
   return (
-    <SimpleTooltip content={hint} placement="top">
+    <SimpleTooltip content={hint} placement="top" open={false}>
       <Button
         ref={ref}
         variant={variant}

--- a/src/features/toolbar/readme.md
+++ b/src/features/toolbar/readme.md
@@ -1,0 +1,11 @@
+## Toolbar
+
+Collapsible panel that provides map tools.
+
+### Behavior
+
+Toolbar has two states: expanded (full) and collapsed (short). In the full state buttons display text labels and tooltips are hidden. In the short state buttons show only icons and tooltips appear on hover.
+
+### How to use
+
+Import `toolbar` and `shortToolbar` panel states from `~features/toolbar` and pass them to `FullAndShortStatesPanelWidget`.


### PR DESCRIPTION
## Summary
- hide tooltips for toolbar buttons when panel is expanded
- update e2e tests for new behavior
- document toolbar feature

Fibery ticket: [17452](https://kontur.fibery.io/Tasks/Task/17452)

------
https://chatgpt.com/codex/tasks/task_e_687f87765838832fb7b275f46e34a581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README file for the toolbar feature, explaining its states, behavior, and usage instructions.

* **Bug Fixes**
  * Tooltips in the expanded toolbar state are now consistently hidden, ensuring they do not appear when not intended.

* **Tests**
  * Updated end-to-end tests to verify only toolbar text visibility in the expanded state, no longer checking for tooltips in this mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->