### PR TITLE
feat(layer-features-panel): show hot project details on selection

### DIFF
--- a/src/features/layer_features_panel/layouts/hotProjectsLayout.ts
+++ b/src/features/layer_features_panel/layouts/hotProjectsLayout.ts
@@ -52,6 +52,7 @@ export const hotProjectsLayout = {
     },
     {
       type: 'PropertyGrid',
+      $if: 'active',
       children: [
         {
           type: 'Field',
@@ -75,6 +76,7 @@ export const hotProjectsLayout = {
     },
     {
       type: 'Url',
+      $if: 'active',
       $value: 'projectId',
       props: {
         urlTemplate: 'https://tasks.hotosm.org/projects/{{value}}',

--- a/src/features/layer_features_panel/readme.md
+++ b/src/features/layer_features_panel/readme.md
@@ -6,6 +6,7 @@ This feature enables Layer Features panel. The panel displays a list of features
 - If Selected area is empty, the features list is empty
 - By default, the panel displays items even if the associated layer (e.g. `hotProjects_outlines`) is disabled.
   - This behavior can be changed to require the layer to be enabled (see [How to use](#how-to-use))
+- In HOT Tasking Manager Projects, creation date, mapping types, last contribution and the Tasking Manager link are shown only for the selected card.
 
 ### Feature Flag
 


### PR DESCRIPTION
## Summary
- show HOT Tasking Manager project details only when card is active
- document that HOT project info appears only for selected cards

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688e9c1863ec832fa9c594de2c53cc20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional display of project details and Tasking Manager link, ensuring they appear only when relevant.

* **Documentation**
  * Updated documentation to clarify that certain project details are shown only for the selected card in the panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->