### PR TITLE
fix(events-list): center empty state placeholders

### DIFF
--- a/src/features/events_list/components/ShortState/ShortState.module.css
+++ b/src/features/events_list/components/ShortState/ShortState.module.css
@@ -4,19 +4,18 @@
 }
 
 .noDisasters {
-  text-align: center;
   padding: calc(var(--unit) * 4) 0;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   align-items: center;
-  align-content: center;
+  justify-content: center;
   gap: var(--unit);
+  text-align: center;
 }
 
-.noDisasterMsg {
-  width: 100%;
-}
-
+.noDisasterMsg,
 .callToAction {
   width: 100%;
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- center "No disaster selected" message and call-to-action button within Disasters panel

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688e59b2a2c8832f9331efea19821961