### PR TITLE
fix(search): avoid flex layout on search panel

### DIFF
--- a/src/features/search/styles.module.css
+++ b/src/features/search/styles.module.css
@@ -27,6 +27,10 @@
   display: none;
 }
 
+.contentContainer {
+  display: block;
+}
+
 /* Mobile */
 @media screen and (max-width: 960px) {
   .searchPanel {


### PR DESCRIPTION
## Summary
- remove unintended flex layout from search panel content

## Testing
- `pnpm lint`
- `pnpm test:unit` *(fails: Command failed with exit code 130 after watch mode exit)*

------
https://chatgpt.com/codex/tasks/task_e_688e5324ba18832fba38dd5bf170e596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced a new `.contentContainer` class to ensure elements are displayed as block-level by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->