### PR TITLE
fix(events-list): center no disaster message in short panel

### DIFF
--- a/src/features/events_list/components/ShortState/ShortState.module.css
+++ b/src/features/events_list/components/ShortState/ShortState.module.css
@@ -10,6 +10,7 @@
   flex-wrap: wrap;
   align-items: center;
   align-content: center;
+  height: 100%;
   gap: var(--unit);
 }
 


### PR DESCRIPTION
## Summary
- ensure "No disaster selected" message fills panel height so content centers in short state

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688e3c0138bc832f9064a11fa635e60f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout for elements with no disasters by ensuring they fully occupy the available height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->