### PR TITLE
feat(layer-features-panel): handle empty state messages

### DIFF
--- a/src/core/localization/gettext/ar/common.po
+++ b/src/core/localization/gettext/ar/common.po
@@ -1619,7 +1619,7 @@ msgid "Your device does not have the required sensors"
 msgstr ""
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr ""
 
 #: layer_features_panel##noFeatureSelected
@@ -1642,7 +1642,7 @@ msgstr ""
 
 #: layer_features_panel##no_features
 #, fuzzy
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "طبقات في المنطقة المختارة"
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/be/common.po
+++ b/src/core/localization/gettext/be/common.po
@@ -1607,7 +1607,7 @@ msgid "Your device does not have the required sensors"
 msgstr "Вашае прылада не мае неабходных датчыкаў"
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr "Аб'екты слоя ў вылучанай вобласці будуць паказаны тут"
 
 #: layer_features_panel##noFeatureSelected
@@ -1630,7 +1630,7 @@ msgstr ""
 "раз."
 
 #: layer_features_panel##no_features
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "У вылучанай вобласці не знойдзена аб'ектаў."
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/de/common.po
+++ b/src/core/localization/gettext/de/common.po
@@ -1624,7 +1624,7 @@ msgid "Your device does not have the required sensors"
 msgstr ""
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr ""
 
 #: layer_features_panel##noFeatureSelected
@@ -1647,7 +1647,7 @@ msgstr ""
 
 #: layer_features_panel##no_features
 #, fuzzy
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "Ebenen im ausgewählten Bereich"
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/es/common.po
+++ b/src/core/localization/gettext/es/common.po
@@ -1623,7 +1623,7 @@ msgid "Your device does not have the required sensors"
 msgstr ""
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr ""
 
 #: layer_features_panel##noFeatureSelected
@@ -1646,7 +1646,7 @@ msgstr ""
 
 #: layer_features_panel##no_features
 #, fuzzy
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "Capas en el área seleccionada"
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/id/common.po
+++ b/src/core/localization/gettext/id/common.po
@@ -1619,7 +1619,7 @@ msgid "Your device does not have the required sensors"
 msgstr ""
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr ""
 
 #: layer_features_panel##noFeatureSelected
@@ -1642,7 +1642,7 @@ msgstr ""
 
 #: layer_features_panel##no_features
 #, fuzzy
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "Lapisan di area pilihan"
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/ko/common.po
+++ b/src/core/localization/gettext/ko/common.po
@@ -1618,7 +1618,7 @@ msgid "Your device does not have the required sensors"
 msgstr ""
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr ""
 
 #: layer_features_panel##noFeatureSelected
@@ -1641,7 +1641,7 @@ msgstr ""
 
 #: layer_features_panel##no_features
 #, fuzzy
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "선택 영역 내 레이어"
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/ru/common.po
+++ b/src/core/localization/gettext/ru/common.po
@@ -1606,7 +1606,7 @@ msgid "Your device does not have the required sensors"
 msgstr "Ваше устройство не имеет необходимые сенсоры"
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr "Здесь будут отображены объекты слоёв в выделенной области"
 
 #: layer_features_panel##noFeatureSelected
@@ -1627,7 +1627,7 @@ msgid "Failed to load layer features data. Please try again."
 msgstr "Не удалось загрузить данные об объектах слоя. Попробуйте снова."
 
 #: layer_features_panel##no_features
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "В выделенной области не найдено ни одного объекта."
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -1547,7 +1547,7 @@ msgid "Your device does not have the required sensors"
 msgstr ""
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr ""
 
 #: layer_features_panel##noFeatureSelected
@@ -1567,7 +1567,7 @@ msgid "Failed to load layer features data. Please try again."
 msgstr ""
 
 #: layer_features_panel##no_features
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr ""
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/uk/common.po
+++ b/src/core/localization/gettext/uk/common.po
@@ -1560,7 +1560,7 @@ msgid "Your device does not have the required sensors"
 msgstr "Ваш пристрій не має необхідних сенсорів"
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr ""
 
 #: layer_features_panel##noFeatureSelected
@@ -1580,7 +1580,7 @@ msgid "Failed to load layer features data. Please try again."
 msgstr ""
 
 #: layer_features_panel##no_features
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr ""
 
 #: layer_features_panel##priority

--- a/src/core/localization/gettext/zh/common.po
+++ b/src/core/localization/gettext/zh/common.po
@@ -1566,7 +1566,7 @@ msgid "Your device does not have the required sensors"
 msgstr "你的设备没有所需的传感器"
 
 #: layer_features_panel##empty
-msgid "Layer features within selected area will be provided here"
+msgid "Layer features in selected area will be provided here"
 msgstr "所选区域的图层特征将显示在此处"
 
 #: layer_features_panel##noFeatureSelected
@@ -1586,7 +1586,7 @@ msgid "Failed to load layer features data. Please try again."
 msgstr "加载图层特征数据失败。请重试。"
 
 #: layer_features_panel##no_features
