### PR TITLE
test(toolbar): 852 improve resize selectors

### DIFF
--- a/e2e/page-objects/toolBar.ts
+++ b/e2e/page-objects/toolBar.ts
@@ -38,8 +38,8 @@ export class ToolBar extends HelperBase {
   )
   async resizeToolbar({ collapse = true }: { collapse: boolean }) {
     const toolbarPanel = this.page.getByTestId('toolbar');
-    const svgNumberToClick = collapse ? 2 : 1;
-    await toolbarPanel.locator('svg').nth(svgNumberToClick).click();
+    const testId = collapse ? 'toolbar-collapse' : 'toolbar-expand';
+    await toolbarPanel.getByTestId(testId).click();
     await expect(
       toolbarPanel.getByText('Toolbar'),
       `Expect toolbar text to be visible and to be ${collapse ? 'short' : 'big'}`,
@@ -101,7 +101,7 @@ export class ToolBar extends HelperBase {
     await element.hover();
     const tooltip = this.page.getByRole('tooltip', { name: tooltipText });
     await tooltip.waitFor({ state: 'visible' });
-    await this.page.getByText('Collapse').hover();
+    await this.page.getByTestId('toolbar-collapse').hover();
     await tooltip.waitFor({ state: 'hidden' });
   }
 

--- a/src/utils/hooks/useShortPanelState.tsx
+++ b/src/utils/hooks/useShortPanelState.tsx
@@ -7,12 +7,16 @@ interface UseShortPanelStateProps {
   initialState?: PanelState | null;
   skipShortState?: boolean;
   isMobile?: boolean;
+  /** Optional id used to generate test ids for panel controls */
+  panelId?: string;
 }
 
 export const useShortPanelState = (props?: UseShortPanelStateProps) => {
   const initialState = props?.initialState ?? 'full';
   const skipShortState = props?.skipShortState ?? false;
   const isMobile = props?.isMobile ?? false;
+  const collapseTestId = props?.panelId ? `${props.panelId}-collapse` : undefined;
+  const expandTestId = props?.panelId ? `${props.panelId}-expand` : undefined;
   const [panelState, setPanelState] = useState<PanelState>(initialState);
 
   const panelControls = useMemo(() => {
@@ -20,7 +24,12 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
       if (!skipShortState && initialState !== 'closed') {
         return [
           {
-            icon: panelState === 'full' ? <ChevronDown24 /> : <ChevronUp24 />,
+            icon:
+              panelState === 'full' ? (
+                <ChevronDown24 data-testid={collapseTestId} />
+              ) : (
+                <ChevronUp24 data-testid={expandTestId} />
+              ),
             onWrapperClick: (e) => {
               e.stopPropagation();
               setPanelState((prevState) => (prevState === 'full' ? 'short' : 'full'));
@@ -34,7 +43,12 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
     if (skipShortState) {
       return [
         {
-          icon: panelState === 'closed' ? <ChevronDown24 /> : <ChevronUp24 />,
+          icon:
+            panelState === 'closed' ? (
+              <ChevronDown24 data-testid={expandTestId} />
+            ) : (
+              <ChevronUp24 data-testid={collapseTestId} />
+            ),
           onWrapperClick: () => {
             const nextState = initialState === 'closed' ? 'full' : initialState;
             setPanelState((prevState) => (prevState === 'closed' ? nextState : 'closed'));
@@ -45,7 +59,7 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
 
     return [
       {
-        icon: <ChevronDown24 />,
+        icon: <ChevronDown24 data-testid={collapseTestId} />,
         onWrapperClick: (e) => {
           e.stopPropagation();
           setPanelState((prevState) => (prevState === 'closed' ? 'short' : 'full'));
@@ -53,7 +67,7 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
         disabled: panelState === 'full',
       },
       {
-        icon: <ChevronUp24 />,
+        icon: <ChevronUp24 data-testid={expandTestId} />,
         onWrapperClick: (e) => {
           e.stopPropagation();
           setPanelState((prevState) => (prevState === 'full' ? 'short' : 'closed'));

--- a/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
@@ -52,6 +52,7 @@ export function FullAndShortStatesPanelWidget({
     initialState,
     skipShortState: Boolean(!fullState || !shortState),
     isMobile: isMobile,
+    panelId: id,
   });
 
   const getProperty = useCallback(


### PR DESCRIPTION
Fibery Ticket: #852

## Summary
- assign test ids for toolbar resize controls via `useShortPanelState`
- update `FullAndShortStatesPanelWidget` to pass panel id for selectors
- use new selectors in toolbar e2e helpers

## Testing
- `pnpm lint`
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_b_6888f5dc69dc83269053dc8e20097c6d