### PR TITLE
fix(MultivariateAnalysisForm): 22367 fix updating bivariate steps in MVA config after it was saved once

### DIFF
--- a/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
+++ b/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
@@ -38,7 +38,6 @@ type MultivariateLayerConfigOverrides = {
 
 export function createMultivariateConfig(
   overrides: MultivariateLayerConfigOverrides,
-  availableBivariateAxes: Axis[],
 ): MultivariateLayerConfig {
   const name = overrides?.name || DEFAULT_MULTIVARIATE_ANALYSIS_NAME;
   const hasScore = !!overrides?.score?.length;
@@ -118,15 +117,7 @@ export function createMultivariateConfig(
     base: baseMCDAStyle,
     opacity: opacityMCDAStyle ?? opacityStatic,
     text: textDimension,
-    stepOverrides: isBivariateStyleLegend
-      ? overrides.stepOverrides || {
-          baseSteps: createStepsForMCDADimension(overrides.base, availableBivariateAxes),
-          scoreSteps: createStepsForMCDADimension(
-            overrides.score,
-            availableBivariateAxes,
-          ),
-        }
-      : undefined,
+    stepOverrides: isBivariateStyleLegend ? overrides.stepOverrides : undefined,
     colors:
       overrides?.colors ||
       (isBivariateStyleLegend


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Bivariate-steps-in-MVA-stop-updating-after-one-edit-22367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for generating and applying step overrides in multivariate analysis configuration, streamlining how custom and automatic steps are handled.
  * Simplified configuration function interfaces for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->