### PR TITLE
feat(focused-geometry-editor): add modal before drawing

### DIFF
--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -1586,6 +1586,22 @@ msgstr ""
 msgid "Selected area has been saved as reference area in your profile"
 msgstr ""
 
+#: focused_geometry_editor_modal##title
+msgid "Selected area already contains geometry"
+msgstr ""
+
+#: focused_geometry_editor_modal##question
+msgid "Do you want to draw new geometry or edit the existing one?"
+msgstr ""
+
+#: focused_geometry_editor_modal##draw_new
+msgid "Draw new geometry"
+msgstr ""
+
+#: focused_geometry_editor_modal##edit_existing
+msgid "Edit existing geometry"
+msgstr ""
+
 #: oam_auth##login_button
 msgid "Login with Google"
 msgstr ""

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -517,6 +517,12 @@
     "error_couldnt_save": "Unfortunately, we could not save your reference area. Please try again.",
     "selected_area_saved_as_reference_area": "Selected area has been saved as reference area in your profile"
   },
+  "focused_geometry_editor_modal": {
+    "title": "Selected area already contains geometry",
+    "question": "Do you want to draw new geometry or edit the existing one?",
+    "draw_new": "Draw new geometry",
+    "edit_existing": "Edit existing geometry"
+  },
   "oam_auth": {
     "login_button": "Login with Google"
   }

--- a/src/widgets/FocusedGeometryEditor/ChooseEditModeModal.module.css
+++ b/src/widgets/FocusedGeometryEditor/ChooseEditModeModal.module.css
@@ -1,0 +1,6 @@
+.buttonsRow {
+  display: flex;
+  flex-flow: row nowrap;
+  gap: var(--unit);
+  justify-content: flex-end;
+}

--- a/src/widgets/FocusedGeometryEditor/ChooseEditModeModal.test.tsx
+++ b/src/widgets/FocusedGeometryEditor/ChooseEditModeModal.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChooseEditModeModal from './ChooseEditModeModal';
+
+describe('ChooseEditModeModal', () => {
+  it('confirms draw mode when Draw new geometry clicked', async () => {
+    const onConfirm = vi.fn();
+    render(<ChooseEditModeModal onConfirm={onConfirm} />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /Draw new geometry/i })
+    );
+    expect(
+      onConfirm,
+      'onConfirm should be called with "draw" when Draw new geometry is selected'
+    ).toHaveBeenCalledWith('draw');
+  });
+
+  it('confirms edit mode when Edit existing geometry clicked', async () => {
+    const onConfirm = vi.fn();
+    render(<ChooseEditModeModal onConfirm={onConfirm} />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /Edit existing geometry/i })
+    );
+    expect(
+      onConfirm,
+      'onConfirm should be called with "edit" when Edit existing geometry is selected'
+    ).toHaveBeenCalledWith('edit');
+  });
+});

--- a/src/widgets/FocusedGeometryEditor/ChooseEditModeModal.tsx
+++ b/src/widgets/FocusedGeometryEditor/ChooseEditModeModal.tsx
@@ -1,0 +1,32 @@
+import { Button, ModalDialog, Text } from '@konturio/ui-kit';
+import { i18n } from '~core/localization';
+import s from './ChooseEditModeModal.module.css';
+
+export type GeometryEditChoice = 'draw' | 'edit';
+
+type Props = {
+  onConfirm: (value: GeometryEditChoice | null) => void;
+};
+
+export default function ChooseEditModeModal({ onConfirm }: Props) {
+  return (
+    <ModalDialog
+      title={i18n.t('focused_geometry_editor_modal.title')}
+      onClose={() => onConfirm(null)}
+      footer={
+        <div className={s.buttonsRow}>
+          <Button variant="invert-outline" onClick={() => onConfirm('edit')}>
+            {i18n.t('focused_geometry_editor_modal.edit_existing')}
+          </Button>
+          <Button onClick={() => onConfirm('draw')}>
+            {i18n.t('focused_geometry_editor_modal.draw_new')}
+          </Button>
+        </div>
+      }
+    >
+      <Text type="short-m">
+        {i18n.t('focused_geometry_editor_modal.question')}
+      </Text>
+    </ModalDialog>
+  );
+}

--- a/src/widgets/FocusedGeometryEditor/index.ts
+++ b/src/widgets/FocusedGeometryEditor/index.ts
@@ -1,4 +1,6 @@
 import { drawTools } from '~core/draw_tools';
