### PR TITLE
fix: Revert #1175 "fix(create_layer): 10088 unique id for new layers"

### DIFF
--- a/src/features/create_layer/atoms/editableLayerController.ts
+++ b/src/features/create_layer/atoms/editableLayerController.ts
@@ -1,15 +1,10 @@
-import { nanoid } from 'nanoid';
 import { configRepo } from '~core/config';
 import { createAtom } from '~utils/atoms';
 import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
 import { notificationServiceInstance } from '~core/notificationServiceInstance';
 import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
 import { createLayer, deleteLayer, updateLayer } from '../api/layers';
-import {
-  EditTargets,
-  DEFAULT_USER_LAYER_LEGEND,
-  USER_LAYER_ID_PREFIX,
-} from '../constants';
+import { EditTargets, DEFAULT_USER_LAYER_LEGEND } from '../constants';
 import { createLayerEditorFormAtom } from './layerEditorForm';
 import { createLayerEditorFormFieldAtom } from './layerEditorFormField';
 import { editableLayerSettingsAtom } from './editableLayerSettings';
@@ -48,9 +43,7 @@ export const editableLayerControllerAtom = createAtom(
       state = {
         loading: false,
         error: null,
-        data: createLayerEditorFormAtom({
-          id: `${USER_LAYER_ID_PREFIX}${nanoid()}`,
-        }),
+        data: createLayerEditorFormAtom(),
       };
       schedule((dispatch) => {
         dispatch(editTargetAtom.set({ type: 'layer' }));

--- a/src/features/create_layer/constants.ts
+++ b/src/features/create_layer/constants.ts
@@ -3,7 +3,6 @@ import type { SimpleLegend } from '~core/logical_layers/types/legends';
 export const CREATE_LAYER_CONTROL_ID = 'EditableLayer' as const;
 export const CUSTOM_LAYER_DRAW_TOOLS_CONTROL = 'customLayerDrawToolsControl';
 export const CREATE_LAYER_CONTROL_NAME = i18n.t('toolbar.create_layer');
-export const USER_LAYER_ID_PREFIX = 'user-layer-';
 
 export const FieldTypes = {
   None: 'none',

--- a/src/features/create_layer/readme.md
+++ b/src/features/create_layer/readme.md
@@ -51,7 +51,6 @@ This feature uses next core modules:
 ## How it works
 
 1. layerSideBarButtonControllerAtom adds "Create layer" button in side bar (layerSideBarButtonControllerAtom). This button creates new layer on click.
-   Each new layer receives a randomly generated `id` prefixed with `user-layer-` so layers with the same name remain independent.
 2. editableLayersListResource atom loads enabled user layers
 3. editableLayersControlsAtom - creates logical_layer (visible in layers panel) for every layer from editableLayersListResource
 4. editableLayersLegendsAndSources - creates legends and sources for enabled layers


### PR DESCRIPTION
Reverts konturio/disaster-ninja-fe#1175

The branch introduced TS error, plus the problem was already fixed before (in https://kontur.fibery.io/Tasks/Task/Layers-are-identified-by-name-instead-of-id-when-enabled-disabled-in-Layers-panel-21754 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation to remove references to layer IDs being prefixed with "user-layer-".

* **Refactor**
  * Simplified the process for creating new layers by no longer generating prefixed random IDs for each layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->