### PR TITLE
feat(reports): make reports translatable

### DIFF
--- a/reports_instruction.md
+++ b/reports_instruction.md
@@ -9,24 +9,29 @@ If you want to display your reports on the Disaster Ninja Reports page, you must
 
 - **id**, _string_ - your report id;
 - **link**, _string_ - relative link to your report, for example '/your_report.csv';
-- **name**, _string_ - your report name;
+- **name**, _string_ or _object_ - your report name.
+  Provide an object with language codes to localize it;
 - **sortable**, _boolean_ - true to make your report sortable, false to keep your report static;
 - **last_updated**, _string_ - Timestamp with date of last update;
 - **publick_access**, _boolean_ - true to make your report visible for unlogged users, false to keep your report visible only for particular groups of users;
-- **description_full**, _string_ - A full description of your report, which will be shown on the report page. - https://disaster.ninja/active/reports/your_report_name;
-- **description_brief**, _string_ - A short description of your report, which will be shown on the reports page. - https://disaster.ninja/active/reports;
+- **description_full**, _string_ or _object_ - A full description of your report, which will be shown on the report page.
+  Provide translations as an object keyed by language codes.
+  - https://disaster.ninja/active/reports/your_report_name;
+- **description_brief**, _string_ or _object_ - A short description of your report, which will be shown on the reports page.
+  Provide translations as an object keyed by language codes.
+  - https://disaster.ninja/active/reports;
 - **searchable_columns_indexes**, _array_ - array with column number from your CSV (0-based) will be used for text search.
 
 ### An example of the internal structure of osm_reports_list.json
 