+import { activeDrawModeAtom } from '~core/draw_tools/atoms/activeDrawMode';
+import { drawModes } from '~core/draw_tools/constants';
 import { toolbar } from '~core/toolbar';
 import { focusedGeometryAtom } from '~core/focused_geometry/model';
 import { store } from '~core/store/store';
@@ -10,6 +12,8 @@ import { setCurrentMapPosition } from '~core/shared_state/currentMapPosition';
 import { configRepo } from '~core/config';
 import { getCameraForGeometry } from '~utils/map/camera';
 import { v3ActionToV2 } from '~utils/atoms/v3tov2';
+import { showModal } from '~core/modal';
+import ChooseEditModeModal, { GeometryEditChoice } from './ChooseEditModeModal';
 import { FOCUSED_GEOMETRY_EDITOR_CONTROL_ID } from './constants';
 import { DrawToolsWidget } from './DrawToolsWidget';
 import type { CenterZoomPosition } from '~core/shared_state/currentMapPosition';
@@ -48,24 +52,54 @@ function zoomToFocusedGeometry(focusedGeometry: GeoJSON.GeoJSON) {
 focusedGeometryControl.onStateChange(async (ctx, state, prevState) => {
   if (state === 'active') {
     try {
-      // Read focused geometry
-      const focusedGeometry =
-        focusedGeometryAtom.getState()?.geometry ?? new FeatureCollection([]);
-      zoomToFocusedGeometry(focusedGeometry);
+      const previousFocused = focusedGeometryAtom.getState();
+      let geometry = previousFocused?.geometry ?? new FeatureCollection([]);
+      let restore: typeof previousFocused | null = null;
+      let mode: GeometryEditChoice = 'draw';
+
+      if (!isGeoJSONEmpty(geometry)) {
+        const choice = await showModal(ChooseEditModeModal);
+        if (!choice) {
+          store.dispatch([focusedGeometryControl.setState('regular')]);
+          return;
+        }
+        mode = choice;
+        if (choice === 'draw') {
+          restore = previousFocused;
+          store.dispatch([focusedGeometryAtom.reset()]);
+          geometry = new FeatureCollection([]);
+        } else {
+          zoomToFocusedGeometry(geometry);
+        }
+      }
+
       store.dispatch(
         // Disable focused geometry layer
         enabledLayersAtom.delete(FOCUSED_GEOMETRY_LOGICAL_LAYER_ID),
       );
-      // Put focused geometry to editor
-      const result = await drawTools.edit(focusedGeometry);
+      const editPromise = drawTools.edit(geometry);
+      if (mode === 'draw') {
+        store.dispatch([activeDrawModeAtom.setDrawMode(drawModes.DrawPolygonMode)]);
+      }
+
+      const result = await editPromise;
       if (!isGeoJSONEmpty(result)) {
         store.dispatch([
           // Update focused geometry with edited geometry
           focusedGeometryAtom.setFocusedGeometry({ type: 'drawn' }, result),
         ]);
       } else {
-        // draw tools returned an empty geometry -> reset focused geometry
-        store.dispatch([focusedGeometryAtom.reset()]);
+        if (restore) {
+          store.dispatch([
+            focusedGeometryAtom.setFocusedGeometry(
+              restore.source,
+              restore.geometry,
+            ),
+          ]);
+        } else {
+          // draw tools returned an empty geometry -> reset focused geometry
+          store.dispatch([focusedGeometryAtom.reset()]);
+        }
       }
     } catch (e) {
       console.error('Draw tools exited with error:', e);


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Show-modal-after-click-Draw-or-edit-geometry-button-on-DN2-toolbar-16705

## Summary
- add ChooseEditModeModal component with tests
- prompt users whether to draw new geometry or edit existing
- restore previous geometry when drawing is cancelled
- add translations for the modal

## Testing
- `npx pnpm test:unit` *(fails: npm error canceled due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688bb32dc844832fa44e1d59b6bb49d5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a modal dialog prompting users to choose between drawing new geometry or editing existing geometry when an area already contains geometry in the focused geometry editor.
  * Introduced localized text for the new modal dialog, with English translations provided.
* **Style**
  * Added new styling for the modal's button layout.
* **Tests**
  * Introduced tests to verify user interactions and correct behavior of the new modal dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->