### PR TITLE
feat(toolbar): remove group names and divider

### DIFF
--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.module.css
@@ -1,105 +1,19 @@
 .toolbarContent {
   padding: var(--unit);
   min-height: inherit;
-  display: flex;
-  flex-flow: row nowrap;
-  gap: var(--unit);
-  overflow-x: auto;
-}
-
-.sectionDivider {
-  width: 1px;
-  min-height: 100%;
-  background-color: var(--faint-weak);
-  flex-shrink: 0;
-}
-
-.sectionLabel {
-  text-align: center;
-  color: var(--faint-strong-up, #848c94);
-
-  font: var(--font-xs);
-  font-style: normal;
-  font-weight: 400;
-  line-height: 16px; /* 133.333% */
-  letter-spacing: 0.038px;
-}
-
-.section {
-  display: flex;
-  flex-flow: column nowrap;
-  gap: var(--unit);
-  transition:
-    max-height 0.3s ease,
-    opacity 0.3s ease;
-}
-
-.sectionArrow {
-  display: none;
-  rotate: 180deg;
-  margin-left: var(--unit);
-}
-
-.sectionToggleCheckbox {
-  display: none;
-}
-
-.sectionContent {
-  flex: 1;
   display: grid;
   grid-template-rows: repeat(6, auto);
   grid-auto-flow: column;
   gap: var(--half-unit);
+  overflow-x: auto;
 }
 
 @media screen and (max-width: 960px) {
   .toolbarContent {
-    flex-direction: column;
-    gap: calc(var(--unit) * 3);
-    padding: calc(var(--unit) * 3) var(--double-unit);
-  }
-
-  .section {
-    gap: calc(var(--unit) * 3);
-  }
-
-  .sectionLabel {
-    order: -1; /* Move the label to come before the content */
-    text-align: start;
-    line-height: 18px;
-    font-size: 16px;
-    display: flex;
-    align-items: center;
-  }
-
-  .sectionArrow {
-    display: inline;
-  }
-
-  .sectionDivider {
-    min-height: 1px;
-    width: 100%;
-  }
-
-  .sectionContent {
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
     gap: 12px;
-  }
-
-  .section:has(.sectionToggleCheckbox:checked) .sectionContent {
-    max-height: 0;
-    opacity: 0;
-    display: none;
-  }
-
-  .section:has(.sectionToggleCheckbox:not(:checked)) .sectionContent {
-    max-height: 500px;
-    opacity: 1;
-  }
-
-  .sectionToggleCheckbox:not(:checked) ~ .sectionArrow {
-    rotate: 0deg;
+    padding: calc(var(--unit) * 3) var(--double-unit);
   }
 }

--- a/src/features/toolbar/components/ToolbarContent/ToolbarContent.tsx
+++ b/src/features/toolbar/components/ToolbarContent/ToolbarContent.tsx
@@ -1,42 +1,22 @@
-import { Fragment } from 'react';
-import { ChevronDown16 } from '@konturio/default-icons';
 import { useToolbarContent } from '~features/toolbar/hooks/use-toolbar-content';
 import { ToolbarControl } from '../ToolbarControl/ToolbarControl';
 import { ToolbarButton } from '../ToolbarButton/ToolbarButton';
 import s from './ToolbarContent.module.css';
 
 export const ToolbarContent = () => {
-  const toolbarContent = useToolbarContent();
+  const toolbarContent = useToolbarContent().flatMap(({ buttons }) => buttons);
 
   return (
     <div className={s.toolbarContent}>
-      {toolbarContent.map(({ sectionName, buttons }, index) => (
-        <Fragment key={sectionName}>
-          {index > 0 && <div className={s.sectionDivider} />}
-          {
-            <div className={s.section}>
-              <div className={s.sectionContent}>
-                {buttons.map(({ id, settings, stateAtom }) => {
-                  return (
-                    <ToolbarControl
-                      id={id}
-                      data-testid={id}
-                      key={id}
-                      settings={settings}
-                      stateAtom={stateAtom}
-                      controlComponent={ToolbarButton}
-                    />
-                  );
-                })}
-              </div>
-              <label className={s.sectionLabel}>
-                <input type="checkbox" className={s.sectionToggleCheckbox} />
-                {sectionName}
-                <ChevronDown16 className={s.sectionArrow} />
-              </label>
-            </div>
-          }
-        </Fragment>
+      {toolbarContent.map(({ id, settings, stateAtom }) => (
+        <ToolbarControl
+          id={id}
+          data-testid={id}
+          key={id}
+          settings={settings}
+          stateAtom={stateAtom}
+          controlComponent={ToolbarButton}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/DN-FE-Remove-group-name-and-vertical-divider-from-toolbar-22401

## Summary
- simplify toolbar rendering by removing group names and separator
- drop related styling and collapse controls
- ensure equal spacing between all buttons via single grid layout

## Testing
- `pnpm run lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688e858bf614832fa59c873051c1a657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the toolbar layout by removing section groupings, labels, toggles, and dividers.
  * Toolbar buttons are now displayed in a single, streamlined row without nested sections.
  * Updated styling for a cleaner and more consistent toolbar appearance, especially on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->