### PR TITLE
fix(layers): auto-enable event shape on selection

### DIFF
--- a/src/features/current_event/atoms/currentEventGeometry.ts
+++ b/src/features/current_event/atoms/currentEventGeometry.ts
@@ -4,6 +4,8 @@ import { dispatchMetricsEventOnce } from '~core/metrics/dispatch';
 import { AppFeature } from '~core/app/types';
 import { currentEventResourceAtom } from '~core/shared_state/currentEventResource';
 import { isEpisodeGeometry } from '~core/focused_geometry/utils';
+import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
+import { FOCUSED_GEOMETRY_LOGICAL_LAYER_ID } from '~core/focused_geometry/constants';
 import type { EventWithGeometry } from '~core/types';
 
 export const currentEventGeometryAtom = createAtom(
@@ -30,6 +32,7 @@ export const currentEventGeometryAtom = createAtom(
                 data.geojson,
               ),
             );
+            dispatch(enabledLayersAtom.set(FOCUSED_GEOMETRY_LOGICAL_LAYER_ID));
           });
         }
       }

--- a/src/features/current_event/atoms/currentEventRefresher.ts
+++ b/src/features/current_event/atoms/currentEventRefresher.ts
@@ -2,12 +2,17 @@ import { atom } from '@reatom/framework';
 import { currentEventAtom } from '~core/shared_state/currentEvent';
 import { autoRefreshService } from '~core/autoRefreshServiceInstance';
 import { currentEventResourceAtom } from '~core/shared_state/currentEventResource';
+import { enabledLayersAtom } from '~core/logical_layers/atoms/enabledLayers';
+import { FOCUSED_GEOMETRY_LOGICAL_LAYER_ID } from '~core/focused_geometry/constants';
 
 export const currentEventRefresherAtom = atom((ctx) => {
   // Subscribe to currentEventAtom changes
   ctx.spy(currentEventAtom.v3atom, (event) => {
     if (event?.id) {
       autoRefreshService.addWatcher('currentEvent', currentEventResourceAtom);
+      ctx.schedule(() =>
+        enabledLayersAtom.set(FOCUSED_GEOMETRY_LOGICAL_LAYER_ID).v3action(ctx),
+      );
     } else {
       autoRefreshService.removeWatcher('currentEvent');
     }

--- a/src/features/current_event/readme.md
+++ b/src/features/current_event/readme.md
@@ -12,6 +12,7 @@ If the current event geometry has changed, the atom uses `getCameraForGeometry` 
 ### `currentEventGeometryAtom`
 
 The `currentEventGeometryAtom` holds the information about the current selected event with geometry. It subscribes to changes in the `currentEventResourceAtom`. If `currentEventResourceAtom` has changed, and it is fully loaded and contains data, the `currentEventGeometryAtom` checks the source of the geometry. If the source is not an episode, the `currentEventGeometryAtom` sets the `focusedGeometryAtom` to the geometry value from the `currentEventResourceAtom` object, with a reference to the original event data as `meta`.
+It also re-enables the focused geometry layer to ensure the event shape becomes visible even when the user previously disabled it.
 
 If `currentEventResourceAtom` is fully loaded but does not contain data, the atom's value is set to `null`.
 

--- a/src/features/current_event/readme.md
+++ b/src/features/current_event/readme.md
@@ -21,3 +21,4 @@ After the `currentEventResourceAtom` is fully loaded, the `currentEventGeometryA
 ### `currentEventRefresherAtom`
 
 This atom is responsible for refreshing the current event. It subscribes to changes in `currentEventAtom` (an atom that contains data about the current event) and when it changes, adds `currentEventResourceAtom` (an atom that contains data about the current event) to the list of data auto-updating service if the current event is not null. If the current event is null or its ID is null, the atom removes `currentEventResourceAtom` from the list of data auto-updating service.
+Whenever a new event is selected, it also re-enables the focused geometry layer so the event shape becomes visible again.


### PR DESCRIPTION
## Summary
- ensure event geometry layer is enabled when selecting an event
- document auto-enabling behaviour in current event feature docs

## Testing
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_688ba3a4e204832f81a291d99107f09d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The focused geometry layer is now automatically enabled when updating the current event geometry, ensuring it remains visible.
  * When a new event is selected, the focused geometry layer is re-enabled to keep the event shape visible.

* **Documentation**
  * Updated documentation to reflect that the focused geometry layer is re-enabled when the current event geometry is set and when a new event is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->