### PR TITLE
chore(ci): 1046 central tracking for disabled e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      - name: Check disabled e2e tests registry
+        run: pnpm run check:fixmes
+
       - name: Coverage
         run: env NODE_ENV=test pnpm run coverage
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ Use the `--headed` flag instead of the `--ui` flag to run the tests in a headed 
 
 > Check the `tests-examples/demo-todo-app.spec.ts` file for an example of how to write tests.
 
+### Disabled e2e tests
+
+All tests skipped with `test.fixme` are tracked in `TEST_FIXMES.md`. Update that
+file whenever a test is disabled or re-enabled. CI will run `pnpm run
+check:fixmes` to ensure the registry stays in sync.
+
 ## Running Playwright e2e tests on a local environment
 
 1. Run the app in dev mode

--- a/TEST_FIXMES.md
+++ b/TEST_FIXMES.md
@@ -1,0 +1,19 @@
+# Disabled e2e tests registry
+
+This file tracks tests disabled via `test.fixme`.
+
+| File | Line | Issue | Disabled on |
+| ---- | ---- | ----- | ----------- |
+| e2e/populationPopup.spec.ts | 54 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/populationPopup.spec.ts | 70 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/populationPopup.spec.ts | 87 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/populationPopup.spec.ts | 103 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/populationPopupWithPro.spec.ts | 52 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/populationPopupWithPro.spec.ts | 68 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/populationPopupWithPro.spec.ts | 85 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/populationPopupWithPro.spec.ts | 101 | Population-density-layer high zooms -21601 | 2024-05-13 |
+| e2e/reload.spec.ts | 13 | Disaster-Ninja extra focused geometry -21604 | 2024-05-13 |
+| e2e/reloadWithPro.spec.ts | 17 | Disaster-Ninja extra focused geometry -21604 | 2024-05-13 |
+| e2e/reloadWithPro.spec.ts | 29 | Disaster-Ninja extra focused geometry -21604 | 2024-05-13 |
+| e2e/reloadWithUser.spec.ts | 18 | Disaster-Ninja extra focused geometry -21604 | 2024-05-13 |
+| e2e/reloadWithUser.spec.ts | 38 | Disaster-Ninja extra focused geometry -21604 | 2024-05-13 |

--- a/docs/disabled-e2e-tests.md
+++ b/docs/disabled-e2e-tests.md
@@ -1,0 +1,9 @@
+# Disabled E2E tests
+
+Some Playwright tests are temporarily disabled using `test.fixme`. All such cases must be recorded in `TEST_FIXMES.md`.
+
+## Updating registry
+
+When adding or removing a `test.fixme` call, update `TEST_FIXMES.md` with the file, line number, related issue and date. CI will fail if the registry is not in sync.
+
+Run `pnpm run check:fixmes` locally to verify.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "i18n:import": "tsx ./scripts/i18n/convertion.ts --to-i18next",
     "i18n:report": "tsx ./scripts/i18n/diagnostic.ts",
     "i18n:update": "i18next-scanner --config i18next-scanner.config.cjs",
-    "i18n:gettext-sync": "sh ./scripts/i18n/gettextSync.sh"
+    "i18n:gettext-sync": "sh ./scripts/i18n/gettextSync.sh",
+    "check:fixmes": "node ./scripts/check-test-fixmes.mjs"
   },
   "lint-staged": {
     "*/**/*.{ts,tsx}": [
@@ -186,6 +187,7 @@
     "globals": "^16.0.0",
     "happy-dom": "^17.4.6",
     "husky": "^9.1.7",
+    "glob": "^10.3.10",
     "i18next-scanner": "^4.6.0",
     "jose": "^6.0.11",
     "lint-staged": "^15.5.2",

--- a/scripts/check-test-fixmes.mjs
+++ b/scripts/check-test-fixmes.mjs
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import path from 'path';
+import { readdirSync } from 'fs';
+
+const registryPath = path.resolve('TEST_FIXMES.md');
+const registryContent = fs.existsSync(registryPath)
+  ? fs.readFileSync(registryPath, 'utf8')
+  : '';
+
+function parseRegistry(content) {
+  const lines = content.split('\n');
+  const entries = [];
+  for (const line of lines) {
+    if (!line.startsWith('|')) continue;
+    const cols = line.split('|').map(s => s.trim());
+    if (cols[1] === 'File' || cols[1].startsWith('----')) continue; // header
+    if (cols.length >= 5) {
+      const [ , file, lineNum ] = cols;
+      entries.push({ file, line: parseInt(lineNum, 10) });
+    }
+  }
+  return entries;
+}
+
+const registry = parseRegistry(registryContent);
+
+function listFiles(dir, ext, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) listFiles(full, ext, acc);
+    else if (full.endsWith(ext)) acc.push(full);
+  }
+  return acc;
+}
+
+function parseFixmes() {
+  const files = listFiles('e2e', '.ts');
+  const res = [];
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8').split('\n');
+    content.forEach((line, idx) => {
+      if (line.includes('test.fixme(')) {
+        res.push({ file, line: idx + 1 });
+      }
+    });
+  }
+  return res;
+}
+
+const fixmes = parseFixmes();
+
+function key(item) {
+  return `${item.file}:${item.line}`;
+}
+
+const missing = fixmes.filter(f => !registry.some(r => key(r) === key(f)));
+const stale = registry.filter(r => !fixmes.some(f => key(f) === key(r)));
+
+if (missing.length || stale.length) {
+  console.error('TEST_FIXMES.md is out of sync with code');
+  if (missing.length) {
+    console.error('Missing entries:', missing);
+  }
+  if (stale.length) {
+    console.error('Stale entries:', stale);
+  }
+  process.exit(1);
+}
+
+console.log('TEST_FIXMES.md is up to date');


### PR DESCRIPTION
Closes #1046 

Implemented a registry for disabled Playwright tests and CI check to keep it up to date.
- added `TEST_FIXMES.md` with current `test.fixme` locations
- new `check:fixmes` script verifies registry entries
- CI workflow calls this script
- documentation updated with instructions


------
https://chatgpt.com/codex/tasks/task_b_6888f641a82c8326bf57d15a216d5146