-msgid "No features found in the selected area."
+msgid "No layer features in selected area"
 msgstr "所选区域未发现特征。"
 
 #: layer_features_panel##priority

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -504,12 +504,12 @@
     "noSensorsError": "Your device does not have the required sensors"
   },
   "layer_features_panel": {
-    "empty": "Layer features within selected area will be provided here",
+    "empty": "Layer features in selected area will be provided here",
     "noFeatureSelected": "No layer feature selected",
     "chooseFeature": "Choose layer feature",
     "listInfo": "The list is filtered by selected area and sorted by project number",
     "error_loading": "Failed to load layer features data. Please try again.",
-    "no_features": "No features found in the selected area.",
+    "no_features": "No layer features in selected area",
     "priority": "{{level}} priority"
   },
   "reference_area": {

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/EmptyState.test.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/EmptyState.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { test, expect, vi } from 'vitest';
+import { i18n } from '../../../../core/localization';
+import { EmptyState } from './EmptyState';
+
+vi.mock('@konturio/ui-kit', () => ({
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+test('renders hint when geometry is missing', () => {
+  render(<EmptyState hasGeometry={false} />);
+  const expectedText = i18n.t('layer_features_panel.empty');
+  expect(
+    screen.getByText(expectedText),
+    'EmptyState should hint about selecting area when geometry is absent',
+  ).toBeDefined();
+});
+
+test('renders no features message when geometry is present', () => {
+  render(<EmptyState hasGeometry={true} />);
+  const expectedText = i18n.t('layer_features_panel.no_features');
+  expect(
+    screen.getByText(expectedText),
+    'EmptyState should show absence of layer features when geometry exists',
+  ).toBeDefined();
+});

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/EmptyState.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/EmptyState.tsx
@@ -2,10 +2,14 @@ import { Text } from '@konturio/ui-kit';
 import { i18n } from '~core/localization';
 import s from './LayerFeaturesPanel.module.css';
 
-export function EmptyState() {
+export function EmptyState({ hasGeometry }: { hasGeometry: boolean }) {
   return (
     <div className={s.noFeatures}>
-      <Text type="short-l">{i18n.t('layer_features_panel.empty')}</Text>
+      <Text type="short-l">
+        {hasGeometry
+          ? i18n.t('layer_features_panel.no_features')
+          : i18n.t('layer_features_panel.empty')}
+      </Text>
     </div>
   );
 }

--- a/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
+++ b/src/features/layer_features_panel/components/LayerFeaturesPanel/index.tsx
@@ -12,6 +12,7 @@ import { useShortPanelState } from '~utils/hooks/useShortPanelState';
 import { scheduledAutoFocus } from '~core/shared_state/currentEvent';
 import { i18n } from '~core/localization';
 import { setCurrentMapBbox, type Bbox } from '~core/shared_state/currentMapPosition';
+import { focusedGeometryAtom } from '~core/focused_geometry/model';
 import { BBoxFilterToggle } from '~components/BBoxFilterToggle/BBoxFilterToggle';
 import {
   layerFeaturesFiltersAtom,
@@ -29,6 +30,7 @@ import {
 import { layerFeatureLayouts } from '~features/layer_features_panel/layouts/layouts';
 import { layerFeaturesFormatsRegistry } from '~features/layer_features_panel/formats/layerFeaturesFormats';
 import { getBBoxForLayerFeature } from '~features/layer_features_panel/helpers/getBBoxForLayerFeature';
+import { isGeoJSONEmpty } from '~utils/geoJSON/helpers';
 import {
   featuresPanelLayerId,
   currentFeatureIdAtom,
@@ -78,8 +80,11 @@ export function LayerFeaturesPanel() {
       : null;
 
   const [{ geometry: bboxFilter }] = useAtom(layerFeaturesFiltersAtom);
+  const [focusedGeometry] = useAtom(focusedGeometryAtom.v3atom);
   const setBboxFilter = useAction(setBBoxAsGeometryForLayerFeatures);
   const resetBboxFilter = useAction(resetGeometryForLayerFeatures);
+
+  const hasGeometry = !isGeoJSONEmpty(bboxFilter ?? focusedGeometry?.geometry);
 
   const [{ data: featuresList, loading }] = useAtom(layerFeaturesCollectionAtom);
 
@@ -135,7 +140,7 @@ export function LayerFeaturesPanel() {
       return <LoadingSpinner message={i18n.t('loading')} marginTop="none" />;
     }
     if (featuresList === null || featuresList.length === 0) {
-      return <EmptyState />;
+      return <EmptyState hasGeometry={hasGeometry} />;
     }
     const content = {
       full: (

--- a/src/features/layer_features_panel/readme.md
+++ b/src/features/layer_features_panel/readme.md
@@ -3,7 +3,8 @@
 This feature enables Layer Features panel. The panel displays a list of features of the associated layer. Features are filtered by the the Selected area geometry.
 
 - If Selected area is not empty, the features data is requested from the backend and then displayed as a list of items
-- If Selected area is empty, the features list is empty
+- If Selected area is not empty but no layer features are found, the panel shows "No layer features in selected area"
+- If Selected area is empty, the panel shows "Layer features in selected area will be provided here"
 - By default, the panel displays items even if the associated layer (e.g. `hotProjects_outlines`) is disabled.
   - This behavior can be changed to require the layer to be enabled (see [How to use](#how-to-use))
 


### PR DESCRIPTION
## Summary
- detect geometry presence for layer features panel and show contextual empty state messages
- document empty state behavior and update translations
- test empty state messages

## Testing
- `pnpm lint`
- `pnpm test:unit --run`

https://kontur.fibery.io/Tasks/Task/20050

------
https://chatgpt.com/codex/tasks/task_e_688e9b0a6340832fa263956ee21fea49