### PR TITLE
fix(toolbar): 22253 align toolbar tooltips

### DIFF
--- a/src/features/boundary_selector/control.ts
+++ b/src/features/boundary_selector/control.ts
@@ -14,7 +14,7 @@ export const boundarySelectorToolbarControl = toolbar.setupControl<{
   borrowMapInteractions: true,
   typeSettings: {
     name: BOUNDARY_SELECTOR_CONTROL_NAME,
-    hint: i18n.t('boundary_selector.title'),
+    hint: BOUNDARY_SELECTOR_CONTROL_NAME,
     icon: 'SelectArea24',
     preferredSize: 'large',
   },

--- a/src/features/create_layer/control.ts
+++ b/src/features/create_layer/control.ts
@@ -13,7 +13,7 @@ export const createLayerController = toolbar.setupControl({
   type: 'button',
   typeSettings: {
     name: CREATE_LAYER_CONTROL_NAME,
-    hint: i18n.t('create_layer.create_layer'),
+    hint: CREATE_LAYER_CONTROL_NAME,
     icon: 'AddLayer24',
     preferredSize: 'large',
   },

--- a/src/features/geometry_uploader/index.tsx
+++ b/src/features/geometry_uploader/index.tsx
@@ -25,7 +25,7 @@ const fileUploaderControl = toolbar.setupControl({
   type: 'button',
   typeSettings: {
     name: GEOMETRY_UPLOADER_CONTROL_NAME,
-    hint: i18n.t('geometry_uploader.title'),
+    hint: GEOMETRY_UPLOADER_CONTROL_NAME,
     icon: 'Upload24',
     preferredSize: 'large',
     onRef: (el) => {

--- a/src/features/live_sensor/index.ts
+++ b/src/features/live_sensor/index.ts
@@ -12,11 +12,7 @@ export const liveSensorsControl = toolbar.setupControl<{
   type: 'button',
   typeSettings: {
     name: i18n.t('toolbar.record_sensors'),
-    hint: {
-      regular: i18n.t('live_sensor.start'),
-      active: i18n.t('live_sensor.finish'),
-      disabled: i18n.t('live_sensor.start'),
-    },
+    hint: i18n.t('toolbar.record_sensors'),
     icon: 'Car24',
     preferredSize: 'large',
   },

--- a/src/features/live_sensor/index.ts
+++ b/src/features/live_sensor/index.ts
@@ -11,7 +11,11 @@ export const liveSensorsControl = toolbar.setupControl<{
   id: SENSOR_CONTROL_ID,
   type: 'button',
   typeSettings: {
-    name: i18n.t('toolbar.record_sensors'),
+     name: {
+      regular: i18n.t('live_sensor.start'),
+      active: i18n.t('live_sensor.finish'),
+      disabled: i18n.t('live_sensor.start'),
+    },
     hint: {
       regular: i18n.t('live_sensor.start'),
       active: i18n.t('live_sensor.finish'),

--- a/src/features/live_sensor/index.ts
+++ b/src/features/live_sensor/index.ts
@@ -12,7 +12,11 @@ export const liveSensorsControl = toolbar.setupControl<{
   type: 'button',
   typeSettings: {
     name: i18n.t('toolbar.record_sensors'),
-    hint: i18n.t('toolbar.record_sensors'),
+    hint: {
+      regular: i18n.t('live_sensor.start'),
+      active: i18n.t('live_sensor.finish'),
+      disabled: i18n.t('live_sensor.start'),
+    },
     icon: 'Car24',
     preferredSize: 'large',
   },

--- a/src/features/locate_me/LocateMeButton.tsx
+++ b/src/features/locate_me/LocateMeButton.tsx
@@ -49,6 +49,7 @@ export function LocateMeButton({
       onClick={handleClick}
       active={state === 'active'}
       disabled={state === 'disabled'}
+      hint={LOCATE_ME_CONTROL_NAME}
     >
       {LOCATE_ME_CONTROL_NAME}
     </ControlComponent>

--- a/src/features/map_ruler/index.tsx
+++ b/src/features/map_ruler/index.tsx
@@ -22,7 +22,7 @@ export const mapRulerControl = toolbar.setupControl<{
   type: 'button',
   typeSettings: {
     name: MAP_RULER_CONTROL_NAME,
-    hint: i18n.t('sidebar.ruler'),
+    hint: MAP_RULER_CONTROL_NAME,
     icon: 'Ruler24',
     preferredSize: 'tiny',
   },

--- a/src/features/osm_edit_link/index.tsx
+++ b/src/features/osm_edit_link/index.tsx
@@ -13,7 +13,7 @@ export const osmEditControl = toolbar.setupControl({
   type: 'button',
   typeSettings: {
     name: EDIT_IN_OSM_CONTROL_NAME,
-    hint: i18n.t('sidebar.edit_osm'),
+    hint: EDIT_IN_OSM_CONTROL_NAME,
     icon: 'EditInOsm16',
     preferredSize: 'tiny',
   },


### PR DESCRIPTION
Fibery ticket: [22253](https://kontur.fibery.io/Tasks/Task/22253)

## Summary
- show same tooltip text as button name for LocateMe and other toolbar buttons
- keep MCDA tooltips distinct

## Testing
- `pnpm lint` *(fails: npm-run-all not found)*
- `pnpm test:unit` *(fails: tsx not found)*


------
https://chatgpt.com/codex/tasks/task_e_68809a5ad500832f86bea05b8ba733a4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated tooltip and hint texts for several toolbar controls to use fixed string values instead of localized translations. This affects boundary selector, create layer, geometry uploader, locate me, map ruler, and OSM edit controls. The visible hint text may now appear in a single language rather than being localized.
* **New Features**
  * Enhanced live sensor control button with dynamic labels reflecting different states: regular, active, and disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->