### PR TITLE
fix(url): preserve event id on load

### DIFF
--- a/src/core/url_store/atoms/urlStore.ts
+++ b/src/core/url_store/atoms/urlStore.ts
@@ -81,14 +81,14 @@ export const urlStoreAtom = createAtom(
           );
         }
 
-        // Apply event
-        if (initialState.event) {
-          actions.push(currentEventAtom.setCurrentEventId(initialState.event));
-        }
-
-        // Apply feed
+        // Apply feed first to preserve event id
         if (initialState.feed && isFeedSelectorEnabled) {
           actions.push(currentEventFeedAtom.setCurrentFeed(initialState.feed));
+        }
+
+        // Apply event after feed to avoid event reset during feed change
+        if (initialState.event) {
+          actions.push(currentEventAtom.setCurrentEventId(initialState.event));
         }
 
         // Done


### PR DESCRIPTION
Fibery: https://kontur.fibery.io/Tasks/Task/DN-FE-Event-id-is-disappearing-from-the-URL-while-sharing-it-with-the-feed-other-than-Kontur-Public-22366 

## Summary
- avoid resetting the current event when URL provides both feed and event

## Testing
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a27df8550832f9ec4d08602c00ac3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of feed and event state initialization to ensure event information is preserved when switching feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->