### PR TITLE
fix(create_layer): 10088 enforce unique layer names

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -237,6 +237,7 @@
     "delete_layer": "Delete Layer",
     "create_layer": "Create Layer",
     "saving_layer": "Saving layer...",
+    "layer_name_exists": "Layer with this name already exists.",
     "field_name": "Field name",
     "layer_name": "Layer name",
     "marker_icon": "Marker icon",

--- a/src/features/create_layer/atoms/editableLayerController.ts
+++ b/src/features/create_layer/atoms/editableLayerController.ts
@@ -2,6 +2,7 @@ import { configRepo } from '~core/config';
 import { createAtom } from '~utils/atoms';
 import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
 import { notificationServiceInstance } from '~core/notificationServiceInstance';
+import { i18n } from '~core/localization';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { createLayer, deleteLayer, updateLayer } from '../api/layers';
 import { EditTargets, DEFAULT_USER_LAYER_LEGEND } from '../constants';
@@ -86,6 +87,17 @@ export const editableLayerControllerAtom = createAtom(
       if (state?.data) {
         const dataState = getUnlistedState(state.data);
         if (!dataState.name) return;
+
+        const existingLayers = getUnlistedState(editableLayersListResource);
+        const duplicateName = existingLayers.data?.some(
+          (l) => l.name === dataState.name && l.id !== dataState.id,
+        );
+        if (duplicateName) {
+          notificationServiceInstance.error({
+            title: i18n.t('create_layer.layer_name_exists'),
+          });
+          return;
+        }
 
         state = { ...state, loading: true };
 

--- a/src/features/create_layer/readme.md
+++ b/src/features/create_layer/readme.md
@@ -5,7 +5,7 @@ Feature flag name: `create_layer`
 ## Short feature purpose description:
 
 Allows the authorized user to create and edit his own layers with geojson source,
-and edit features properties
+and edit features properties. Layer names must be unique for each user.
 
 Consists of two parts:
 


### PR DESCRIPTION
Fibery ticket: [10088](https://kontur.fibery.io/Tasks/Task/10088)

Implemented validation preventing creation of user layers with duplicate names. Added corresponding error translation and updated documentation.

------
https://chatgpt.com/codex/tasks/task_b_68822e7736bc8326b591816aca90be6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-facing error message when attempting to create or rename a layer with a name that already exists.
* **Bug Fixes**
  * Prevented saving layers with duplicate names to ensure each layer name is unique per user.
* **Documentation**
  * Updated documentation to clarify that layer names must be unique for each user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->