### PR TITLE
fix(events): fit event name label to content

### DIFF
--- a/src/features/events_list/components/EventsPanel/EventsPanel.module.css
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.module.css
@@ -3,8 +3,10 @@
   z-index: 1;
 }
 
+/* Utility for truncating text within flex containers */
 .truncated {
-  max-width: 100px;
+  min-width: 0;
+
   & > span {
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -14,14 +16,18 @@
 
 .combinedHeader {
   display: flex;
+  align-items: center;
   width: 100%;
-  justify-content: space-between;
+  gap: var(--unit);
+
   & .eventNameLabel {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     border-radius: calc(var(--border-radius-unit) * 3);
     background-color: var(--faint-weak);
     padding: 0 var(--unit);
+    max-width: 100%;
+
     & > span {
       font: var(--font-xs);
       font-weight: 500;


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/DN-FE-Disaster-label-on-folded-panel-header-is-too-narrow-22398

## Summary
- allow the event name label to wrap tightly around the disaster name instead of stretching across the header

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688e5963c994832fa922db75cdf68f71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alignment and spacing of header elements in the events panel.
  * Enhanced text truncation behavior for better display within flex containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->