### PR TITLE
fix(toolbar): 22253 show default tooltips except MCDA

### DIFF
--- a/src/features/toolbar/components/ShortToolbarButton/ShortToolbarButton.tsx
+++ b/src/features/toolbar/components/ShortToolbarButton/ShortToolbarButton.tsx
@@ -20,7 +20,7 @@ export const ShortToolbarButton = forwardRef(function ToolbarButton(
   ref: React.Ref<HTMLButtonElement>,
 ) {
   return (
-    <SimpleTooltip content={hint} placement="top">
+    <SimpleTooltip content={hint ?? children} placement="top">
       <Button
         data-testid={id}
         ref={ref}

--- a/src/features/toolbar/components/ToolbarButton/ToolbarButton.tsx
+++ b/src/features/toolbar/components/ToolbarButton/ToolbarButton.tsx
@@ -35,7 +35,7 @@ export const ToolbarButton = forwardRef(function ToolbarButton(
   ref: React.Ref<HTMLButtonElement>,
 ) {
   return (
-    <SimpleTooltip content={hint} placement="top">
+    <SimpleTooltip content={hint ?? children} placement="top">
       <Button
         ref={ref}
         variant={variant}

--- a/src/features/toolbar/components/ToolbarControl/ToolbarControl.tsx
+++ b/src/features/toolbar/components/ToolbarControl/ToolbarControl.tsx
@@ -1,6 +1,10 @@
 import { useCallback } from 'react';
 import { useAtom } from '@reatom/react-v2';
 import { passRefToSettings, resolveValue } from '~core/toolbar/utils';
+import {
+  MCDA_CONTROL_ID,
+  UPLOAD_MCDA_CONTROL_ID,
+} from '~features/mcda/constants';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import { ToolbarIcon } from '../ToolbarIcon';
 import type {
@@ -49,10 +53,17 @@ export function ToolbarControl({
       const size = isMobile
         ? (settings.typeSettings.mobilePreferredSize ?? 'medium')
         : settings.typeSettings.preferredSize;
-      const hint = resolveValue(
+      const defaultHint = resolveValue(settings.typeSettings.name, state);
+
+      const mcdaHint = resolveValue(
         settings.typeSettings.hint ?? settings.typeSettings.name,
         state,
       );
+
+      const hint =
+        id === MCDA_CONTROL_ID || id === UPLOAD_MCDA_CONTROL_ID
+          ? mcdaHint
+          : defaultHint;
 
       return (
         <ControlComponent


### PR DESCRIPTION
Fibery ticket: [22253](https://kontur.fibery.io/Tasks/Task/22253)

## Summary
- revert generic hint tooltips usage
- keep custom tooltips only for MCDA buttons

## Testing
- `pnpm test:unit` *(fails: unsupported pnpm version; install attempt hit 404)*

------
https://chatgpt.com/codex/tasks/task_e_6880e6f0e65c832fa5872e9fde1da06e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tooltip display for toolbar buttons, ensuring tooltips always show content even if a hint is not provided.
  * Enhanced logic for toolbar control tooltips to provide context-specific hints for certain controls.

* **Bug Fixes**
  * Tooltips now consistently display fallback text, preventing empty tooltips when hints are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->