### PR TITLE
fix(ui): remove panel dividers

### DIFF
--- a/src/components/Panel/styles.module.css
+++ b/src/components/Panel/styles.module.css
@@ -26,8 +26,15 @@
 }
 
 /* Remove divider below panel header */
-:global(.knt-panel-header) {
-  border-bottom: none;
+:global(.knt-panel-header),
+:global(.knt-panel > header) {
+  border-bottom: none !important;
+  box-shadow: none !important;
+}
+
+:global(.knt-panel-header::after),
+:global(.knt-panel > header::after) {
+  display: none !important;
 }
 
 @media screen and (max-width: 960px) {

--- a/src/components/Panel/styles.module.css
+++ b/src/components/Panel/styles.module.css
@@ -26,7 +26,7 @@
 }
 
 /* Remove divider below panel header */
-:global(.knt-panel-header > div) {
+:global(.knt-panel-header) {
   border-bottom: none;
 }
 

--- a/src/components/Panel/styles.module.css
+++ b/src/components/Panel/styles.module.css
@@ -25,6 +25,11 @@
   z-index: var(--modal);
 }
 
+/* Remove divider below panel header */
+:global(.knt-panel-header > div) {
+  border-bottom: none;
+}
+
 @media screen and (max-width: 960px) {
   .modal > section {
     top: calc(50% + var(--app-header-height)); /* header offset */

--- a/src/components/PanelSettingsRow/PanelSettingsRow.module.css
+++ b/src/components/PanelSettingsRow/PanelSettingsRow.module.css
@@ -1,6 +1,5 @@
 .panelSettingsRow:not(:empty) {
   padding: var(--half-unit) var(--double-unit) var(--unit);
-  border-bottom: 1px solid var(--faint-weak);
   gap: var(--unit);
   display: flex;
   flex-direction: row;

--- a/src/features/layer_features_panel/components/LayerFeaturesCard/LayerFeaturesCard.module.css
+++ b/src/features/layer_features_panel/components/LayerFeaturesCard/LayerFeaturesCard.module.css
@@ -1,3 +1,2 @@
 .layerFeaturesCard {
-  border-bottom: 1px solid var(--faint-weak);
 }

--- a/src/features/layer_features_panel/components/LayerFeaturesCard/LayerFeaturesCard.module.css
+++ b/src/features/layer_features_panel/components/LayerFeaturesCard/LayerFeaturesCard.module.css
@@ -1,2 +1,9 @@
 .layerFeaturesCard {
+  /* remove divider between cards */
+  border: none;
+}
+
+/* ensure no divider remains when cards stack */
+:global(.knt-card + .knt-card) {
+  border-top: none;
 }

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/LayerFeaturesPanel.module.css
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/LayerFeaturesPanel.module.css
@@ -114,3 +114,12 @@
 .callToAction {
   width: 100%;
 }
+
+/* Remove divider between HOT Tasking Manager cards */
+.featuresPanel :global(.knt-card) {
+  border-bottom: none;
+}
+
+.featuresPanel :global(.knt-card + .knt-card) {
+  border-top: none;
+}


### PR DESCRIPTION
Fibery ticket: n/a

Removed default horizontal rules below panel headers and cards.

------
https://chatgpt.com/codex/tasks/task_e_6887410ace3c832f9b7dd9a573227987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed bottom borders and dividers from panel headers, settings rows, and layer feature cards for a cleaner, more streamlined appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->