### PR TITLE
feat(toolbar): remove group names and divider

### DIFF
--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
@@ -7,41 +7,10 @@
   overflow-x: auto;
 }
 
-.sectionDivider {
-  width: 1px;
-  min-height: 100%;
-  background-color: var(--faint-weak);
-  flex-shrink: 0;
-}
-
-.sectionLabel {
-  text-align: center;
-  color: var(--faint-strong-up, #848c94);
-
-  font: var(--font-xs);
-  font-style: normal;
-  font-weight: 400;
-  line-height: 16px; /* 133.333% */
-  letter-spacing: 0.038px;
-}
-
 .section {
   display: flex;
   flex-flow: column nowrap;
   gap: var(--unit);
-  transition:
-    max-height 0.3s ease,
-    opacity 0.3s ease;
-}
-
-.sectionArrow {
-  display: none;
-  rotate: 180deg;
-  margin-left: var(--unit);
-}
-
-.sectionToggleCheckbox {
-  display: none;
 }
 
 .sectionContent {
@@ -63,43 +32,10 @@
     gap: calc(var(--unit) * 3);
   }
 
-  .sectionLabel {
-    order: -1; /* Move the label to come before the content */
-    text-align: start;
-    line-height: 18px;
-    font-size: 16px;
-    display: flex;
-    align-items: center;
-  }
-
-  .sectionArrow {
-    display: inline;
-  }
-
-  .sectionDivider {
-    min-height: 1px;
-    width: 100%;
-  }
-
   .sectionContent {
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
     gap: 12px;
-  }
-
-  .section:has(.sectionToggleCheckbox:checked) .sectionContent {
-    max-height: 0;
-    opacity: 0;
-    display: none;
-  }
-
-  .section:has(.sectionToggleCheckbox:not(:checked)) .sectionContent {
-    max-height: 500px;
-    opacity: 1;
-  }
-
-  .sectionToggleCheckbox:not(:checked) ~ .sectionArrow {
-    rotate: 0deg;
   }
 }

--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.tsx
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.tsx
@@ -1,5 +1,3 @@
-import { Fragment } from 'react';
-import { ChevronDown16 } from '@konturio/default-icons';
 import { useToolbarContent } from '~features/toolbar/hooks/use-toolbar-content';
 import { ToolbarControl } from '../ToolbarControl/ToolbarControl';
 import { ToolbarButton } from '../ToolbarButton/ToolbarButton';
@@ -10,33 +8,21 @@ export const ToolbarContent = () => {
 
   return (
     <div className={s.toolbarContent}>
-      {toolbarContent.map(({ sectionName, buttons }, index) => (
-        <Fragment key={sectionName}>
-          {index > 0 && <div className={s.sectionDivider} />}
-          {
-            <div className={s.section}>
-              <div className={s.sectionContent}>
-                {buttons.map(({ id, settings, stateAtom }) => {
-                  return (
-                    <ToolbarControl
-                      id={id}
-                      data-testid={id}
-                      key={id}
-                      settings={settings}
-                      stateAtom={stateAtom}
-                      controlComponent={ToolbarButton}
-                    />
-                  );
-                })}
-              </div>
-              <label className={s.sectionLabel}>
-                <input type="checkbox" className={s.sectionToggleCheckbox} />
-                {sectionName}
-                <ChevronDown16 className={s.sectionArrow} />
-              </label>
-            </div>
-          }
-        </Fragment>
+      {toolbarContent.map(({ sectionName, buttons }) => (
+        <div key={sectionName} className={s.section}>
+          <div className={s.sectionContent}>
+            {buttons.map(({ id, settings, stateAtom }) => (
+              <ToolbarControl
+                id={id}
+                data-testid={id}
+                key={id}
+                settings={settings}
+                stateAtom={stateAtom}
+                controlComponent={ToolbarButton}
+              />
+            ))}
+          </div>
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- simplify toolbar rendering by removing group names and separator
- drop related styling and collapse controls

## Testing
- `pnpm run test:unit` *(fails: Command failed with exit code 130 after manual interrupt)*
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e858bf614832fa59c873051c1a657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the toolbar content layout by removing section dividers, labels, toggles, and related animations.
  * Streamlined the appearance of toolbar sections for a cleaner and more consistent user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->