### PR TITLE
feat(MVA): 22302 Don't show units for normalized Label dimensions

### DIFF
--- a/src/core/logical_layers/renderers/MultivariateRenderer/helpers/createTextLayerSpecification.ts
+++ b/src/core/logical_layers/renderers/MultivariateRenderer/helpers/createTextLayerSpecification.ts
@@ -30,7 +30,9 @@ export function createTextLayerSpecification(
       values = textDimension.mcdaValue.config.layers.map((layer) =>
         calculateMCDALayer(layer),
       );
-      units = textDimension.mcdaValue.config.layers.map((layer) => layer.unit ?? '');
+      units = textDimension.mcdaValue.config.layers.map((layer) =>
+        layer.normalization === 'no' ? (layer.unit ?? '') : '',
+      );
     }
   }
   if (values?.length) {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Hide-units-for-normalized-Label-dimension-values-on-map-22302
<img width="455" height="251" alt="image" src="https://github.com/user-attachments/assets/7a66fe4d-c98e-4778-bae1-489746ece01d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how units are displayed for text layers, now showing units only for layers without normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->