### PR TITLE
feat(panel): 0000 bottom edge resizing

### DIFF
--- a/docs/investigations/panels-report.md
+++ b/docs/investigations/panels-report.md
@@ -151,6 +151,8 @@ The following panels are configured to be vertically resizable, often using the 
 - [`EventsPanel.tsx`](../../src/features/events_list/components/EventsPanel/EventsPanel.tsx)
 - [`layers_panel/index.tsx`](../../src/features/layers_panel/index.tsx) (configured via `PanelFeatureInterface`)
 
+Since version 2.53.1, the local `Panel` wrapper extends the UI kit component by adding a drag handle that spans the entire bottom edge. Users can now resize panels by dragging anywhere along the bottom border instead of only the bottom-right corner.
+
 ### Mobile Modal Panels
 
 Several Panel implementations are designed to appear as modal sheets on narrow displays (mobile view). This is primarily achieved through the conditional use of the `modal` prop, often in conjunction with the `useMediaQuery` hook and the `react-modal-sheet` library.

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -1,0 +1,55 @@
+import { Panel as UIKitPanel } from '@konturio/ui-kit';
+import { forwardRef, useRef } from 'react';
+import s from './styles.module.css';
+import type { Panel as PanelProps } from '@konturio/ui-kit/tslib/Panel/types';
+
+export const Panel = forwardRef<HTMLDivElement, PanelProps>((props, ref) => {
+  const { resize = 'none', contentContainerRef, children, ...rest } = props;
+  const internalRef = useRef<HTMLDivElement | null>(null);
+
+  const handleContainerRef = (node: HTMLDivElement) => {
+    internalRef.current = node;
+    contentContainerRef?.(node);
+  };
+
+  const startY = useRef<number | null>(null);
+  const startHeight = useRef<number>(0);
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (startY.current === null || !internalRef.current) return;
+    const diff = e.clientY - startY.current;
+    const newHeight = startHeight.current + diff;
+    internalRef.current.style.height = `${newHeight}px`;
+  };
+
+  const stopDrag = () => {
+    startY.current = null;
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', stopDrag);
+  };
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    if (!internalRef.current) return;
+    startY.current = e.clientY;
+    startHeight.current = internalRef.current.getBoundingClientRect().height;
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', stopDrag);
+    e.preventDefault();
+  };
+
+  return (
+    <UIKitPanel
+      {...rest}
+      ref={ref}
+      resize={resize}
+      contentContainerRef={handleContainerRef}
+    >
+      {children}
+      {resize === 'vertical' && (
+        <div className={s.resizeHandle} onMouseDown={onMouseDown} />
+      )}
+    </UIKitPanel>
+  );
+});
+
+Panel.displayName = 'Panel';

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -1,4 +1,6 @@
 import s from './styles.module.css';
+export { PanelIcon } from '@konturio/ui-kit/tslib/Panel';
+export { Panel } from './Panel';
 
 export const panelClasses = {
   header: `${s.header} knt-panel-header`,

--- a/src/components/Panel/styles.module.css
+++ b/src/components/Panel/styles.module.css
@@ -25,6 +25,19 @@
   z-index: var(--modal);
 }
 
+.contentContainer {
+  position: relative;
+}
+
+.resizeHandle {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 6px;
+  cursor: ns-resize;
+}
+
 @media screen and (max-width: 960px) {
   .modal > section {
     top: calc(50% + var(--app-header-height)); /* header offset */

--- a/src/features/breadcrumbs/BreadcrumbsPanel.tsx
+++ b/src/features/breadcrumbs/BreadcrumbsPanel.tsx
@@ -1,5 +1,5 @@
-import { Panel } from '@konturio/ui-kit';
 import { useAction } from '@reatom/npm-react';
+import { Panel } from '~components/Panel';
 import { constructOptionsFromBoundaries } from '~utils/map/boundaries';
 import { i18n } from '~core/localization';
 import Breadcrumbs from './components/Breadcrumbs/Breadcrumbs';

--- a/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.tsx
+++ b/src/features/create_layer/components/EditFeaturesPanel/EditFeaturesPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import clsx from 'clsx';
 import { useAction, useAtom } from '@reatom/react-v2';
-import { Panel } from '@konturio/ui-kit';
+import { Panel } from '~components/Panel';
 import { i18n } from '~core/localization';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import { EditTargets } from '../../constants';

--- a/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.tsx
+++ b/src/features/create_layer/components/EditLayerPanel/EditLayerPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useAction, useAtom } from '@reatom/react-v2';
 import clsx from 'clsx';
-import { Panel } from '@konturio/ui-kit';
+import { Panel } from '~components/Panel';
 import { i18n } from '~core/localization';
 import { createStateMap } from '~utils/atoms';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';

--- a/src/features/event_episodes/components/EpisodesTimelinePanel/EpisodesTimelinePanel.tsx
+++ b/src/features/event_episodes/components/EpisodesTimelinePanel/EpisodesTimelinePanel.tsx
@@ -1,5 +1,5 @@
-import { Panel } from '@konturio/ui-kit';
 import { useAtom } from '@reatom/react-v2';
+import { Panel } from '~components/Panel';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';
 import { ErrorMessage } from '~components/ErrorMessage/ErrorMessage';
 import { createStateMap } from '~utils/atoms/createStateMap';

--- a/src/features/events_list/components/EventsPanel/EventsPanel.tsx
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.tsx
@@ -1,10 +1,11 @@
 import { Disasters24 } from '@konturio/default-icons';
-import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
+import { Text } from '@konturio/ui-kit';
 import { useAtom } from '@reatom/react-v2';
 import { useAtom as useAtomV3 } from '@reatom/npm-react';
 import clsx from 'clsx';
 import { useCallback, useMemo, useRef } from 'react';
 import { Sheet } from 'react-modal-sheet';
+import { Panel, PanelIcon } from '~components/Panel';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';
 import { panelClasses } from '~components/Panel';
 import {

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
@@ -1,9 +1,9 @@
-import { Panel, PanelIcon } from '@konturio/ui-kit';
 import { useCallback, useMemo, useRef } from 'react';
 import { clsx } from 'clsx';
 import { Legend24 } from '@konturio/default-icons';
 import { useAction, useAtom } from '@reatom/npm-react';
 import { Sheet } from 'react-modal-sheet';
+import { Panel, PanelIcon } from '~components/Panel';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import { useAutoCollapsePanel } from '~utils/hooks/useAutoCollapsePanel';
 import { panelClasses } from '~components/Panel';

--- a/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
+++ b/src/widgets/FullAndShortStatesPanelWidget/components/FullAndShortStatesPanelWidget.tsx
@@ -1,7 +1,7 @@
-import { Panel, PanelIcon } from '@konturio/ui-kit';
 import clsx from 'clsx';
 import { useCallback, useRef } from 'react';
 import { Sheet } from 'react-modal-sheet';
+import { Panel, PanelIcon } from '~components/Panel';
 import { panelClasses as defaultPanelClasses } from '~components/Panel';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
 import { useHeightResizer } from '~utils/hooks/useResizer';


### PR DESCRIPTION
Fibery#0000
- extend Panel component with a full-width bottom resize handle
- update feature imports to use local Panel wrapper
- document resize handle capability


------
https://chatgpt.com/codex/tasks/task_e_688a67000974832f96276e6d84f238c8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Panels now support vertical resizing by dragging anywhere along the bottom edge, making it easier to adjust panel height.

* **Documentation**
  * Updated documentation to note the new panel resizing capability available from version 2.53.1.

* **Style**
  * Added visual cues and styles for the new resize handle at the bottom of panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->