### PR TITLE
feat(panels): 18136 persist panel and layer state

### DIFF
--- a/docs/investigations/panels-report.md
+++ b/docs/investigations/panels-report.md
@@ -106,6 +106,8 @@ const handleRefChange = useHeightResizer(
   isOpen,
   MIN_HEIGHT,
   'panel_identifier',
+  undefined, // skipAutoResize
+  true, // persist height
 );
 ```
 

--- a/src/core/app/postAppInit.ts
+++ b/src/core/app/postAppInit.ts
@@ -1,13 +1,16 @@
 import { urlStoreAtom } from '~core/url_store';
+import { persistEnabledLayers, loadEnabledLayers } from '~core/panels_state';
 import { onLogin } from './authHooks';
 import { runAtom } from './index';
 import type { Config } from '~core/config/types';
 
 export async function postAppInit(config: Config) {
   onLogin();
+  const storedLayers = loadEnabledLayers();
   urlStoreAtom.init.dispatch({
     ...config.initialUrlData,
-    layers: config.activeLayers,
+    layers: storedLayers ?? config.activeLayers,
   });
+  persistEnabledLayers();
   runAtom(urlStoreAtom);
 }

--- a/src/core/panels_state/index.ts
+++ b/src/core/panels_state/index.ts
@@ -1,0 +1,27 @@
+import { AppStorage } from '~core/cookie_settings/AppStorage';
+import { configRepo } from '~core/config';
+import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
+
+const layersStorageKey = () => `kontur_layers_${configRepo.get().id}`;
+
+export function loadEnabledLayers(): string[] | null {
+  const storage = new AppStorage<string[]>(layersStorageKey());
+  return storage.get('layers');
+}
+
+export function persistEnabledLayers() {
+  const storage = new AppStorage<string[]>(layersStorageKey());
+  enabledLayersAtom.v3atom.onChange((ctx, layers) => {
+    storage.set('layers', Array.from(layers));
+  });
+}
+
+export function savePanelState(panelId: string, state: string) {
+  const storage = new AppStorage<string>(`kontur_panels_${configRepo.get().id}`);
+  storage.set(panelId, state);
+}
+
+export function loadPanelState(panelId: string): string | null {
+  const storage = new AppStorage<string>(`kontur_panels_${configRepo.get().id}`);
+  return storage.get(panelId);
+}

--- a/src/core/panels_state/index.ts
+++ b/src/core/panels_state/index.ts
@@ -25,3 +25,17 @@ export function loadPanelState(panelId: string): string | null {
   const storage = new AppStorage<string>(`kontur_panels_${configRepo.get().id}`);
   return storage.get(panelId);
 }
+
+export function savePanelHeight(panelId: string, height: string | null) {
+  const storage = new AppStorage<string>(`kontur_panel_heights_${configRepo.get().id}`);
+  if (height) {
+    storage.set(panelId, height);
+  } else {
+    storage.remove(panelId);
+  }
+}
+
+export function loadPanelHeight(panelId: string): string | null {
+  const storage = new AppStorage<string>(`kontur_panel_heights_${configRepo.get().id}`);
+  return storage.get(panelId);
+}

--- a/src/core/panels_state/readme.md
+++ b/src/core/panels_state/readme.md
@@ -1,0 +1,11 @@
+# Panel and Layer State Persistence
+
+This module stores UI panel states and enabled map layers in `localStorage` so the application can restore them on the next visit.
+
+## API
+
+- `loadEnabledLayers()` – returns an array of layer IDs saved from the previous session or `null` if nothing is stored.
+- `persistEnabledLayers()` – subscribes to `enabledLayersAtom` changes and saves the current layer set.
+- `savePanelState(panelId, state)` / `loadPanelState(panelId)` – save and restore a single panel state (`'full' | 'short' | 'closed'`).
+
+The storage keys are namespaced with the current application id from `configRepo`.

--- a/src/core/panels_state/readme.md
+++ b/src/core/panels_state/readme.md
@@ -7,5 +7,6 @@ This module stores UI panel states and enabled map layers in `localStorage` so t
 - `loadEnabledLayers()` – returns an array of layer IDs saved from the previous session or `null` if nothing is stored.
 - `persistEnabledLayers()` – subscribes to `enabledLayersAtom` changes and saves the current layer set.
 - `savePanelState(panelId, state)` / `loadPanelState(panelId)` – save and restore a single panel state (`'full' | 'short' | 'closed'`).
+- `savePanelHeight(panelId, height)` / `loadPanelHeight(panelId)` – persist custom panel heights between sessions.
 
 The storage keys are namespaced with the current application id from `configRepo`.

--- a/src/features/events_list/components/EventsPanel/EventsPanel.tsx
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.tsx
@@ -66,7 +66,7 @@ export function EventsPanel({
     togglePanel,
     isOpen,
     isShort,
-  } = useShortPanelState({ isMobile });
+  } = useShortPanelState({ isMobile, persistKey: 'events_panel' });
 
   const [focusedGeometry] = useAtom(focusedGeometryAtom);
   const [{ data: eventsList, error, loading }] = useAtomV3(sortedEventListAtom);

--- a/src/features/events_list/components/EventsPanel/EventsPanel.tsx
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.tsx
@@ -77,6 +77,8 @@ export function EventsPanel({
     isOpen,
     MIN_HEIGHT,
     'event_list',
+    undefined,
+    true,
   );
 
   useAutoCollapsePanel(isOpen, closePanel);

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
@@ -98,7 +98,7 @@ export function LayerFeaturesPanel() {
     togglePanel,
     closePanel,
     setPanelState,
-  } = useShortPanelState({ isMobile });
+  } = useShortPanelState({ isMobile, persistKey: 'layer_features_panel' });
 
   const isOpen = panelState !== 'closed';
   const isShort = panelState === 'short';
@@ -108,6 +108,8 @@ export function LayerFeaturesPanel() {
     isOpen,
     FEATURESPANEL_MIN_HEIGHT,
     'lf_list',
+    undefined,
+    true,
   );
 
   useAutoCollapsePanel(isOpen, closePanel);

--- a/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
@@ -53,6 +53,7 @@ export function FullAndShortStatesPanelWidget({
     skipShortState: Boolean(!fullState || !shortState),
     isMobile: isMobile,
     panelId: id,
+    persistKey: id,
   });
 
   const getProperty = useCallback(

--- a/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
@@ -75,6 +75,7 @@ export function FullAndShortStatesPanelWidget({
     minHeight,
     id || 'primary_and_secondary',
     isShort ? shortState?.skipAutoResize : fullState?.skipAutoResize,
+    true,
   );
 
   useAutoCollapsePanel(isOpen, closePanel);


### PR DESCRIPTION
Fibery Ticket: [18136](https://kontur.fibery.io/Tasks/Task/18136)

## Summary
- store panel state and active layers in localStorage
- load saved layers on app init
- persist panel state via `useShortPanelState`

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688a657944d4832f8934b302caf47967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panel state and enabled map layers are now saved and restored automatically, preserving your UI preferences across sessions.
  * Panels such as the events panel and others now remember their open, closed, or minimized states after you revisit the app.

* **Documentation**
  * Added documentation describing how panel and layer state persistence works within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->