### PR TITLE
Revert "feat(ci): 21190 cache docker layers"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,3 @@
-node_modules/
-.git/
-e2e/
-.github/
-playwright.config.ts
-!dist/
-# CI artifacts
-coverage/
-playwright-report/
-*.trace
-docker-compose*.yml
+*
+!./dist/*
+!./server/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,10 +198,6 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=gha,scope=${{ github.ref_name }}
-            type=gha,scope=main
-          cache-to: type=gha,scope=${{ github.ref_name }},mode=max
 
       - name: Set output for image tag
         id: set_output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,9 +177,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,12 @@
-# Build stage
-FROM golang:1.20.2-alpine3.16 AS builder
+FROM golang:1.20.2-alpine3.16
 WORKDIR /usr/src/app
 
 COPY ./server/go.mod ./server/go.sum ./
 RUN go mod download && go mod verify
 
 COPY ./server/. ./
-RUN CGO_ENABLED=0 go build -v -ldflags="-s -w" -o app .
-
-# Runtime stage
-FROM alpine:3.16
-RUN apk --no-cache add ca-certificates=20240226-r0 \
-    && adduser -D appuser
-WORKDIR /home/appuser
-COPY --from=builder /usr/src/app/app .
 COPY ./dist/. ./static/
-ENV PORT=8080
-EXPOSE 8080
-USER appuser
-HEALTHCHECK --interval=30s --timeout=3s CMD wget --quiet --tries=1 --spider http://localhost:${PORT}/ || exit 1
-CMD ["./app"]
+RUN go build -v -o /usr/local/bin/app ./...
+
+EXPOSE 80
+CMD ["app"]

--- a/server/main.go
+++ b/server/main.go
@@ -16,15 +16,9 @@ import (
 )
 
 const (
-        Host = ""
+	Host = ""
+	Port = "80"
 )
-
-func getPort() string {
-        if p := os.Getenv("PORT"); p != "" {
-                return p
-        }
-        return "8080"
-}
 
 type TemplateVariables struct {
 	CurrentQueries string
@@ -173,9 +167,8 @@ func main() {
 	http.Handle("/active/static/", http.StripPrefix("/active/static", http.HandlerFunc(handleStaticFiles(fs))))
 	http.Handle("/metrics", promhttp.Handler())
 	http.Handle("/active/log", http.StripPrefix("/active", http.HandlerFunc(writeLogs)))
-        port := getPort()
-        log.Println("Server listening:", "http://"+Host+":"+port)
-        err := http.ListenAndServe(Host+":"+port, nil)
+	log.Println("Server listening:", "http://"+Host+":"+Port)
+	err := http.ListenAndServe(Host+":"+Port, nil)
 	if err != nil {
 		log.Fatal("Error Starting the HTTP Server :", err)
 		return


### PR DESCRIPTION
Reverts konturio/disaster-ninja-fe#1161 and https://github.com/konturio/disaster-ninja-fe/pull/1183

#1161 in its initial form breaks FE build process. It needs to be fixed and --**tested**-- before merging into main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Dockerfile to use a single build stage, now exposing port 80 and removing health checks and non-root user setup.
  * Updated server configuration to listen on a fixed port 80 instead of dynamically selecting the port.
  * Streamlined Docker ignore rules for a cleaner build context.
  * Simplified CI workflow by removing Docker Buildx setup and build cache options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->