### PR TITLE
fix(events-list): 18556 do not autoselect event on feed change

### DIFF
--- a/src/features/events_list/components/FeedSelector/FeedSelector.tsx
+++ b/src/features/events_list/components/FeedSelector/FeedSelector.tsx
@@ -3,7 +3,6 @@ import { Select, type SelectableItem } from '@konturio/ui-kit';
 import { useCallback } from 'react';
 import { configRepo } from '~core/config';
 import { i18n } from '~core/localization';
-import { scheduledAutoSelect } from '~core/shared_state/currentEvent';
 import { eventFeedsAtom } from '~core/shared_state/eventFeeds';
 import { currentEventFeedAtom } from '~core/shared_state/currentEventFeed';
 import s from './FeedSelector.module.css';
@@ -16,7 +15,6 @@ type FeedItem = {
 export function FeedSelector() {
   const [eventFeeds] = useAtom(eventFeedsAtom);
   const [currentFeed, { setCurrentFeed }] = useAtom(currentEventFeedAtom);
-  const scheduleAutoSelect = useAction(scheduledAutoSelect.setTrue);
 
   const mappedItems: FeedItem[] =
     eventFeeds.data?.map((fd) => ({
@@ -29,9 +27,8 @@ export function FeedSelector() {
       if (!selection || Array.isArray(selection)) return;
 
       setCurrentFeed(selection.value as string);
-      scheduleAutoSelect();
     },
-    [setCurrentFeed, scheduleAutoSelect],
+    [setCurrentFeed],
   );
 
   if (eventFeeds.data?.length < 2) {

--- a/src/features/events_list/readme.md
+++ b/src/features/events_list/readme.md
@@ -75,6 +75,8 @@ The `autoSelectEvent` atom is responsible for automatically selecting an event w
 
 The `autoSelectEvent` atom automatically selects an event from the `eventListResource` atom based on certain conditions. If `scheduledAutoSelect` has been set to `true`, and if the `eventListResource` atom exists, is not `loading` or in `error`, and contains at least one event, then the current event is checked to see if it is in the list of events. If it is, the function returns the current state. If it is not, the function schedules an auto-focus on the first event in the list, and sets the current event to the first event in the list. If there is no current event, a notification is shown.
 
+`scheduledAutoSelect` can be toggled by various parts of the application (for example URL handling or feed synchronization). The `FeedSelector` component no longer triggers this flag on feed change, so switching feeds simply clears the current event without auto-selecting another.
+
 The `autoSelectEvent` atom is useful in situations where the user lands on the events list page and there is no pre-selected event. It ensures that the first event in the list is selected automatically, allowing the user to see event details without manually selecting one.
 
 ## `currentEventBbox`

--- a/src/features/events_list/readme.md
+++ b/src/features/events_list/readme.md
@@ -23,7 +23,7 @@ The `CurrentEvent` component displays details for the currently selected unliste
 
 ### FeedSelector
 
-The `FeedSelector` component allows users to filter the event list by feed. It displays a list of available feeds and allows the user to select one or more to filter the event list. When the component mounts, it selects the default feed from the user profile settings. Will be displayed if feedSelector feature is enabled.
+The `FeedSelector` component allows users to filter the event list by feed. It displays a list of available feeds and allows the user to select one or more to filter the event list. When the component mounts, it selects the default feed from the user profile settings. Will be displayed if feedSelector feature is enabled. When a different feed is chosen, the currently selected event is cleared and nothing is auto-selected from the new feed.
 
 ### BBoxFilter
 


### PR DESCRIPTION
## Summary
- remove auto-select when changing feeds
- document no auto-selection after feed switch

Fibery task: [18556](https://kontur.fibery.io/Tasks/Task/18556)

## Testing
- `pnpm coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a1e9fc594832fa2a0c251e14bf49f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation for the feed selection component to clarify that changing the selected feed will clear the current event selection and will not automatically select a new event.

* **Bug Fixes**
  * Removed automatic event selection when switching feeds to prevent unintended event changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->