### PR TITLE
fix(layers): show HOT project details only when selected

### DIFF
--- a/src/features/layer_features_panel/layouts/hotProjectsLayout.test.ts
+++ b/src/features/layer_features_panel/layouts/hotProjectsLayout.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, assert } from 'vitest';
+import { hotProjectsLayout } from './hotProjectsLayout';
+
+type LayoutNode = {
+  [key: string]: any;
+  children?: LayoutNode[];
+  $template?: LayoutNode;
+};
+
+function findNode(
+  node: LayoutNode,
+  predicate: (n: LayoutNode) => boolean,
+): LayoutNode | undefined {
+  if (predicate(node)) return node;
+  if (node.children) {
+    for (const child of node.children) {
+      const found = findNode(child, predicate);
+      if (found) return found;
+    }
+  }
+  if (node.$template) {
+    const found = findNode(node.$template, predicate);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+describe('hotProjectsLayout conditional elements', () => {
+  test('mapping types are shown only for active card', () => {
+    const mappingNode = findNode(
+      hotProjectsLayout as unknown as LayoutNode,
+      (n) => n.$value === 'mappingTypes',
+    );
+    assert(
+      mappingNode,
+      'Expected mapping types field node to be present in hotProjectsLayout',
+    );
+    assert.equal(
+      mappingNode.$if,
+      'active',
+      `Mapping types field should be visible only when card is active, got condition: ${mappingNode.$if}`,
+    );
+  });
+
+  test('open in Tasking Manager link is shown only for active card', () => {
+    const linkNode = findNode(
+      hotProjectsLayout as unknown as LayoutNode,
+      (n) => n.label === 'Open in Tasking Manager',
+    );
+    assert(
+      linkNode,
+      'Expected Open in Tasking Manager link node to be present in hotProjectsLayout',
+    );
+    assert.equal(
+      linkNode.$if,
+      'active',
+      `Open in Tasking Manager link should be visible only when card is active, got condition: ${linkNode.$if}`,
+    );
+  });
+});

--- a/src/features/layer_features_panel/layouts/hotProjectsLayout.ts
+++ b/src/features/layer_features_panel/layouts/hotProjectsLayout.ts
@@ -64,6 +64,7 @@ export const hotProjectsLayout = {
           $value: 'mappingTypes',
           format: 'capitalized_list',
           overrides: { value: { label: 'Mapping types' } },
+          $if: 'active',
         },
         {
           type: 'Field',
@@ -80,6 +81,7 @@ export const hotProjectsLayout = {
         urlTemplate: 'https://tasks.hotosm.org/projects/{{value}}',
       },
       label: 'Open in Tasking Manager',
+      $if: 'active',
     },
   ],
 };


### PR DESCRIPTION
## Summary
- show mapping types only when HOT Tasking Manager card is active
- display Tasking Manager link only for selected cards
- test conditional rendering of HOT project extras

## Testing
- `pnpm vitest run`
- `pnpm lint`
- `make precommit` *(fails: No rule to make target 'precommit')*

------
https://chatgpt.com/codex/tasks/task_e_688ea37f29cc832faa0d71b3a1ddbcd1