### PR TITLE
fix(create_layer): 10088 unique id for new layers

### DIFF
--- a/src/features/create_layer/atoms/editableLayerController.ts
+++ b/src/features/create_layer/atoms/editableLayerController.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid';
 import { configRepo } from '~core/config';
 import { createAtom } from '~utils/atoms';
 import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
@@ -43,7 +44,7 @@ export const editableLayerControllerAtom = createAtom(
       state = {
         loading: false,
         error: null,
-        data: createLayerEditorFormAtom(),
+        data: createLayerEditorFormAtom({ id: nanoid() }),
       };
       schedule((dispatch) => {
         dispatch(editTargetAtom.set({ type: 'layer' }));

--- a/src/features/create_layer/atoms/editableLayerController.ts
+++ b/src/features/create_layer/atoms/editableLayerController.ts
@@ -5,7 +5,11 @@ import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
 import { notificationServiceInstance } from '~core/notificationServiceInstance';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { createLayer, deleteLayer, updateLayer } from '../api/layers';
-import { EditTargets, DEFAULT_USER_LAYER_LEGEND } from '../constants';
+import {
+  EditTargets,
+  DEFAULT_USER_LAYER_LEGEND,
+  USER_LAYER_ID_PREFIX,
+} from '../constants';
 import { createLayerEditorFormAtom } from './layerEditorForm';
 import { createLayerEditorFormFieldAtom } from './layerEditorFormField';
 import { editableLayerSettingsAtom } from './editableLayerSettings';
@@ -44,7 +48,9 @@ export const editableLayerControllerAtom = createAtom(
       state = {
         loading: false,
         error: null,
-        data: createLayerEditorFormAtom({ id: nanoid() }),
+        data: createLayerEditorFormAtom({
+          id: `${USER_LAYER_ID_PREFIX}${nanoid()}`,
+        }),
       };
       schedule((dispatch) => {
         dispatch(editTargetAtom.set({ type: 'layer' }));

--- a/src/features/create_layer/constants.ts
+++ b/src/features/create_layer/constants.ts
@@ -3,6 +3,7 @@ import type { SimpleLegend } from '~core/logical_layers/types/legends';
 export const CREATE_LAYER_CONTROL_ID = 'EditableLayer' as const;
 export const CUSTOM_LAYER_DRAW_TOOLS_CONTROL = 'customLayerDrawToolsControl';
 export const CREATE_LAYER_CONTROL_NAME = i18n.t('toolbar.create_layer');
+export const USER_LAYER_ID_PREFIX = 'user-layer-';
 
 export const FieldTypes = {
   None: 'none',

--- a/src/features/create_layer/readme.md
+++ b/src/features/create_layer/readme.md
@@ -51,7 +51,7 @@ This feature uses next core modules:
 ## How it works
 
 1. layerSideBarButtonControllerAtom adds "Create layer" button in side bar (layerSideBarButtonControllerAtom). This button creates new layer on click.
-   Each new layer receives a randomly generated `id` so layers with the same name remain independent.
+   Each new layer receives a randomly generated `id` prefixed with `user-layer-` so layers with the same name remain independent.
 2. editableLayersListResource atom loads enabled user layers
 3. editableLayersControlsAtom - creates logical_layer (visible in layers panel) for every layer from editableLayersListResource
 4. editableLayersLegendsAndSources - creates legends and sources for enabled layers

--- a/src/features/create_layer/readme.md
+++ b/src/features/create_layer/readme.md
@@ -51,6 +51,7 @@ This feature uses next core modules:
 ## How it works
 
 1. layerSideBarButtonControllerAtom adds "Create layer" button in side bar (layerSideBarButtonControllerAtom). This button creates new layer on click.
+   Each new layer receives a randomly generated `id` so layers with the same name remain independent.
 2. editableLayersListResource atom loads enabled user layers
 3. editableLayersControlsAtom - creates logical_layer (visible in layers panel) for every layer from editableLayersListResource
 4. editableLayersLegendsAndSources - creates legends and sources for enabled layers


### PR DESCRIPTION
Fibery ticket: [10088](https://kontur.fibery.io/Tasks/Task/10088)

## Summary
- generate a random id for each new user layer using `nanoid`
- document unique id logic in create layer feature

## Testing
- `pnpm run test:unit -- --run --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6888f3109f80832686d0c999ab8457ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Each new layer now receives a unique, randomly generated ID upon creation, ensuring layers with identical names remain independent.

* **Documentation**
  * Updated documentation to clarify that new layers are assigned unique IDs when created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->