### PR TITLE
style(panel): narrow headers

### DIFF
--- a/docs/investigations/panels-report.md
+++ b/docs/investigations/panels-report.md
@@ -135,7 +135,7 @@ export const layersPanel: () => PanelFeatureInterface = () => ({
       <PanelContent />
     </Suspense>
   ),
-  panelIcon: <Layers24 />,
+  panelIcon: <Layers16 />,
   header: i18n.t('layers'),
   minHeight: MIN_HEIGHT,
   resize: 'vertical',

--- a/src/components/Panel/styles.module.css
+++ b/src/components/Panel/styles.module.css
@@ -1,15 +1,24 @@
 .header {
   user-select: none;
+  padding: calc(var(--unit) / 2) var(--unit);
+
+  & svg {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .headerTitle {
   max-width: 260px;
   min-width: 200px;
+  font: var(--font-heading-05);
 }
 
 .closeBtn {
   & svg {
     color: var(--icon-base-strong);
+    width: 16px;
+    height: 16px;
   }
 
   &:disabled svg {
@@ -37,7 +46,7 @@
   }
 
   .header {
-    padding: 0 var(--unit);
+    padding: 0 calc(var(--unit) / 2);
   }
 
   .header:before {

--- a/src/features/analytics_panel/index.tsx
+++ b/src/features/analytics_panel/index.tsx
@@ -1,4 +1,4 @@
-import { Analytics24 } from '@konturio/default-icons';
+import { Analytics16 } from '@konturio/default-icons';
 import { lazily } from 'react-lazily';
 import { Suspense } from 'react';
 import { i18n } from '~core/localization';
@@ -30,7 +30,7 @@ export const analyticsPanel = (
         ))}
       </Suspense>
     ),
-    panelIcon: <Analytics24 />,
+    panelIcon: <Analytics16 />,
     header: i18n.t('analytics_panel.header_title'),
     minHeight: MIN_HEIGHT,
     maxHeight: MAX_HEIGHT,

--- a/src/features/events_list/components/EventsPanel/EventsPanel.tsx
+++ b/src/features/events_list/components/EventsPanel/EventsPanel.tsx
@@ -1,4 +1,4 @@
-import { Disasters24 } from '@konturio/default-icons';
+import { Disasters16 } from '@konturio/default-icons';
 import { Panel, PanelIcon, Text } from '@konturio/ui-kit';
 import { useAtom } from '@reatom/react-v2';
 import { useAtom as useAtomV3 } from '@reatom/npm-react';
@@ -147,7 +147,7 @@ export function EventsPanel({
       header={header}
       headerIcon={
         <div className={s.iconWrap}>
-          <Disasters24 />
+          <Disasters16 />
         </div>
       }
       onHeaderClick={togglePanel}
@@ -190,7 +190,7 @@ export function EventsPanel({
       <PanelIcon
         clickHandler={openFullState}
         className={clsx(s.panelIcon, isMobile ? '' : s.desktop, 'knt-panel-icon')}
-        icon={<Disasters24 />}
+        icon={<Disasters16 />}
       />
     </>
   );

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
@@ -1,7 +1,7 @@
 import { Panel, PanelIcon } from '@konturio/ui-kit';
 import { useCallback, useMemo, useRef } from 'react';
 import { clsx } from 'clsx';
-import { Legend24, List24 } from '@konturio/default-icons';
+import { Legend16, List16 } from '@konturio/default-icons';
 import { useAction, useAtom } from '@reatom/npm-react';
 import { Sheet } from 'react-modal-sheet';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
@@ -128,7 +128,7 @@ export function LayerFeaturesPanel() {
   }, []);
 
   const panelIcon =
-    featuresPanelLayerId === HOT_PROJECTS_LAYER_ID ? <List24 /> : <Legend24 />;
+    featuresPanelLayerId === HOT_PROJECTS_LAYER_ID ? <List16 /> : <Legend16 />;
 
   const getPanelContent = useMemo(() => {
     if (loading) {

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
@@ -1,7 +1,7 @@
 import { Panel, PanelIcon } from '@konturio/ui-kit';
 import { useCallback, useMemo, useRef } from 'react';
 import { clsx } from 'clsx';
-import { Legend16, List16 } from '@konturio/default-icons';
+import { Legend16, List24 } from '@konturio/default-icons';
 import { useAction, useAtom } from '@reatom/npm-react';
 import { Sheet } from 'react-modal-sheet';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
@@ -128,7 +128,7 @@ export function LayerFeaturesPanel() {
   }, []);
 
   const panelIcon =
-    featuresPanelLayerId === HOT_PROJECTS_LAYER_ID ? <List16 /> : <Legend16 />;
+    featuresPanelLayerId === HOT_PROJECTS_LAYER_ID ? <List24 /> : <Legend16 />;
 
   const getPanelContent = useMemo(() => {
     if (loading) {

--- a/src/features/layers_panel/index.tsx
+++ b/src/features/layers_panel/index.tsx
@@ -1,5 +1,5 @@
 import { lazily } from 'react-lazily';
-import { Layers24 } from '@konturio/default-icons';
+import { Layers16 } from '@konturio/default-icons';
 import { Suspense } from 'react';
 import { i18n } from '~core/localization';
 import { MIN_HEIGHT } from './constants';
@@ -13,7 +13,7 @@ export const layersPanel: () => PanelFeatureInterface = () => ({
       <PanelContent />
     </Suspense>
   ),
-  panelIcon: <Layers24 />,
+  panelIcon: <Layers16 />,
   header: i18n.t('layers'),
   minHeight: MIN_HEIGHT,
   resize: 'vertical',

--- a/src/features/legend_panel/index.tsx
+++ b/src/features/legend_panel/index.tsx
@@ -1,5 +1,5 @@
 import { lazily } from 'react-lazily';
-import { Legend24 } from '@konturio/default-icons';
+import { Legend16 } from '@konturio/default-icons';
 import { Suspense } from 'react';
 import { i18n } from '~core/localization';
 import { MIN_HEIGHT } from './constants';
@@ -13,7 +13,7 @@ export const legendPanel = (): PanelFeatureInterface => ({
       <PanelContent />
     </Suspense>
   ),
-  panelIcon: <Legend24 />,
+  panelIcon: <Legend16 />,
   header: i18n.t('legend'),
   minHeight: MIN_HEIGHT,
   contentheight: 'min-content',

--- a/src/features/search/index.tsx
+++ b/src/features/search/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Panel, PanelIcon, Text } from '@konturio/ui-kit';
-import { Search24 } from '@konturio/default-icons';
+import { Search16 } from '@konturio/default-icons';
 import clsx from 'clsx';
 import { useEffect, useRef } from 'react';
 import { IS_MOBILE_QUERY, useMediaQuery } from '~utils/hooks/useMediaQuery';
@@ -45,7 +45,7 @@ export function Search() {
         </div>
       </Panel>
       <PanelIcon
-        icon={<Search24 />}
+        icon={<Search16 />}
         className={clsx(s.panelIcon, 'knt-panel-icon')}
         clickHandler={openFullState}
       />

--- a/src/features/toolbar/index.tsx
+++ b/src/features/toolbar/index.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { lazily } from 'react-lazily';
-import { Tools16 } from '@konturio/default-icons';
+import { Tools24 } from '@konturio/default-icons';
 import { i18n } from '~core/localization';
 import type { PanelFeatureInterface } from '~core/types/featuresTypes';
 
@@ -13,7 +13,7 @@ export const shortToolbar: () => PanelFeatureInterface = () => ({
       <ShortToolbarContent />
     </Suspense>
   ),
-  panelIcon: <Tools16 />,
+  panelIcon: <Tools24 />,
   header: i18n.t('toolbar.panel_title'),
   minHeight: 56,
 });
@@ -24,7 +24,7 @@ export const toolbar: () => PanelFeatureInterface = () => ({
       <ToolbarContent />
     </Suspense>
   ),
-  panelIcon: <Tools16 />,
+  panelIcon: <Tools24 />,
   header: i18n.t('toolbar.panel_title'),
   minHeight: 121,
 });

--- a/src/features/toolbar/index.tsx
+++ b/src/features/toolbar/index.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { lazily } from 'react-lazily';
-import { Tools24 } from '@konturio/default-icons';
+import { Tools16 } from '@konturio/default-icons';
 import { i18n } from '~core/localization';
 import type { PanelFeatureInterface } from '~core/types/featuresTypes';
 
@@ -13,7 +13,7 @@ export const shortToolbar: () => PanelFeatureInterface = () => ({
       <ShortToolbarContent />
     </Suspense>
   ),
-  panelIcon: <Tools24 />,
+  panelIcon: <Tools16 />,
   header: i18n.t('toolbar.panel_title'),
   minHeight: 56,
 });
@@ -24,7 +24,7 @@ export const toolbar: () => PanelFeatureInterface = () => ({
       <ToolbarContent />
     </Suspense>
   ),
-  panelIcon: <Tools24 />,
+  panelIcon: <Tools16 />,
   header: i18n.t('toolbar.panel_title'),
   minHeight: 121,
 });

--- a/src/utils/hooks/useShortPanelState.tsx
+++ b/src/utils/hooks/useShortPanelState.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown24, ChevronUp24 } from '@konturio/default-icons';
+import { ChevronDown16, ChevronUp16 } from '@konturio/default-icons';
 import { useCallback, useMemo, useState } from 'react';
 
 export type PanelState = 'full' | 'short' | 'closed';
@@ -26,9 +26,9 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
           {
             icon:
               panelState === 'full' ? (
-                <ChevronDown24 data-testid={collapseTestId} />
+                <ChevronDown16 data-testid={collapseTestId} />
               ) : (
-                <ChevronUp24 data-testid={expandTestId} />
+                <ChevronUp16 data-testid={expandTestId} />
               ),
             onWrapperClick: (e) => {
               e.stopPropagation();
@@ -45,9 +45,9 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
         {
           icon:
             panelState === 'closed' ? (
-              <ChevronDown24 data-testid={expandTestId} />
+              <ChevronDown16 data-testid={expandTestId} />
             ) : (
-              <ChevronUp24 data-testid={collapseTestId} />
+              <ChevronUp16 data-testid={collapseTestId} />
             ),
           onWrapperClick: () => {
             const nextState = initialState === 'closed' ? 'full' : initialState;
@@ -59,7 +59,7 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
 
     return [
       {
-        icon: <ChevronDown24 data-testid={collapseTestId} />,
+        icon: <ChevronDown16 data-testid={collapseTestId} />,
         onWrapperClick: (e) => {
           e.stopPropagation();
           setPanelState((prevState) => (prevState === 'closed' ? 'short' : 'full'));
@@ -67,7 +67,7 @@ export const useShortPanelState = (props?: UseShortPanelStateProps) => {
         disabled: panelState === 'full',
       },
       {
-        icon: <ChevronUp24 data-testid={expandTestId} />,
+        icon: <ChevronUp16 data-testid={expandTestId} />,
         onWrapperClick: (e) => {
           e.stopPropagation();
           setPanelState((prevState) => (prevState === 'full' ? 'short' : 'closed'));


### PR DESCRIPTION
## Summary
- reduce panel header padding and icon size
- switch panel title typography to heading-05
- use 16px icons in panel headers

## Testing
- `pnpm lint`
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_688e99293620832f81f68e0e7b39b60c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all panel and toolbar icons to use a more compact 16px size for a consistent and streamlined appearance.
  * Adjusted panel header and icon styles for improved alignment and spacing, especially on smaller screens.

* **Bug Fixes**
  * Ensured all icons display at the intended size within panels and toolbars for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->