### PR TITLE
fix(legend): replace outline circles with lines

### DIFF
--- a/src/components/SimpleLegend/icons/CircleIcon.test.tsx
+++ b/src/components/SimpleLegend/icons/CircleIcon.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { CircleIcon } from './CircleIcon';
+
+describe('CircleIcon', () => {
+  it('renders horizontal line when no fill color provided', () => {
+    const { container } = render(
+      <CircleIcon styles={{ width: 4 } as any} size="normal" />,
+    );
+    const line = container.querySelector('line');
+    expect(line, 'CircleIcon without fill should render line element').not.toBeNull();
+    const circle = container.querySelector('circle');
+    expect(circle, 'CircleIcon without fill should not render circle element').toBeNull();
+  });
+});

--- a/src/components/SimpleLegend/icons/CircleIcon.tsx
+++ b/src/components/SimpleLegend/icons/CircleIcon.tsx
@@ -17,6 +17,14 @@ export function CircleIcon({
   fill?: string;
   stroke?: string;
 }) {
+  const fillColor = fill || styles['fill-color'] || styles['circle-color'] || 'none';
+  const strokeColor =
+    stroke ||
+    styles['circle-stroke-color'] ||
+    styles.color ||
+    styles['circle-color'] ||
+    '#000000';
+
   return (
     <svg
       width={sizes[size]}
@@ -26,20 +34,25 @@ export function CircleIcon({
       xmlns="http://www.w3.org/2000/svg"
       className={className}
     >
-      <circle
-        cx="9"
-        cy="9"
-        r="7"
-        fill={fill || styles['fill-color'] || styles['circle-color'] || 'none'}
-        stroke={
-          stroke ||
-          styles['circle-stroke-color'] ||
-          styles.color ||
-          styles['circle-color'] ||
-          '#000000'
-        }
-        strokeWidth={styles.width ?? 4}
-      />
+      {fillColor === 'none' ? (
+        <line
+          x1="2"
+          y1="9"
+          x2="16"
+          y2="9"
+          stroke={strokeColor}
+          strokeWidth={styles.width ?? 4}
+        />
+      ) : (
+        <circle
+          cx="9"
+          cy="9"
+          r="7"
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={styles.width ?? 4}
+        />
+      )}
     </svg>
   );
 }


### PR DESCRIPTION
https://kontur.fibery.io/Product_management/Pain_Point/Legend-Outlined-circles-look-like-radiobuttons-123

## Summary
- render horizontal line instead of outline circle in legend when no fill color
- cover CircleIcon line rendering with unit test

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688f389ee554832f805700390345f36c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The icon component now dynamically displays either a line or a circle based on the fill color provided.
* **Tests**
  * Added tests to verify that the icon correctly renders a line when no fill color is specified and a circle when a fill color is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->