### PR TITLE
fix(events_list): keep url event from unlisted feeds

### DIFF
--- a/src/features/events_list/atoms/eventListResource.ts
+++ b/src/features/events_list/atoms/eventListResource.ts
@@ -5,6 +5,7 @@ import { i18n } from '~core/localization';
 import { dispatchMetricsEventOnce } from '~core/metrics/dispatch';
 import { currentEventAtom } from '~core/shared_state/currentEvent';
 import { currentEventFeedAtom } from '~core/shared_state/currentEventFeed';
+import { configRepo } from '~core/config';
 import { combineAtoms } from '~utils/atoms';
 import { createAsyncAtom } from '~utils/atoms/createAsyncAtom';
 import { eventListFilters } from './eventListFilters';
@@ -42,8 +43,14 @@ export const eventListResourceAtom = createAsyncAtom(
 
     const currentEvent = currentEventAtom.getState();
     if (currentEvent?.id) {
-      if (responseData.findIndex((d) => d.eventId === currentEvent?.id) === -1) {
-        // selected event is not in list, reset selection
+      const currentEventInList = responseData.some((d) => d.eventId === currentEvent.id);
+      const initUrl = configRepo.get().initialUrlData;
+      const cameFromUrl =
+        initUrl.event === currentEvent.id && initUrl.feed === params.feed;
+
+      if (!currentEventInList && !cameFromUrl) {
+        // Selected event is not in the list and wasn't provided via URL,
+        // so we clear it to avoid pointing to a non-listed event
         currentEventAtom.setCurrentEventId.dispatch(null);
       }
     }


### PR DESCRIPTION
## Summary
- handle events opened via URL by skipping event reset when they aren't in event list

## Testing
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688ba69698f8832fa1c1bdf1926561f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event selection behavior to prevent clearing the selected event when it was set via URL parameters, even if it is not present in the fetched list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->