### PR TITLE
feat(MVA): 21209 Bivariate colors for custom MVA based on sentiments direction

### DIFF
--- a/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
+++ b/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
@@ -85,7 +85,7 @@ export function MultivariateAnalysisForm({
     text: initialConfig?.text?.mcdaValue?.config.layers ?? [],
     extrusion: initialConfig?.extrusion?.height?.config.layers ?? [],
   });
-  const [isKeepColorsChecked, setKeepColorsChecked] = useState(true);
+  const [isKeepColorsChecked, setKeepColorsChecked] = useState(false);
   const [isCustomStepsChecked, setCustomStepsChecked] = useState(false);
   const [isTextScoreModeChecked, setTextScoreModeChecked] = useState(
     initialConfig?.text?.mcdaMode === 'score',

--- a/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
+++ b/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { deepEqual } from 'fast-equals';
+import {
+  sentimentDefault,
+  sentimentReversed,
+} from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants';
+import { createBivariateColorsForMVA } from './createBivariateColorsForMVA';
+import type { ColorTheme } from '~core/types';
+import type { MCDALayer } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
+
+describe('createBivariateColorsForMVA', () => {
+  it('should return default color scheme if both score and base have one layer with direct sentiment', () => {
+    const scoreLayers = [{ ...LAYER, sentiment: sentimentDefault }];
+    const baseLayer = [{ ...LAYER, sentiment: sentimentDefault }];
+    expect(
+      deepEqual(
+        createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS),
+        DEFAULT_COLORS,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('should return horizontally reversed color scheme if base hase one layer with reversed sentiment', () => {
+    const scoreLayers = [{ ...LAYER, sentiment: sentimentDefault }];
+    const baseLayer = [{ ...LAYER, sentiment: sentimentReversed }];
+    expect(
+      deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
+        {
+          id: 'A1',
+          color: 'rgba(228, 26, 28, 0.5)',
+        },
+        {
+          id: 'A3',
+          color: 'rgba(232, 232, 157, 0.5)',
+        },
+        {
+          id: 'C1',
+          color: 'rgba(102, 154, 112, 0.5)',
+        },
+        {
+          id: 'C3',
+          color: 'rgba(166, 239, 179, 0.5)',
+        },
+      ]),
+    ).toBeTruthy();
+  });
+
+  it('should return vertically reversed color scheme if score has one layer with reversed sentiment', () => {
+    const scoreLayers = [{ ...LAYER, sentiment: sentimentReversed }];
+    const baseLayer = [{ ...LAYER, sentiment: sentimentDefault }];
+    expect(
+      deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
+        {
+          id: 'A1',
+          color: 'rgba(166, 239, 179, 0.5)',
+        },
+        {
+          id: 'A3',
+          color: 'rgba(102, 154, 112, 0.5)',
+        },
+        {
+          id: 'C1',
+          color: 'rgba(232, 232, 157, 0.5)',
+        },
+        {
+          id: 'C3',
+          color: 'rgba(228, 26, 28, 0.5)',
+        },
+      ]),
+    ).toBeTruthy();
+  });
+
+  it('should return vertically and horizontally reversed color scheme if both score and base have one layer with reversed sentiment', () => {
+    const scoreLayers = [{ ...LAYER, sentiment: sentimentReversed }];
+    const baseLayer = [{ ...LAYER, sentiment: sentimentReversed }];
+    expect(
+      deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
+        {
+          id: 'A1',
+          color: 'rgba(102, 154, 112, 0.5)',
+        },
+        {
+          id: 'A3',
+          color: 'rgba(166, 239, 179, 0.5)',
+        },
+        {
+          id: 'C1',
+          color: 'rgba(228, 26, 28, 0.5)',
+        },
+        {
+          id: 'C3',
+          color: 'rgba(232, 232, 157, 0.5)',
+        },
+      ]),
+    ).toBeTruthy();
+  });
+});
+
+export const DEFAULT_COLORS: ColorTheme = [
+  {
+    id: 'A1',
+    color: 'rgba(232, 232, 157, 0.5)',
+  },
+  {
+    id: 'A3',
+    color: 'rgba(228, 26, 28, 0.5)',
+  },
+  {
+    id: 'C1',
+    color: 'rgba(166, 239, 179, 0.5)',
+  },
+  {
+    id: 'C3',
+    color: 'rgba(102, 154, 112, 0.5)',
+  },
+];
+
+const LAYER: MCDALayer = {
+  id: '',
+  name: '',
+  axis: ['', ''],
+  indicators: [],
+  outliers: 'clamp',
+  unit: '',
+  range: [0, 100],
+  sentiment: ['bad', 'good'],
+  coefficient: 1,
+  transformationFunction: 'no',
+  normalization: 'max-min',
+};

