### PR TITLE
fix(sentry): PROD-DISASTER-NINJA-FE-1C ignore yandex metrics spans

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,10 @@ function initSentry(config: Config) {
       dsn: config.sentryDsn,
       integrations: [
         Sentry.browserTracingIntegration({
-          shouldCreateSpanForRequest: (url: string) => !url.includes('mc.yandex.ru'),
+          shouldCreateSpanForRequest: (url: string) => {
+            const { hostname } = new URL(url, window.location.origin);
+            return hostname !== 'mc.yandex.ru';
+          },
         }),
         Sentry.replayIntegration({
           maskAllText: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,9 @@ function initSentry(config: Config) {
     Sentry.init({
       dsn: config.sentryDsn,
       integrations: [
-        Sentry.browserTracingIntegration(),
+        Sentry.browserTracingIntegration({
+          shouldCreateSpanForRequest: (url: string) => !url.includes('mc.yandex.ru'),
+        }),
         Sentry.replayIntegration({
           maskAllText: false,
           blockAllMedia: false,


### PR DESCRIPTION
## Summary
- ignore mc.yandex.ru spans in Sentry's BrowserTracing to avoid noisy N+1 issues

## Testing
- `pnpm lint` *(fails: npm-run-all not found)*
- `pnpm install` *(fails: 404 fetching stylus-0.62.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6880ef967c14832495169cd442278fbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error monitoring by excluding specific requests from performance tracing, resulting in more accurate tracking and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->