### PR TITLE
feat(layers): add zoom control for focused and reference areas

### DIFF
--- a/src/components/Layer/ZoomToControl/ZoomToControl.tsx
+++ b/src/components/Layer/ZoomToControl/ZoomToControl.tsx
@@ -1,0 +1,38 @@
+import { ZoomTo16 } from '@konturio/default-icons';
+import { useAction, useAtom } from '@reatom/react-v2';
+import { useCallback } from 'react';
+import { i18n } from '~core/localization';
+import { focusOnGeometry } from '~core/shared_state/currentMapPosition';
+import { focusedGeometryAtom } from '~core/focused_geometry/model';
+import { referenceAreaAtom } from '~core/shared_state/referenceArea';
+import { FOCUSED_GEOMETRY_LOGICAL_LAYER_ID } from '~core/focused_geometry/constants';
+import { REFERENCE_AREA_LOGICAL_LAYER_ID } from '~features/reference_area/constants';
+import { LayerActionIcon } from '~components/LayerActionIcon/LayerActionIcon';
+import type { LogicalLayerState } from '~core/logical_layers/types/logicalLayer';
+
+export function ZoomToControl({ layerState }: { layerState: LogicalLayerState }) {
+  const [focusedGeometry] = useAtom(focusedGeometryAtom);
+  const [referenceArea] = useAtom(referenceAreaAtom);
+  const zoomTo = useAction(focusOnGeometry);
+
+  const geometry =
+    layerState.id === FOCUSED_GEOMETRY_LOGICAL_LAYER_ID
+      ? focusedGeometry?.geometry
+      : layerState.id === REFERENCE_AREA_LOGICAL_LAYER_ID
+        ? referenceArea
+        : null;
+
+  const onZoom = useCallback(() => {
+    if (geometry) {
+      zoomTo(geometry);
+    }
+  }, [geometry, zoomTo]);
+
+  if (!geometry) return null;
+
+  return (
+    <LayerActionIcon onClick={onZoom} hint={i18n.t('layer_actions.tooltips.zoom_to')}>
+      <ZoomTo16 />
+    </LayerActionIcon>
+  );
+}

--- a/src/components/Layer/useControlElements.tsx
+++ b/src/components/Layer/useControlElements.tsx
@@ -7,6 +7,7 @@ import { DownloadControl } from './DownloadControl/DownloadControl';
 import { EditControl } from './EditControl/EditControl';
 import { LayerContextMenu } from './LayerContextMenu/LayerContextMenu';
 import { CleanControl } from './EraseControl/CleanControl';
+import { ZoomToControl } from './ZoomToControl/ZoomToControl';
 import type {
   LogicalLayerActions,
   LogicalLayerState,
@@ -55,6 +56,7 @@ export function useControlElements({
       layerState?.id === REFERENCE_AREA_LOGICAL_LAYER_ID
     ) {
       elements.push(
+        <ZoomToControl layerState={layerState} key={layerState.id + 'zoom'} />,
         <CleanControl layerActions={layerActions} key={layerState.id + 'clean'} />,
       );
     }

--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -165,6 +165,10 @@ msgstr ""
 msgid "Show"
 msgstr ""
 
+#: layer_actions##tooltips##zoom_to
+msgid "Zoom to"
+msgstr ""
+
 #: feed
 msgid "Feed"
 msgstr ""
@@ -602,6 +606,10 @@ msgstr ""
 msgid "Compare"
 msgstr ""
 
+#: multivariate##score_and_compare
+msgid "Score and compare"
+msgstr ""
+
 #: multivariate##hide_area
 msgid "Hide area"
 msgstr ""
@@ -612,6 +620,16 @@ msgstr ""
 
 #: multivariate##3d
 msgid "3D"
+msgstr ""
+
+#: multivariate##static_opacity
+msgid "Static opacity"
+msgstr ""
+
+#: multivariate##mcda_legend_subtitle
+msgid ""
+"Hexagons are colored as weighted average of normalized and transformed "
+"layers values"
 msgstr ""
 
 #: map_popup##value
@@ -926,20 +944,12 @@ msgstr ""
 msgid "Polygon should not overlap itself"
 msgstr ""
 
-#: boundary_selector##title
-msgid "Focus to administrative boundary"
-msgstr ""
-
 #: geometry_uploader##title
 msgid "Focus to uploaded geometry"
 msgstr ""
 
 #: geometry_uploader##error
 msgid "Error while reading uploaded file"
-msgstr ""
-
-#: focus_geometry##title
-msgid "Focus to freehand geometry"
 msgstr ""
 
 #: reference_area_layer##settings##name
@@ -1078,18 +1088,6 @@ msgstr ""
 
 #: bivariate##color_manager##layers_tab
 msgid "Layers (indicators)"
-msgstr ""
-
-#: sidebar##biv_color_manager
-msgid "Сolor manager"
-msgstr ""
-
-#: sidebar##edit_osm
-msgid "Edit in OpenStreetMap"
-msgstr ""
-
-#: sidebar##ruler
-msgid "Ruler"
 msgstr ""
 
 #: sidebar##collapse

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -42,7 +42,8 @@
       "edit": "Edit",
       "hide": "Hide",
       "show": "Show",
-      "delete": "Delete"
+      "delete": "Delete",
+      "zoom_to": "Zoom to"
     }
   },
   "feed": "Feed",


### PR DESCRIPTION
## Summary
- add zoom-to action for selected and reference area layers
- provide translation string for zoom tooltip

## Testing
- `pnpm test:unit`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688ea2a5f108832fa60ca7c070ba97df

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Zoom to" control for focused geometry and reference area layers, allowing users to quickly zoom to selected geometries from the layer controls.

* **Localization**
  * Introduced a new "Zoom to" tooltip for layer actions.
  * Updated translation files to include the new tooltip and other UI text changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->