-`[{"id": "your_report_id",
+ `[{"id": "your_report_id",
   "link": "/your_report.csv",
-  "name": "your report name",
+  "name": {"en": "your report name"},
   "sortable": true,
   "last_updated": "2022-09-18T18:59:51Z",
   "public_access": true,
-  "description_full": "full description",
-  "description_brief": "brief description",
+  "description_full": {"en": "full description"},
+  "description_brief": {"en": "brief description"},
   "searchable_columns_indexes": [0]},
   {another report description}]`
 

--- a/src/features/reports/atoms/reportsAtom.ts
+++ b/src/features/reports/atoms/reportsAtom.ts
@@ -1,16 +1,17 @@
 import { reportsClient } from '~core/apiClientInstance';
 import { i18n } from '~core/localization';
 import { createAtom } from '~utils/atoms';
+import type { TranslatableString } from '../utils';
 
 export type Report = {
   id: string;
   link: string;
-  name: string;
+  name: TranslatableString;
   sortable: boolean;
   last_updated: string;
   public_access: string;
-  description_full: string;
-  description_brief: string;
+  description_full: TranslatableString;
+  description_brief: TranslatableString;
   column_link_templates: [
     { 'OSM ID': string },
     { Name: string } | { ['OSM name']: string },

--- a/src/features/reports/components/ReportInfo/ReportInfo.tsx
+++ b/src/features/reports/components/ReportInfo/ReportInfo.tsx
@@ -9,6 +9,7 @@ import { i18n } from '~core/localization';
 import { notificationServiceInstance } from '~core/notificationServiceInstance';
 import { LoadingSpinner } from '~components/LoadingSpinner/LoadingSpinner';
 import { LinkRenderer } from '~components/LinkRenderer/LinkRenderer';
+import { translateReportField } from '../../utils';
 import { reportsAtom } from '../../atoms/reportsAtom';
 import { currentReportAtom, reportResourceAtom } from '../../atoms/reportResource';
 import commonStyles from '../ReportsList/ReportsList.module.css';
@@ -51,7 +52,9 @@ export function ReportInfo() {
       </Text>
 
       <Heading type="heading-05">
-        <span className={clsx(commonStyles.pageTitle, styles.title)}>{report?.name}</span>
+        <span className={clsx(commonStyles.pageTitle, styles.title)}>
+          {translateReportField(report?.name)}
+        </span>
       </Heading>
 
       {report?.description_full && (
@@ -60,7 +63,7 @@ export function ReportInfo() {
             className={commonStyles.description}
             options={{ overrides: { a: LinkRenderer } }}
           >
-            {report.description_full}
+            {translateReportField(report.description_full)}
           </Markdown>
         </Text>
       )}

--- a/src/features/reports/components/ReportsList/ReportsList.tsx
+++ b/src/features/reports/components/ReportsList/ReportsList.tsx
@@ -6,6 +6,7 @@ import Markdown from 'markdown-to-jsx';
 import { useAtom } from '@reatom/react-v2';
 import { i18n } from '~core/localization';
 import { LinkRenderer } from '~components/LinkRenderer/LinkRenderer';
+import { translateReportField } from '../../utils';
 import { reportsAtom } from '../../atoms/reportsAtom';
 import styles from './ReportsList.module.css';
 
@@ -60,7 +61,7 @@ export function ReportsList({ goToReport }: { goToReport: (id: string) => void }
               <div className={styles.reportWrap} key={report.id} onClick={onClick}>
                 <Heading type="heading-05">
                   <div className={clsx(styles.link, styles.reportTitle)}>
-                    {report.name}
+                    {translateReportField(report.name)}
                   </div>
                 </Heading>
                 <Text type="long-l">
@@ -68,7 +69,7 @@ export function ReportsList({ goToReport }: { goToReport: (id: string) => void }
                     options={{ overrides: { a: LinkRenderer } }}
                     className={clsx(styles.reportDescr)}
                   >
-                    {report.description_brief}
+                    {translateReportField(report.description_brief)}
                   </Markdown>
                 </Text>
               </div>

--- a/src/features/reports/readme.md
+++ b/src/features/reports/readme.md
@@ -70,6 +70,7 @@ function ReportInfo() {
 There are 2 dynamic configs we receive from the back-end.
 
 1. `"Reports List"` - array of available reports containing all info about them including link to `.csv` file with report data (all the keys stored in `./atoms/reportsAtom.ts` `Report` type).
+   `name`, `description_full` and `description_brief` fields may be provided as strings or as objects with language codes to support localization.
 
 2. `"Report Content"` - data received from `.csv` link is the second data model.
 

--- a/src/features/reports/utils.test.ts
+++ b/src/features/reports/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { i18n } from '~core/localization';
+import { translateReportField } from './utils';
+
+describe('translateReportField', () => {
+  afterAll(async () => {
+    await i18n.instance.changeLanguage('en');
+  });
+
+  it('returns string value as-is', () => {
+    expect(translateReportField('plain'), 'should return string unchanged').toBe('plain');
+  });
+
+  it('returns value for current language', async () => {
+    await i18n.instance.changeLanguage('es');
+    const field = { en: 'Hello', es: 'Hola' };
+    expect(translateReportField(field), 'should pick Spanish translation').toBe('Hola');
+  });
+
+  it('falls back to english when language missing', async () => {
+    await i18n.instance.changeLanguage('de');
+    const field = { en: 'Hello' };
+    expect(translateReportField(field), 'should fall back to English').toBe('Hello');
+  });
+});

--- a/src/features/reports/utils.ts
+++ b/src/features/reports/utils.ts
@@ -1,0 +1,10 @@
+import { i18n } from '~core/localization';
+
+export type TranslatableString = string | Record<string, string>;
+
+export function translateReportField(value: TranslatableString | undefined): string {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  const lang = i18n.instance.language;
+  return value[lang] ?? value.en ?? Object.values(value)[0] ?? '';
+}


### PR DESCRIPTION
## Summary
- allow report metadata to provide language variants
- render translated report names and descriptions
- document multilingual report structure

## Testing
- `pnpm lint`
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688e85d06b64832fb7711d1d93cebdfe