### PR TITLE
fix(events-list): center empty state content

### DIFF
--- a/src/features/events_list/components/ShortState/ShortState.module.css
+++ b/src/features/events_list/components/ShortState/ShortState.module.css
@@ -4,6 +4,7 @@
 }
 
 .noDisasters {
+  width: 100%;
   text-align: center;
   padding: calc(var(--unit) * 4) 0;
   display: flex;


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/DN-FE-Disasters-panel-empty-state-is-not-centered-22399

## Summary
- ensure empty-state container spans full panel width so message and button center correctly

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688e84b8340c832f80750511b5c20063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout of elements with the "no disasters" message to span the full available width for improved appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->