### PR TITLE
feat(MVA): 22236 Update bivariate legend component for Multivariate legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@konturio/default-icons": "^2.5.1",
     "@konturio/default-theme": "~3.2.7",
     "@konturio/floating": "^1.2.1",
-    "@konturio/ui-kit": "^5.4.3",
+    "@konturio/ui-kit": "^5.5.0",
     "@nebula.gl/edit-modes": "1.1.0-alpha.5",
     "@nebula.gl/layers": "1.1.0-alpha.5",
     "@paypal/react-paypal-js": "^8.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1(clsx@2.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@konturio/ui-kit':
-        specifier: ^5.4.3
-        version: 5.4.3(@egjs/hammerjs@2.0.17)(clsx@2.1.1)(component-emitter@1.3.1)(keycharm@0.4.0)(moment@2.30.1)(propagating-hammerjs@2.0.1(@egjs/hammerjs@2.0.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(uuid@8.3.2)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))(xss@1.0.15)
+        specifier: ^5.5.0
+        version: 5.5.0(@egjs/hammerjs@2.0.17)(clsx@2.1.1)(component-emitter@1.3.1)(keycharm@0.4.0)(moment@2.30.1)(propagating-hammerjs@2.0.1(@egjs/hammerjs@2.0.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(uuid@8.3.2)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))(xss@1.0.15)
       '@nebula.gl/edit-modes':
         specifier: 1.1.0-alpha.5
         version: 1.1.0-alpha.5
@@ -942,12 +942,6 @@ packages:
   '@floating-ui/dom@1.6.12':
     resolution: {integrity: sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==}
 
-  '@floating-ui/react-dom@2.1.2':
-    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   '@floating-ui/react-dom@2.1.3':
     resolution: {integrity: sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==}
     peerDependencies:
@@ -1054,8 +1048,14 @@ packages:
       clsx: ^2.1.1
       react: ^18.2.0
 
-  '@konturio/ui-kit@5.4.3':
-    resolution: {integrity: sha512-1na/go9J8aUUqo5j1dGp06AhwR4dlnUSL5q1a1q1o5xY67LquZP120ov1YsHaPi2cjEc500LH3ljG+lruqsoaw==}
+  '@konturio/floating@1.2.2':
+    resolution: {integrity: sha512-48HXWSSYtOZydRBo6O78wKl8qPCVcTUKaRUpVvd5iUSTgFPs+YXW0R/zFZ9fvU+ONDPaNL17yDF51dOAATKq2w==}
+    peerDependencies:
+      clsx: ^2.1.1
+      react: ^18.2.0
+
+  '@konturio/ui-kit@5.5.0':
+    resolution: {integrity: sha512-u4U1f1O+r7LcpKV6qqSjinKf02MpUzKlp3pBv5RBk1BvBondZJflL3KJrAE94MIOCNYQ4frBxB4xGh/cok6j9Q==}
     peerDependencies:
       clsx: ^2.1.1
       react: ^18.2.0
@@ -6690,12 +6690,6 @@ snapshots:
       '@floating-ui/core': 1.6.8
       '@floating-ui/utils': 0.2.9
 
-  '@floating-ui/react-dom@2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/dom': 1.6.12
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@floating-ui/react-dom@2.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/dom': 1.6.12
@@ -6814,10 +6808,19 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@konturio/ui-kit@5.4.3(@egjs/hammerjs@2.0.17)(clsx@2.1.1)(component-emitter@1.3.1)(keycharm@0.4.0)(moment@2.30.1)(propagating-hammerjs@2.0.1(@egjs/hammerjs@2.0.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(uuid@8.3.2)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))(xss@1.0.15)':
+  '@konturio/floating@1.2.2(clsx@2.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@konturio/floating': 1.2.1(clsx@2.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react': 0.27.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      nanoid: 4.0.2
+      react: 18.3.1
+    transitivePeerDependencies:
+      - react-dom
+
+  '@konturio/ui-kit@5.5.0(@egjs/hammerjs@2.0.17)(clsx@2.1.1)(component-emitter@1.3.1)(keycharm@0.4.0)(moment@2.30.1)(propagating-hammerjs@2.0.1(@egjs/hammerjs@2.0.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(uuid@8.3.2)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))(xss@1.0.15)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@konturio/floating': 1.2.2(clsx@2.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       downshift: 8.5.0(react@18.3.1)
       nanoid: 4.0.2

--- a/src/components/MultivariateLegend/MultivariateLegend.module.css
+++ b/src/components/MultivariateLegend/MultivariateLegend.module.css
@@ -21,3 +21,22 @@
 .grayscale {
   filter: grayscale(1);
 }
+
+.bivariateAxis {
+  max-height: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--half-unit);
+}
+
+.bivariateAxisLayer {
+  line-height: 13px;
+}
+
+.bivariateAxisLabel {
+  color: var(--black);
+}
+
+.bivariateAxisRange {
+  color: var(--faint-strong);
+}

--- a/src/components/MultivariateLegend/MultivariateLegend.module.css
+++ b/src/components/MultivariateLegend/MultivariateLegend.module.css
@@ -22,11 +22,19 @@
   filter: grayscale(1);
 }
 
