### PR TITLE
fix(workflows): no-ticket handle codecov errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,10 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
   build:


### PR DESCRIPTION
## Summary
- stop skipping the Codecov upload when `CODECOV_TOKEN` is missing
- mark the Codecov step as optional so missing token doesn't break the build

## Testing
- `pnpm install --prod=false`
- `pnpm run coverage`


------
https://chatgpt.com/codex/tasks/task_b_6888ee79aa84832683d925e26a62ca09

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow to prevent Codecov upload errors from failing the overall test job or workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->