### PR TITLE
fix(osm-edit-link): correct JOSM link construction

### DIFF
--- a/src/features/osm_edit_link/openOsmLink.ts
+++ b/src/features/osm_edit_link/openOsmLink.ts
@@ -24,7 +24,7 @@ function calculateMaxJosmArea(
 
 export function openJosmLink(
   { lat, lng },
-  baseLink = 'http://127.0.0.1:8111/load_and_zoom?',
+  baseLink = 'http://127.0.0.1:8111/load_and_zoom',
 ) {
   const { left, bottom, right, top } = calculateMaxJosmArea(lat, lng);
   const url = `${baseLink}?left=${left}&right=${right}&top=${top}&bottom=${bottom}`;

--- a/src/features/osm_edit_link/readme.md
+++ b/src/features/osm_edit_link/readme.md
@@ -17,3 +17,5 @@ if (featureFlags[FeatureFlag.OSM_EDIT_LINK]) {
 On the index file it adds control to the toolbar core instance.
 On control click current map position being read from `currentMapPositionAtom` and preferred user editor being picked from user info.
 That's enough to generate a link. New tab opens with by a new link and becomes focused.
+
+Default JOSM links are opened with the local remote control url `http://127.0.0.1:8111/load_and_zoom`.


### PR DESCRIPTION
Fibery ticket: N/A

## Summary
- remove the trailing `?` from the default JOSM link to avoid malformed URLs
- document the JOSM link behaviour in the feature readme

## Testing
- `pnpm run lint:js` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_b_688086145ad083268aaabe3e8ca12be9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify the default URL used for opening JOSM editor links.

* **Refactor**
  * Adjusted the default URL for JOSM editor links to improve consistency in link formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->