-.bivariateAxis {
-  max-height: 180px;
+.bivariateXAxis {
+  max-width: 160px;
   display: flex;
   flex-direction: column;
   gap: var(--half-unit);
+}
+
+.bivariateYAxis {
+  max-height: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--half-unit);
+  margin-block-start: var(--double-unit);
 }
 
 .bivariateAxisLayer {

--- a/src/components/MultivariateLegend/MultivariateLegend.tsx
+++ b/src/components/MultivariateLegend/MultivariateLegend.tsx
@@ -1,7 +1,10 @@
 import { Legend as BiLegend, MCDALegend, Text } from '@konturio/ui-kit';
 import { Letter } from '@konturio/default-icons';
 import clsx from 'clsx';
-import { generateMCDALegendColors } from '~utils/mcda/mcdaLegendsUtils';
+import {
+  generateMCDALegendColors,
+  mcdaRangeToFixedNumber,
+} from '~utils/mcda/mcdaLegendsUtils';
 import { BIVARIATE_LEGEND_SIZE } from '~components/BivariateLegend/const';
 import { DEFAULT_MULTIBIVARIATE_STEPS } from '~utils/multivariate/constants';
 import { invertClusters, type Step } from '~utils/bivariate';
@@ -121,6 +124,33 @@ function createBivariateLegend(
     'label',
   ) as Cell[];
 
+  function renderBivLegendAxisLayer(layer: MCDALayer) {
+    return (
+      <div className={s.bivariateAxisLayer} key={layer.id}>
+        <span className={s.bivariateAxisLabel}>{layer.name}</span>
+        <span
+          className={s.bivariateAxisRange}
+        >{` ${mcdaRangeToFixedNumber(layer.range?.at(0))} \u2192 ${mcdaRangeToFixedNumber(layer.range?.at(1))} ${layer.unit ?? ''}`}</span>
+      </div>
+    );
+  }
+
+  const renderScoreAxisLabel = (axis, rootClassName) => {
+    return (
+      <div className={clsx(rootClassName, s.bivariateAxis)}>
+        {score.layers.map(renderBivLegendAxisLayer)}
+      </div>
+    );
+  };
+
+  const renderBaseAxisLabel = (axis, rootClassName) => {
+    return (
+      <div className={clsx(rootClassName, s.bivariateAxis)}>
+        {base.layers.map(renderBivLegendAxisLayer)}
+      </div>
+    );
+  };
+
   const hints: LayerMeta['hints'] = {
     x: getCornerHintsForDimension(score, DEFAULT_SCORE_DIRECTION),
     y: getCornerHintsForDimension(base, DEFAULT_BASE_DIRECTION),
@@ -133,6 +163,9 @@ function createBivariateLegend(
           size={BIVARIATE_LEGEND_SIZE}
           axis={{ x: xAxis, y: yAxis }}
           showAxisLabels
+          showSteps={false}
+          renderYAxisLabel={renderScoreAxisLabel}
+          renderXAxisLabel={renderBaseAxisLabel}
         />
       </CornerTooltipWrapper>
     </DimensionStack>

--- a/src/components/MultivariateLegend/MultivariateLegend.tsx
+++ b/src/components/MultivariateLegend/MultivariateLegend.tsx
@@ -137,7 +137,7 @@ function createBivariateLegend(
 
   const renderScoreAxisLabel = (axis, rootClassName) => {
     return (
-      <div className={clsx(rootClassName, s.bivariateAxis)}>
+      <div className={clsx(rootClassName, s.bivariateYAxis)}>
         {score.layers.map(renderBivLegendAxisLayer)}
       </div>
     );
@@ -145,11 +145,18 @@ function createBivariateLegend(
 
   const renderBaseAxisLabel = (axis, rootClassName) => {
     return (
-      <div className={clsx(rootClassName, s.bivariateAxis)}>
+      <div className={clsx(rootClassName, s.bivariateXAxis)}>
         {base.layers.map(renderBivLegendAxisLayer)}
       </div>
     );
   };
+
+  const showScoreSteps =
+    score.layers.length === 1 ||
+    score.layers.every((layer) => layer.normalization === 'max-min');
+  const showBaseSteps =
+    base.layers.length === 1 ||
+    base.layers.every((layer) => layer.normalization === 'max-min');
 
   const hints: LayerMeta['hints'] = {
     x: getCornerHintsForDimension(score, DEFAULT_SCORE_DIRECTION),
@@ -163,7 +170,7 @@ function createBivariateLegend(
           size={BIVARIATE_LEGEND_SIZE}
           axis={{ x: xAxis, y: yAxis }}
           showAxisLabels
-          showSteps={false}
+          showSteps={{ x: showBaseSteps, y: showScoreSteps }}
           renderYAxisLabel={renderScoreAxisLabel}
           renderXAxisLabel={renderBaseAxisLabel}
         />

--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
@@ -166,12 +166,12 @@ export function MCDALayerParameters({
       left: {
         label: layer.sentiment.at(0)!, // Sentiments name needed instead of id
         color: isGoodLeft ? sentimentColors.good : sentimentColors.bad,
-        value: String(layer.range.at(0)),
+        value: layer.range.at(0),
       },
       right: {
         label: layer.sentiment.at(1)!,
         color: isGoodLeft ? sentimentColors.bad : sentimentColors.good,
-        value: String(layer.range.at(1)),
+        value: layer.range.at(1),
       },
     };
   }, [layer]);

--- a/src/features/mcda/components/MCDALayerEditor/Sentiments.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/Sentiments.tsx
@@ -1,9 +1,10 @@
 import { Text } from '@konturio/ui-kit';
+import { mcdaRangeToFixedNumber } from '~utils/mcda/mcdaLegendsUtils';
 
 export type Sentiment = {
   label: string;
   color: string;
-  value: string;
+  value: number | undefined;
 };
 
 export function Sentiments({
@@ -21,13 +22,13 @@ export function Sentiments({
       <span style={{ color: left.color }}>
         <Text type={'caption'}>{`${left.label} `}</Text>
       </span>{' '}
-      <Text type={'caption'}>({+parseFloat(left.value).toFixed(3)})</Text>
+      <Text type={'caption'}>({mcdaRangeToFixedNumber(left.value)})</Text>
       {' \u2192 '}
       {/* Right */}
       <span style={{ color: right.color }}>
         <Text type={'caption'}>{`${right.label} `}</Text>
       </span>
-      <Text type={'caption'}>({+parseFloat(right.value).toFixed(3)})</Text>
+      <Text type={'caption'}>({mcdaRangeToFixedNumber(right.value)})</Text>
       {units ? <Text type={'caption'}>, {units}</Text> : null}
     </div>
   );

--- a/src/utils/mcda/mcdaLegendsUtils.ts
+++ b/src/utils/mcda/mcdaLegendsUtils.ts
@@ -20,3 +20,7 @@ export function generateMCDALegendColors(colors: ColorsBySentiments) {
     return generateHclGradientColors(colorBad.toString(), colorGood.toString(), 5);
   }
 }
+
+export function mcdaRangeToFixedNumber(rawValue: number | undefined): number {
+  return Number(rawValue?.toFixed(3));
+}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Update-Bivariate-legend-component-for-Multivariate-legend-22236

<img width="378" height="251" alt="image" src="https://github.com/user-attachments/assets/1a815167-862d-4851-855d-b190a7e748a4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bivariate legend with improved axis label rendering and clearer display of MCDA layer names and ranges.
  * Added a utility for consistent numeric formatting of MCDA layer ranges.

* **Style**
  * Updated styles for bivariate axes in the MultivariateLegend for improved layout and readability.

* **Bug Fixes**
  * Corrected handling of sentiment values to use numeric types directly for improved accuracy and consistency.

* **Chores**
  * Updated "@konturio/ui-kit" dependency to version 5.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->