### PR TITLE
fix(ui): remove panel and card dividers

### DIFF
--- a/src/components/Panel/styles.module.css
+++ b/src/components/Panel/styles.module.css
@@ -1,5 +1,8 @@
 .header {
   user-select: none;
+  & :global(.headerContent) {
+    border-bottom: none;
+  }
 }
 
 .headerTitle {

--- a/src/features/layer_features_panel/components/LayerFeaturesCard/LayerFeaturesCard.module.css
+++ b/src/features/layer_features_panel/components/LayerFeaturesCard/LayerFeaturesCard.module.css
@@ -1,3 +1,1 @@
-.layerFeaturesCard {
-  border-bottom: 1px solid var(--faint-weak);
-}
+/* intentionally empty */


### PR DESCRIPTION
Fibery#???

## Summary
- remove borders under panel headers
- drop borders between HOT Tasking Manager cards

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_68876c2b24b0832fb0ee2d6a8850ec8f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the bottom border from elements with the .headerContent class when inside a header.
  * Removed the bottom border styling from Layer Features Card elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->