### PR TITLE
feat(layer_features_panel): 21648 HOT projects min height

### DIFF
--- a/src/features/layer_features_panel/constants.ts
+++ b/src/features/layer_features_panel/constants.ts
@@ -1,4 +1,4 @@
-export const FEATURESPANEL_MIN_HEIGHT = 80;
+export const FEATURESPANEL_MIN_HEIGHT = 360;
 
 // name for optional custom bbox property. Used to focus on custom bbox area associated with feature
 export const LAYER_FEATURES_CUSTOM_FOCUS_BBOX = '__customFocusBbox';


### PR DESCRIPTION
Fibery ticket: `21648`

## Summary
- set HOT Tasking Manager Projects panel minimum height to 360px

## Testing
- `npx -y pnpm@9 vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a126ac9b8832f966534450abd9a9a