### PR TITLE
fix(intercom): move chat icon 8px lower

### DIFF
--- a/src/features/intercom/intercom.css
+++ b/src/features/intercom/intercom.css
@@ -4,9 +4,9 @@
 }
 .intercom-lightweight-app-launcher.intercom-launcher,
 .intercom-namespace .intercom-app .intercom-dfosxs {
-  bottom: var(--half-unit);
+  bottom: calc(var(--half-unit) - var(--unit));
   right: var(--double-unit);
-  margin-bottom: var(--half-unit) !important;
+  margin-bottom: calc(var(--half-unit) - var(--unit)) !important;
 }
 
 /* handling app header here bacause 
@@ -20,7 +20,7 @@
     display: none;
   }
   .intercom-lightweight-app-launcher.intercom-launcher {
-    bottom: var(--half-unit);
+    bottom: calc(var(--half-unit) - var(--unit));
     right: calc(10px + var(--half-unit));
   }
   /* move map controls to the right so kontur logo wouldn't be overlapped */


### PR DESCRIPTION
## Summary
- adjust Intercom launcher styling to sit 8px closer to the bottom on desktop and mobile
- express spacing with design unit variables

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688e8714bf40832f87e031f6d4486c43