### PR TITLE
fix(workflows): no-ticket set up buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## Summary
- ensure Docker Buildx builder is initialized in build workflow

Fixes build error due to unsupported cache export on the default docker driver.

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `NODE_ENV=test pnpm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a15d73c60832f8837c6754fcf802a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build pipeline to include an additional setup step for Docker Buildx during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->