### PR TITLE
feat(layer_features_panel): add loading state

### DIFF
--- a/src/core/localization/gettext/ar/common.po
+++ b/src/core/localization/gettext/ar/common.po
@@ -1636,6 +1636,10 @@ msgstr "حفظ الميزات"
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "جارٍ تحميل ميزات الطبقة"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/be/common.po
+++ b/src/core/localization/gettext/be/common.po
@@ -1623,6 +1623,10 @@ msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 "Спіс адфільтраваны па вылучанай вобласці і адсартаваны па нумары праекта"
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "Загрузка аб'ектаў слоя"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/de/common.po
+++ b/src/core/localization/gettext/de/common.po
@@ -1641,6 +1641,10 @@ msgstr "Merkmale speichern"
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "Layer-Features werden geladen"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/es/common.po
+++ b/src/core/localization/gettext/es/common.po
@@ -1640,6 +1640,10 @@ msgstr "Guardar características"
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "Cargando características de la capa"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/id/common.po
+++ b/src/core/localization/gettext/id/common.po
@@ -1636,6 +1636,10 @@ msgstr "Simpan fitur"
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "Memuat fitur layer"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/ko/common.po
+++ b/src/core/localization/gettext/ko/common.po
@@ -1635,6 +1635,10 @@ msgstr "특성 저장"
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "레이어 기능을 불러오는 중"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/ru/common.po
+++ b/src/core/localization/gettext/ru/common.po
@@ -1622,6 +1622,10 @@ msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 "Список отфильтрован по выделенной области и отсортирован по номеру проекта"
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "Загрузка объектов слоя"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr "Не удалось загрузить данные об объектах слоя. Попробуйте снова."

--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -1562,6 +1562,10 @@ msgstr ""
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr ""
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/uk/common.po
+++ b/src/core/localization/gettext/uk/common.po
@@ -1575,6 +1575,10 @@ msgstr ""
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr ""
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr ""
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr ""

--- a/src/core/localization/gettext/zh/common.po
+++ b/src/core/localization/gettext/zh/common.po
@@ -1581,6 +1581,10 @@ msgstr "选择图层特征"
 msgid "The list is filtered by selected area and sorted by project number"
 msgstr "列表按所选区域筛选，并按项目编号排序"
 
+#: layer_features_panel##loading
+msgid "Loading layer features"
+msgstr "正在加载图层特征"
+
 #: layer_features_panel##error_loading
 msgid "Failed to load layer features data. Please try again."
 msgstr "加载图层特征数据失败。请重试。"

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -508,6 +508,7 @@
     "noFeatureSelected": "No layer feature selected",
     "chooseFeature": "Choose layer feature",
     "listInfo": "The list is filtered by selected area and sorted by project number",
+    "loading": "Loading layer features",
     "error_loading": "Failed to load layer features data. Please try again.",
     "no_features": "No features found in the selected area.",
     "priority": "{{level}} priority"

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
@@ -132,7 +132,12 @@ export function LayerFeaturesPanel() {
 
   const getPanelContent = useMemo(() => {
     if (loading) {
-      return <LoadingSpinner message={i18n.t('loading')} marginTop="none" />;
+      return (
+        <LoadingSpinner
+          message={i18n.t('layer_features_panel.loading')}
+          marginTop="none"
+        />
+      );
     }
     if (featuresList === null || featuresList.length === 0) {
       return <EmptyState />;

--- a/src/features/layer_features_panel/readme.md
+++ b/src/features/layer_features_panel/readme.md
@@ -4,6 +4,7 @@ This feature enables Layer Features panel. The panel displays a list of features
 
 - If Selected area is not empty, the features data is requested from the backend and then displayed as a list of items
 - If Selected area is empty, the features list is empty
+- While data is being loaded, a spinner with "Loading layer features" message is shown
 - By default, the panel displays items even if the associated layer (e.g. `hotProjects_outlines`) is disabled.
   - This behavior can be changed to require the layer to be enabled (see [How to use](#how-to-use))
 


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/DN-FE-Add-loading-state-for-Layer-features-panel-17786

## Summary
- show loading spinner while layer features load
- add i18n key for "Loading layer features" and update docs and translations

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688e9a91bdc4832f9fe97a8e6a417663