### PR TITLE
chore(15369): remove legacy config case conversion

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -37,8 +37,8 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           sed -i "s|https://disaster.ninja|https://${PREVIEW_API_DOMAIN}|" configs/config.default.json
-          sed -i "s|\"KEYCLOAK_URL\": \"https://keycloak01.kontur.io\"|\"KEYCLOAK_URL\": \"${KEYCLOAK_URL}\"|" configs/config.default.json
-          sed -i "s|\"KEYCLOAK_REALM\": \"kontur\"|\"KEYCLOAK_REALM\": \"${KEYCLOAK_REALM}\"|" configs/config.default.json
+          sed -i "s|\"keycloakUrl\": \"https://keycloak01.kontur.io\"|\"keycloakUrl\": \"${KEYCLOAK_URL}\"|" configs/config.default.json
+          sed -i "s|\"keycloakRealm\": \"kontur\"|\"keycloakRealm\": \"${KEYCLOAK_REALM}\"|" configs/config.default.json
           sed -i "s|VITE_BASE_PATH=/active/|VITE_BASE_PATH=/|" .env.production
           sed -i "s|VITE_STATIC_PATH=static/|VITE_STATIC_PATH=|" .env.production
 

--- a/configs/config.default.json
+++ b/configs/config.default.json
@@ -1,33 +1,33 @@
 {
-  "API_GATEWAY": "https://disaster.ninja/active/api",
-  "REPORTS_API": "https://disaster.ninja/active/reports",
-  "BIVARIATE_TILES_RELATIVE_URL": "api/tiles/bivariate/v1/",
-  "BIVARIATE_TILES_INDICATORS_CLASS": "all",
-  "REFRESH_INTERVAL_SEC": 300,
-  "MAP_BASE_STYLE": "https://disaster.ninja/tiles/basemap/style_ninja.json",
-  "MAP_BLANK_SPACE_ID": "map-view",
-  "AUTOFOCUS_ZOOM": 13,
-  "FEATURES_BY_DEFAULT": [
-    "events_list",
-    "current_event",
-    "reports",
-    "osm_edit_link",
-    "side_bar",
-    "analytics_panel",
-    "map_layers_panel",
-    "focused_geometry_layer",
-    "map_ruler",
-    "boundary_selector",
-    "geometry_uploader",
-    "legend_panel",
-    "layers_in_area",
-    "toasts",
-    "feed_selector",
-    "tooltip"
-  ],
-  "DEFAULT_FEED": "kontur-public",
-  "DEFAULT_LANGUAGE": "en",
-  "OSM_EDITORS": [
+  "apiGateway": "https://disaster.ninja/active/api",
+  "reportsApiGateway": "https://disaster.ninja/active/reports",
+  "bivariateTilesRelativeUrl": "api/tiles/bivariate/v1/",
+  "bivariateTilesIndicatorsClass": "all",
+  "refreshIntervalSec": 300,
+  "mapBaseStyle": "https://disaster.ninja/tiles/basemap/style_ninja.json",
+  "mapBlankSpaceId": "map-view",
+  "autofocusZoom": 13,
+  "featuresByDefault": {
+    "events_list": true,
+    "current_event": true,
+    "reports": true,
+    "osm_edit_link": true,
+    "side_bar": true,
+    "analytics_panel": true,
+    "map_layers_panel": true,
+    "focused_geometry_layer": true,
+    "map_ruler": true,
+    "boundary_selector": true,
+    "geometry_uploader": true,
+    "legend_panel": true,
+    "layers_in_area": true,
+    "toasts": true,
+    "feed_selector": true,
+    "tooltip": true
+  },
+  "defaultFeed": "kontur-public",
+  "defaultLanguage": "en",
+  "osmEditors": [
     {
       "id": "osm",
       "title": "OpenStreetMap.org default editor",
@@ -49,9 +49,9 @@
       "url": "https://mapwith.ai/rapid#map="
     }
   ],
-  "KEYCLOAK_URL": "https://keycloak01.kontur.io",
-  "KEYCLOAK_REALM": "kontur",
-  "KEYCLOAK_CLIENT_ID": "kontur_platform",
-  "SENTRY_DSN": "https://fixme@dsn.ingest.sentry.io/project-id",
-  "MATOMO_CONTAINER_URL": "https://matomo.kontur.io/js/container_I7eDYwKj.js"
+  "keycloakUrl": "https://keycloak01.kontur.io",
+  "keycloakRealm": "kontur",
+  "keycloakClientId": "kontur_platform",
+  "sentryDsn": "https://fixme@dsn.ingest.sentry.io/project-id",
+  "matomoContainerUrl": "https://matomo.kontur.io/js/container_I7eDYwKj.js"
 }

--- a/reports_instruction.md
+++ b/reports_instruction.md
@@ -34,6 +34,6 @@ If you want to display your reports on the Disaster Ninja Reports page, you must
 
 Reports have to be served by some web server.
 Standalone configuration expects that reports are served at /reports/ subpath - as shown in default DN Front End configuration:
-`"REPORTS_API": "https://disaster.ninja/active/reports"`
+`"reportsApiGateway": "https://disaster.ninja/active/reports"`
 
 For more information, please see https://github.com/konturio/disaster-ninja-fe/blob/main/configs/config.default.json

--- a/scripts/build-config-scheme.mjs
+++ b/scripts/build-config-scheme.mjs
@@ -5,7 +5,7 @@ export function buildScheme() {
   const config = {
     path: 'src/core/config/loaders/stageConfigLoader.ts',
     tsconfig: './tsconfig.json',
-    type: 'StageConfigLegacy',
+    type: 'StageConfig',
     skipTypeCheck: true,
   };
   const schema = tsj.createGenerator(config).createSchema(config.type);

--- a/src/core/config/loaders/stageConfigLoader.ts
+++ b/src/core/config/loaders/stageConfigLoader.ts
@@ -39,32 +39,41 @@ export async function getStageConfig(): Promise<StageConfig> {
       `Failed to load stage config: ${response.status} ${response.statusText}`,
     );
   }
-  const c = (await response.json()) as StageConfigLegacy;
-  // TODO - reformat configs to new case
+  const raw = await response.json();
+  if ('API_GATEWAY' in raw) {
+    const c = raw as StageConfigLegacy;
+    return {
+      apiGateway: c.API_GATEWAY,
+      reportsApiGateway: c.REPORTS_API,
+      bivariateTilesRelativeUrl: c.BIVARIATE_TILES_RELATIVE_URL,
+      bivariateTilesIndicatorsClass: c.BIVARIATE_TILES_INDICATORS_CLASS,
+      bivariateTilesServer: c.BIVARIATE_TILES_SERVER,
+      refreshIntervalSec: c.REFRESH_INTERVAL_SEC,
+      sentryDsn: c.SENTRY_DSN,
+      keycloakUrl: c.KEYCLOAK_URL,
+      keycloakRealm: c.KEYCLOAK_REALM,
+      keycloakClientId: c.KEYCLOAK_CLIENT_ID,
+      yandexMetricaId: c.YANDEX_METRICA_ID,
+      matomoContainerUrl: c.MATOMO_CONTAINER_URL,
+      intercomDefaultName: c.INTERCOM_DEFAULT_NAME,
+      intercomAppId: c.INTERCOM_APP_ID,
+      intercomSelector: c.INTERCOM_SELECTOR,
+      defaultFeed: c.DEFAULT_FEED,
+      osmEditors: c.OSM_EDITORS,
+      autofocusZoom: c.AUTOFOCUS_ZOOM,
+      mapBlankSpaceId: c.MAP_BLANK_SPACE_ID,
+      mapBaseStyle: c.MAP_BASE_STYLE,
+      defaultLanguage: c.DEFAULT_LANGUAGE,
+      featuresByDefault: getFeaturesFromStageConfig(
+        c.FEATURES_BY_DEFAULT,
+      ) as AppConfig['features'],
+    };
+  }
+  const c = raw as StageConfig & { featuresByDefault: unknown };
   return {
-    apiGateway: c.API_GATEWAY,
-    reportsApiGateway: c.REPORTS_API,
-    bivariateTilesRelativeUrl: c.BIVARIATE_TILES_RELATIVE_URL,
-    bivariateTilesIndicatorsClass: c.BIVARIATE_TILES_INDICATORS_CLASS,
-    bivariateTilesServer: c.BIVARIATE_TILES_SERVER,
-    refreshIntervalSec: c.REFRESH_INTERVAL_SEC,
-    sentryDsn: c.SENTRY_DSN,
-    keycloakUrl: c.KEYCLOAK_URL,
-    keycloakRealm: c.KEYCLOAK_REALM,
-    keycloakClientId: c.KEYCLOAK_CLIENT_ID,
-    yandexMetricaId: c.YANDEX_METRICA_ID,
-    matomoContainerUrl: c.MATOMO_CONTAINER_URL,
-    intercomDefaultName: c.INTERCOM_DEFAULT_NAME,
-    intercomAppId: c.INTERCOM_APP_ID,
-    intercomSelector: c.INTERCOM_SELECTOR,
-    defaultFeed: c.DEFAULT_FEED,
-    osmEditors: c.OSM_EDITORS,
-    autofocusZoom: c.AUTOFOCUS_ZOOM,
-    mapBlankSpaceId: c.MAP_BLANK_SPACE_ID,
-    mapBaseStyle: c.MAP_BASE_STYLE,
-    defaultLanguage: c.DEFAULT_LANGUAGE,
-    featuresByDefault: getFeaturesFromStageConfig(
-      c.FEATURES_BY_DEFAULT,
-    ) as AppConfig['features'],
+    ...c,
+    featuresByDefault: Array.isArray(c.featuresByDefault)
+      ? (getFeaturesFromStageConfig(c.featuresByDefault) as AppConfig['features'])
+      : c.featuresByDefault,
   };
 }

--- a/src/core/config/types.ts
+++ b/src/core/config/types.ts
@@ -57,7 +57,7 @@ export interface StageConfig {
   mapBlankSpaceId: string;
   mapBaseStyle: string;
   // App Defaults
-  featuresByDefault: FeaturesConfig;
+  featuresByDefault: Partial<FeaturesConfig>;
   defaultLanguage: string;
   // Sentry
   sentryDsn: string;


### PR DESCRIPTION
Fibery Ticket: 15369

Updated stage configuration handling to match `StageConfig` interface.
Configs now use camelCase keys and `featuresByDefault` object. Legacy
snake_case values remain supported for backward compatibility. Docs and
preview workflow updated accordingly.

------
https://chatgpt.com/codex/tasks/task_b_688242da57708326846706f287195dea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration files and documentation to use camelCase key naming for consistency.
  * Changed the features configuration from an array to an object mapping feature names to boolean values.
  * Improved compatibility to support both legacy and new configuration formats.
  * Adjusted type definitions to allow partial feature configurations in settings.

* **Documentation**
  * Updated example configuration in user instructions to reflect new camelCase key names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->