### PR TITLE
fix(subscriptions): localize plan labels

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -393,7 +393,11 @@
       "title": "Success",
       "thank_you_for_subscribing": "Thank you for subscribing to our platform!",
       "after_the_page_refreshes": "After the page refreshes, you can start using Kontur Atlas"
-    }
+    },
+    "monthly": "Monthly",
+    "annually": "Annually",
+    "save_percent": "Save {{percent}}%",
+    "month_abbr": "mo"
   },
   "reports": {
     "title": "Disaster Ninja Reports",

--- a/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
+++ b/src/features/subscriptions/components/PaymentPlanCard/PaymentPlanCard.tsx
@@ -105,7 +105,7 @@ const PaymentPlanCard = memo(function PaymentPlanCard({
             [s.hidden]: billingOption.id === 'month',
           })}
         >
-          {`$${billingOption?.initialPricePerMonth?.toLocaleString('en-US')} USD / mo`}
+          {`$${billingOption?.initialPricePerMonth?.toLocaleString('en-US')} ${i18n.t('currency.usd')} / ${i18n.t('subscription.month_abbr')}`}
         </div>
       )}
       {billingOption && (

--- a/src/features/subscriptions/components/Price/Price.tsx
+++ b/src/features/subscriptions/components/Price/Price.tsx
@@ -13,7 +13,9 @@ export function Price({ amount, className }: PriceProps) {
     <div className={clsx(s.priceWrap, className)}>
       <div className={s.dollarSign}>$</div>
       <div className={s.amount}>{amount.toLocaleString('en-US')}</div>
-      <div className={s.perMonth}>{i18n.t('currency.usd')} / mo*</div>
+      <div className={s.perMonth}>
+        {i18n.t('currency.usd')} / {i18n.t('subscription.month_abbr')}*
+      </div>
     </div>
   );
 }

--- a/src/features/subscriptions/components/PricingContent/PricingContent.tsx
+++ b/src/features/subscriptions/components/PricingContent/PricingContent.tsx
@@ -50,6 +50,17 @@ export function PricingContent({ config }: { config: SubscriptionsConfig }) {
 
   const [monthlyPlanConfig, annuallyPlanConfig] = config.billingCyclesDetails;
 
+  const monthlyName = i18n.t('subscription.monthly');
+  const annuallyName = i18n.t('subscription.annually');
+
+  const parseNote = (note: string | null) => {
+    const percent = note?.match(/\d+/)?.[0];
+    return percent ? i18n.t('subscription.save_percent', { percent }) : note;
+  };
+
+  const monthlyNote = parseNote(monthlyPlanConfig.note);
+  const annuallyNote = parseNote(annuallyPlanConfig.note);
+
   const onTogglerChange = useCallback(() => {
     setCurrentBillingCycleID((prev) => (prev === 'month' ? 'year' : 'month'));
   }, []);
@@ -95,15 +106,13 @@ export function PricingContent({ config }: { config: SubscriptionsConfig }) {
         <Heading type="heading-02">{i18n.t('subscription.title')}</Heading>
         <div
           className={clsx(s.togglerSwitch, {
-            [s.withOffLabel]: monthlyPlanConfig.note,
+            [s.withOffLabel]: monthlyNote,
           })}
         >
-          {monthlyPlanConfig.note && (
-            <div className={s.note}>{monthlyPlanConfig.note}</div>
-          )}
+          {monthlyNote && <div className={s.note}>{monthlyNote}</div>}
           <Toggler
-            label={annuallyPlanConfig.name}
-            offValueLabel={monthlyPlanConfig.name}
+            label={annuallyName}
+            offValueLabel={monthlyName}
             id="paymentPeriodToggler"
             on={currentBillingCycleID === togglerInitialValue}
             classes={{
@@ -112,9 +121,7 @@ export function PricingContent({ config }: { config: SubscriptionsConfig }) {
             }}
             onChange={onTogglerChange}
           />
-          {annuallyPlanConfig.note && (
-            <div className={s.note}>{annuallyPlanConfig.note}</div>
-          )}
+          {annuallyNote && <div className={s.note}>{annuallyNote}</div>}
         </div>
         <div className={s.plans}>
           {plansContent.map((planContent, i) => (


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/FE-Some-texts-on-Plans-page-can't-be-translated-21059

## Summary
- translate plan period labels and notes
- include month abbreviation in price translations

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688e99cc0bb0832fb406299a144647af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localization support for subscription-related terms, including monthly and annual billing labels, savings percentages, and month abbreviations.

* **Enhancements**
  * Updated subscription pricing displays to use localized currency and time unit labels.
  * Improved toggler switch UI by showing localized billing cycle names and savings notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->