### PR TITLE
fix(layer-features-panel): show tasking manager link only when selected

### DIFF
--- a/src/features/layer_features_panel/layouts/hotProjectsLayout.ts
+++ b/src/features/layer_features_panel/layouts/hotProjectsLayout.ts
@@ -80,6 +80,7 @@ export const hotProjectsLayout = {
         urlTemplate: 'https://tasks.hotosm.org/projects/{{value}}',
       },
       label: 'Open in Tasking Manager',
+      $if: 'active',
     },
   ],
 };


### PR DESCRIPTION
## Summary
- render HOT Tasking Manager link only for active feature cards

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688eaa647310832fbffe4d70adbc59d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Open in Tasking Manager" link is now only visible when the project is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->