### PR TITLE
fix(events): expand event name label width

### DIFF
--- a/src/features/events_list/components/EventsPanel/EventsPanel.module.css
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.module.css
@@ -3,8 +3,11 @@
   z-index: 1;
 }
 
+/* Utility for truncating text within flex containers */
 .truncated {
-  max-width: 100px;
+  flex: 1;
+  min-width: 0;
+
   & > span {
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -14,14 +17,18 @@
 
 .combinedHeader {
   display: flex;
+  align-items: center;
   width: 100%;
-  justify-content: space-between;
+  gap: var(--unit);
+
   & .eventNameLabel {
     display: flex;
+    flex: 1;
     align-items: center;
     border-radius: calc(var(--border-radius-unit) * 3);
     background-color: var(--faint-weak);
     padding: 0 var(--unit);
+
     & > span {
       font: var(--font-xs);
       font-weight: 500;


### PR DESCRIPTION
## Summary
- allow the event name label to fill remaining space in the collapsed Disasters panel header

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688e5963c994832fa922db75cdf68f71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and alignment of event panel headers for better responsiveness and appearance.
  * Enhanced text truncation behavior to ensure content displays cleanly within flexible layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->