--- a/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
+++ b/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
@@ -8,7 +8,7 @@ import { createBivariateColorsForMVA } from './createBivariateColorsForMVA';
 import type { ColorTheme } from '~core/types';
 import type { MCDALayer } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 
-export const DEFAULT_COLORS: ColorTheme = [
+const DEFAULT_COLORS: ColorTheme = [
   {
     id: 'A1',
     color: 'rgba(232, 232, 157, 0.5)',

--- a/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
+++ b/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
@@ -8,10 +8,43 @@ import { createBivariateColorsForMVA } from './createBivariateColorsForMVA';
 import type { ColorTheme } from '~core/types';
 import type { MCDALayer } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 
+export const DEFAULT_COLORS: ColorTheme = [
+  {
+    id: 'A1',
+    color: 'rgba(232, 232, 157, 0.5)',
+  },
+  {
+    id: 'A3',
+    color: 'rgba(228, 26, 28, 0.5)',
+  },
+  {
+    id: 'C1',
+    color: 'rgba(166, 239, 179, 0.5)',
+  },
+  {
+    id: 'C3',
+    color: 'rgba(102, 154, 112, 0.5)',
+  },
+];
+
+const layer: MCDALayer = {
+  id: '',
+  name: '',
+  axis: ['', ''],
+  indicators: [],
+  outliers: 'clamp',
+  unit: '',
+  range: [0, 100],
+  sentiment: ['bad', 'good'],
+  coefficient: 1,
+  transformationFunction: 'no',
+  normalization: 'max-min',
+};
+
 describe('createBivariateColorsForMVA', () => {
   it('should return default color scheme if both score and base have one layer with direct sentiment', () => {
-    const scoreLayers = [{ ...LAYER, sentiment: sentimentDefault }];
-    const baseLayer = [{ ...LAYER, sentiment: sentimentDefault }];
+    const scoreLayers = [{ ...layer, sentiment: sentimentDefault }];
+    const baseLayer = [{ ...layer, sentiment: sentimentDefault }];
     expect(
       deepEqual(
         createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS),
@@ -21,8 +54,8 @@ describe('createBivariateColorsForMVA', () => {
   });
 
   it('should return horizontally reversed color scheme if base hase one layer with reversed sentiment', () => {
-    const scoreLayers = [{ ...LAYER, sentiment: sentimentDefault }];
-    const baseLayer = [{ ...LAYER, sentiment: sentimentReversed }];
+    const scoreLayers = [{ ...layer, sentiment: sentimentDefault }];
+    const baseLayer = [{ ...layer, sentiment: sentimentReversed }];
     expect(
       deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
         {
@@ -46,8 +79,8 @@ describe('createBivariateColorsForMVA', () => {
   });
 
   it('should return vertically reversed color scheme if score has one layer with reversed sentiment', () => {
-    const scoreLayers = [{ ...LAYER, sentiment: sentimentReversed }];
-    const baseLayer = [{ ...LAYER, sentiment: sentimentDefault }];
+    const scoreLayers = [{ ...layer, sentiment: sentimentReversed }];
+    const baseLayer = [{ ...layer, sentiment: sentimentDefault }];
     expect(
       deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
         {
@@ -71,8 +104,8 @@ describe('createBivariateColorsForMVA', () => {
   });
 
   it('should return vertically and horizontally reversed color scheme if both score and base have one layer with reversed sentiment', () => {
-    const scoreLayers = [{ ...LAYER, sentiment: sentimentReversed }];
-    const baseLayer = [{ ...LAYER, sentiment: sentimentReversed }];
+    const scoreLayers = [{ ...layer, sentiment: sentimentReversed }];
+    const baseLayer = [{ ...layer, sentiment: sentimentReversed }];
     expect(
       deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
         {
@@ -95,36 +128,3 @@ describe('createBivariateColorsForMVA', () => {
     ).toBeTruthy();
   });
 });
-
-export const DEFAULT_COLORS: ColorTheme = [
-  {
-    id: 'A1',
-    color: 'rgba(232, 232, 157, 0.5)',
-  },
-  {
-    id: 'A3',
-    color: 'rgba(228, 26, 28, 0.5)',
-  },
-  {
-    id: 'C1',
-    color: 'rgba(166, 239, 179, 0.5)',
-  },
-  {
-    id: 'C3',
-    color: 'rgba(102, 154, 112, 0.5)',
-  },
-];
-
-const LAYER: MCDALayer = {
-  id: '',
-  name: '',
-  axis: ['', ''],
-  indicators: [],
-  outliers: 'clamp',
-  unit: '',
-  range: [0, 100],
-  sentiment: ['bad', 'good'],
-  coefficient: 1,
-  transformationFunction: 'no',
-  normalization: 'max-min',
-};

--- a/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
+++ b/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { deepEqual } from 'fast-equals';
 import {
   sentimentDefault,
   sentimentReversed,
@@ -45,86 +44,77 @@ describe('createBivariateColorsForMVA', () => {
   it('should return default color scheme if both score and base have one layer with direct sentiment', () => {
     const scoreLayers = [{ ...layer, sentiment: sentimentDefault }];
     const baseLayer = [{ ...layer, sentiment: sentimentDefault }];
-    expect(
-      deepEqual(
-        createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS),
-        DEFAULT_COLORS,
-      ),
-    ).toBeTruthy();
+    expect(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS)).toEqual(
+      DEFAULT_COLORS,
+    );
   });
 
   it('should return horizontally reversed color scheme if base hase one layer with reversed sentiment', () => {
     const scoreLayers = [{ ...layer, sentiment: sentimentDefault }];
     const baseLayer = [{ ...layer, sentiment: sentimentReversed }];
-    expect(
-      deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
-        {
-          id: 'A1',
-          color: 'rgba(228, 26, 28, 0.5)',
-        },
-        {
-          id: 'A3',
-          color: 'rgba(232, 232, 157, 0.5)',
-        },
-        {
-          id: 'C1',
-          color: 'rgba(102, 154, 112, 0.5)',
-        },
-        {
-          id: 'C3',
-          color: 'rgba(166, 239, 179, 0.5)',
-        },
-      ]),
-    ).toBeTruthy();
+    expect(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS)).toEqual([
+      {
+        id: 'A1',
+        color: 'rgba(228, 26, 28, 0.5)',
+      },
+      {
+        id: 'A3',
+        color: 'rgba(232, 232, 157, 0.5)',
+      },
+      {
+        id: 'C1',
+        color: 'rgba(102, 154, 112, 0.5)',
+      },
+      {
+        id: 'C3',
+        color: 'rgba(166, 239, 179, 0.5)',
+      },
+    ]);
   });
 
   it('should return vertically reversed color scheme if score has one layer with reversed sentiment', () => {
     const scoreLayers = [{ ...layer, sentiment: sentimentReversed }];
     const baseLayer = [{ ...layer, sentiment: sentimentDefault }];
-    expect(
-      deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
-        {
-          id: 'A1',
-          color: 'rgba(166, 239, 179, 0.5)',
-        },
-        {
-          id: 'A3',
-          color: 'rgba(102, 154, 112, 0.5)',
-        },
-        {
-          id: 'C1',
-          color: 'rgba(232, 232, 157, 0.5)',
-        },
-        {
-          id: 'C3',
-          color: 'rgba(228, 26, 28, 0.5)',
-        },
-      ]),
-    ).toBeTruthy();
+    expect(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS)).toEqual([
+      {
+        id: 'A1',
+        color: 'rgba(166, 239, 179, 0.5)',
+      },
+      {
+        id: 'A3',
+        color: 'rgba(102, 154, 112, 0.5)',
+      },
+      {
+        id: 'C1',
+        color: 'rgba(232, 232, 157, 0.5)',
+      },
+      {
+        id: 'C3',
+        color: 'rgba(228, 26, 28, 0.5)',
+      },
+    ]);
   });
 
   it('should return vertically and horizontally reversed color scheme if both score and base have one layer with reversed sentiment', () => {
     const scoreLayers = [{ ...layer, sentiment: sentimentReversed }];
     const baseLayer = [{ ...layer, sentiment: sentimentReversed }];
-    expect(
-      deepEqual(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS), [
-        {
-          id: 'A1',
-          color: 'rgba(102, 154, 112, 0.5)',
-        },
-        {
-          id: 'A3',
-          color: 'rgba(166, 239, 179, 0.5)',
-        },
-        {
-          id: 'C1',
-          color: 'rgba(228, 26, 28, 0.5)',
-        },
-        {
-          id: 'C3',
-          color: 'rgba(232, 232, 157, 0.5)',
-        },
-      ]),
-    ).toBeTruthy();
+    expect(createBivariateColorsForMVA(scoreLayers, baseLayer, DEFAULT_COLORS)).toEqual([
+      {
+        id: 'A1',
+        color: 'rgba(102, 154, 112, 0.5)',
+      },
+      {
+        id: 'A3',
+        color: 'rgba(166, 239, 179, 0.5)',
+      },
+      {
+        id: 'C1',
+        color: 'rgba(228, 26, 28, 0.5)',
+      },
+      {
+        id: 'C3',
+        color: 'rgba(232, 232, 157, 0.5)',
+      },
+    ]);
   });
 });

--- a/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.ts
+++ b/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.ts
@@ -1,29 +1,29 @@
 import { sentimentReversed } from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants';
 import { arraysAreEqualWithStrictOrder } from '~utils/common/equality';
-import { DEFAULT_MULTIBIVARIATE_COLORS } from '~utils/multivariate/constants';
 import { clusterize } from '~utils/bivariate';
-import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
+import type { MCDALayer } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
 import type { ColorTheme } from '~core/types';
 
 export function createBivariateColorsForMVA(
-  score: MCDAConfig,
-  base: MCDAConfig,
+  scoreLayers: MCDALayer[],
+  baseLayers: MCDALayer[],
+  defaultColors: ColorTheme,
 ): ColorTheme {
   let reverseScore = false;
   let reverseBase = false;
-  if (score.layers?.length === 1) {
+  if (scoreLayers.length === 1) {
     reverseScore = arraysAreEqualWithStrictOrder(
-      score.layers[0].sentiment,
+      scoreLayers[0].sentiment,
       sentimentReversed,
     );
   }
-  if (base.layers?.length === 1) {
+  if (baseLayers.length === 1) {
     reverseBase = arraysAreEqualWithStrictOrder(
-      base.layers[0].sentiment,
+      baseLayers[0].sentiment,
       sentimentReversed,
     );
   }
-  const tmpColors = clusterize(DEFAULT_MULTIBIVARIATE_COLORS);
+  const tmpColors = clusterize(defaultColors);
   if (reverseScore) {
     // reverse colors vertically
     tmpColors.reverse();
@@ -37,5 +37,5 @@ export function createBivariateColorsForMVA(
   // match colors with default class names
   return tmpColors
     .flat()
-    .map((v, index) => ({ color: v.color, id: DEFAULT_MULTIBIVARIATE_COLORS[index].id }));
+    .map((v, index) => ({ id: defaultColors[index].id, color: v.color }));
 }

--- a/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.ts
+++ b/src/features/multivariate_layer/helpers/createBivariateColorsForMVA.ts
@@ -1,0 +1,41 @@
+import { sentimentReversed } from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations/constants';
+import { arraysAreEqualWithStrictOrder } from '~utils/common/equality';
+import { DEFAULT_MULTIBIVARIATE_COLORS } from '~utils/multivariate/constants';
+import { clusterize } from '~utils/bivariate';
+import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
+import type { ColorTheme } from '~core/types';
+
+export function createBivariateColorsForMVA(
+  score: MCDAConfig,
+  base: MCDAConfig,
+): ColorTheme {
+  let reverseScore = false;
+  let reverseBase = false;
+  if (score.layers?.length === 1) {
+    reverseScore = arraysAreEqualWithStrictOrder(
+      score.layers[0].sentiment,
+      sentimentReversed,
+    );
+  }
+  if (base.layers?.length === 1) {
+    reverseBase = arraysAreEqualWithStrictOrder(
+      base.layers[0].sentiment,
+      sentimentReversed,
+    );
+  }
+  const tmpColors = clusterize(DEFAULT_MULTIBIVARIATE_COLORS);
+  if (reverseScore) {
+    // reverse colors vertically
+    tmpColors.reverse();
+  }
+  if (reverseBase) {
+    // reverse colors horizontally
+    for (const row of tmpColors) {
+      row.reverse();
+    }
+  }
+  // match colors with default class names
+  return tmpColors
+    .flat()
+    .map((v, index) => ({ color: v.color, id: DEFAULT_MULTIBIVARIATE_COLORS[index].id }));
+}

--- a/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
+++ b/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
@@ -135,7 +135,11 @@ export function createMultivariateConfig(
             type: 'bivariate',
             colors:
               scoreMCDAStyle?.config && baseMCDAStyle?.config
-                ? createBivariateColorsForMVA(scoreMCDAStyle.config, baseMCDAStyle.config)
+                ? createBivariateColorsForMVA(
+                    scoreMCDAStyle.config.layers,
+                    baseMCDAStyle.config.layers,
+                    DEFAULT_MULTIBIVARIATE_COLORS,
+                  )
                 : DEFAULT_MULTIBIVARIATE_COLORS,
           }
         : {

--- a/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
+++ b/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
@@ -12,6 +12,7 @@ import {
 } from '../constants';
 import { generateMultivariateId } from './generateMultivariateId';
 import { createStepsForMCDADimension } from './createStepsForMCDADimension';
+import { createBivariateColorsForMVA } from './createBivariateColorsForMVA';
 import type { Axis } from '~utils/bivariate';
 import type {
   MCDALayer,
@@ -130,7 +131,13 @@ export function createMultivariateConfig(
     colors:
       overrides?.colors ||
       (isBivariateStyleLegend
-        ? { type: 'bivariate', colors: DEFAULT_MULTIBIVARIATE_COLORS }
+        ? {
+            type: 'bivariate',
+            colors:
+              scoreMCDAStyle?.config && baseMCDAStyle?.config
+                ? createBivariateColorsForMVA(scoreMCDAStyle.config, baseMCDAStyle.config)
+                : DEFAULT_MULTIBIVARIATE_COLORS,
+          }
         : {
             type: 'mcda',
             colors: DEFAULT_MCDA_COLORS_BY_SENTIMENT,


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Sentiment-based-bivariate-colors-for-multivariate-layers-21209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced dynamic generation of bivariate color schemes for multivariate analysis based on the configuration of score and base layers.
* **Bug Fixes**
  * Updated the default state of the "Keep colors" checkbox in the multivariate analysis form to be unchecked initially.
* **Tests**
  * Added comprehensive unit tests to verify correct color scheme generation for various sentiment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->