### PR TITLE
feat(events-list): 16777 add magnitude/category shield to disaster card

### DIFF
--- a/src/components/Uni/Components/DisasterShield.module.css
+++ b/src/components/Uni/Components/DisasterShield.module.css
@@ -1,0 +1,11 @@
+.shield {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 16px;
+  padding: 0 var(--unit);
+  border-radius: 999px;
+  color: #fff;
+  font: 600 var(--font-xs);
+  white-space: nowrap;
+}

--- a/src/components/Uni/Components/DisasterShield.module.css
+++ b/src/components/Uni/Components/DisasterShield.module.css
@@ -5,7 +5,6 @@
   height: 16px;
   padding: 0 var(--unit);
   border-radius: 999px;
-  color: #fff;
   font: 600 var(--font-xs);
   white-space: nowrap;
 }

--- a/src/components/Uni/Components/DisasterShield.test.tsx
+++ b/src/components/Uni/Components/DisasterShield.test.tsx
@@ -9,19 +9,25 @@ describe('DisasterShield', () => {
     render(<DisasterShield eventType="EARTHQUAKE" magnitude={8.6} />);
     const el = screen.getByText('M 8.6');
     expect(el, 'Earthquake shield should show magnitude text').toBeTruthy();
-    expect(
-      el.getAttribute('style'),
-      'Earthquake magnitude 8.6 should map to #FF6600',
-    ).toContain('background-color: #FF6600');
+    const style = (el.getAttribute('style') ?? '').toLowerCase();
+    expect(style, 'Earthquake magnitude 8.6 should map text color to #FF6600').toContain(
+      'color: #ff6600',
+    );
+    expect(style, 'Earthquake magnitude 8.6 should have 10% opaque background').toContain(
+      'background-color: #ff66001a',
+    );
   });
 
   it('renders cyclone category with correct color', () => {
     render(<DisasterShield eventType="CYCLONE" cycloneCategory="2" />);
     const el = screen.getByText('Cat 2');
     expect(el, 'Cyclone shield should show category text').toBeTruthy();
-    expect(
-      el.getAttribute('style'),
-      'Cyclone category 2 should map to #FFB800',
-    ).toContain('background-color: #FFB800');
+    const style = (el.getAttribute('style') ?? '').toLowerCase();
+    expect(style, 'Cyclone category 2 should map text color to #FFB800').toContain(
+      'color: #ffb800',
+    );
+    expect(style, 'Cyclone category 2 should have 10% opaque background').toContain(
+      'background-color: #ffb8001a',
+    );
   });
 });

--- a/src/components/Uni/Components/DisasterShield.test.tsx
+++ b/src/components/Uni/Components/DisasterShield.test.tsx
@@ -1,0 +1,27 @@
+/* @vitest-environment happy-dom */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { DisasterShield } from './DisasterShield';
+
+describe('DisasterShield', () => {
+  it('renders earthquake magnitude with correct color', () => {
+    render(<DisasterShield eventType="EARTHQUAKE" magnitude={8.6} />);
+    const el = screen.getByText('M 8.6');
+    expect(el, 'Earthquake shield should show magnitude text').toBeTruthy();
+    expect(
+      el.getAttribute('style'),
+      'Earthquake magnitude 8.6 should map to #FF6600',
+    ).toContain('background-color: #FF6600');
+  });
+
+  it('renders cyclone category with correct color', () => {
+    render(<DisasterShield eventType="CYCLONE" cycloneCategory="2" />);
+    const el = screen.getByText('Cat 2');
+    expect(el, 'Cyclone shield should show category text').toBeTruthy();
+    expect(
+      el.getAttribute('style'),
+      'Cyclone category 2 should map to #FFB800',
+    ).toContain('background-color: #FFB800');
+  });
+});

--- a/src/components/Uni/Components/DisasterShield.tsx
+++ b/src/components/Uni/Components/DisasterShield.tsx
@@ -1,0 +1,66 @@
+import clsx from 'clsx';
+import s from './DisasterShield.module.css';
+import type { EventType } from '~core/types';
+
+type CycloneCategory = 'TD' | 'TS' | '1' | '2' | '3' | '4' | '5';
+
+const magnitudeColors: Array<{ from: number; to: number; color: string }> = [
+  { from: 0, to: 1.9, color: '#009900' },
+  { from: 2, to: 2.9, color: '#5CB702' },
+  { from: 3, to: 3.9, color: '#9BCC33' },
+  { from: 4, to: 4.9, color: '#CED21B' },
+  { from: 5, to: 5.9, color: '#FACD2D' },
+  { from: 6, to: 6.9, color: '#FFAB2E' },
+  { from: 7, to: 7.9, color: '#FF8A00' },
+  { from: 8, to: 8.9, color: '#FF6600' },
+  { from: 9, to: 9.9, color: '#FF3D00' },
+  { from: 10, to: 10.9, color: '#DA2902' },
+  { from: 11, to: 11.9, color: '#B32000' },
+  { from: 12, to: Number.POSITIVE_INFINITY, color: '#700D00' },
+];
+
+const cycloneCategoryColors: Record<CycloneCategory, string> = {
+  TD: '#5CB702',
+  TS: '#9BCC33',
+  '1': '#FACD2D',
+  '2': '#FFB800',
+  '3': '#FF8A00',
+  '4': '#FF3D00',
+  '5': '#EA2A00',
+};
+
+interface DisasterShieldProps {
+  eventType: EventType;
+  magnitude?: number;
+  cycloneCategory?: string;
+  className?: string;
+}
+
+export function DisasterShield({
+  eventType,
+  magnitude,
+  cycloneCategory,
+  className,
+}: DisasterShieldProps) {
+  let label: string | null = null;
+  let color: string | undefined;
+
+  if (eventType === 'EARTHQUAKE' && typeof magnitude === 'number') {
+    label = `M ${magnitude}`;
+    color = magnitudeColors.find((r) => magnitude >= r.from && magnitude <= r.to)?.color;
+  }
+
+  if (eventType === 'CYCLONE' && cycloneCategory) {
+    const cat = cycloneCategory as CycloneCategory;
+    color = cycloneCategoryColors[cat];
+    label = ['TD', 'TS'].includes(cat) ? cat : `Cat ${cat}`;
+  }
+
+  if (!label || !color) return null;
+
+  return (
+    <div className={clsx(s.shield, className)} style={{ backgroundColor: color }}>
+      {label}
+    </div>
+  );
+}

--- a/src/components/Uni/Components/DisasterShield.tsx
+++ b/src/components/Uni/Components/DisasterShield.tsx
@@ -36,6 +36,15 @@ interface DisasterShieldProps {
   className?: string;
 }
 
+function addOpacity(hex: string, opacity: number) {
+  const alpha = Math.round(opacity * 255)
+    .toString(16)
+    .padStart(2, '0')
+    .toUpperCase();
+
+  return `${hex}${alpha}`;
+}
+
 export function DisasterShield({
   eventType,
   magnitude,
@@ -59,7 +68,10 @@ export function DisasterShield({
   if (!label || !color) return null;
 
   return (
-    <div className={clsx(s.shield, className)} style={{ backgroundColor: color }}>
+    <div
+      className={clsx(s.shield, className)}
+      style={{ color, backgroundColor: addOpacity(color, 0.1) }}
+    >
       {label}
     </div>
   );

--- a/src/components/Uni/componentsRegistry.ts
+++ b/src/components/Uni/componentsRegistry.ts
@@ -4,6 +4,7 @@ import { SeverityIndicator } from './Components/Severity';
 import { Url } from './Components/Url';
 import { Text, Title } from './Components/Base';
 import { Badge } from './Components/Badge';
+import { DisasterShield } from './Components/DisasterShield';
 import { MappingProgress } from './Components/MappingProgress';
 import { Field } from './Components/Field';
 import { CardHeader } from './Components/CardHeader';
@@ -24,6 +25,7 @@ export const componentsRegistry = {
   IconButton,
   Url,
   Badge,
+  DisasterShield,
   Image,
 
   MappingProgress,

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -48,6 +48,10 @@ export interface Event {
   location: string;
   /** How it important */
   severity: Severity;
+  /** Earthquake magnitude if applicable */
+  magnitude?: number;
+  /** Cyclone category (TD, TS or 1-5) */
+  cycloneCategory?: string;
   /** How many people affected. >= 0 */
   affectedPopulation: number;
   /** Settled area in km2. >= 0 */

--- a/src/features/events_list/components/EventsPanel/eventLayouts.ts
+++ b/src/features/events_list/components/EventsPanel/eventLayouts.ts
@@ -8,6 +8,14 @@ export const eventCardLayoutTemplate = {
       type: 'Row',
       children: [
         { type: 'Title', $value: 'eventName' },
+        {
+          type: 'DisasterShield',
+          $props: {
+            eventType: 'eventType',
+            magnitude: 'magnitude',
+            cycloneCategory: 'cycloneCategory',
+          },
+        },
         { type: 'Severity', $value: 'severity' },
       ],
     },

--- a/src/features/events_list/readme.md
+++ b/src/features/events_list/readme.md
@@ -17,6 +17,8 @@ The `EventList` component is a feature that implements a list of disasters in th
 The `EventCard` component is responsible for displaying a single event in the list. It includes information such as the event title, location, and date, including a description and associated external links. Users can click on an event to view more details or select it as the current event.
 It can also contains a show timeline button, if the episodes timeline feature is enabled.
 
+When magnitude or cyclone category information is available, a colored shield is rendered to the left of the severity indicator showing values like `M 8.6` or `Cat 2`.
+
 ### CurrentEvent
 
 The `CurrentEvent` component displays details for the currently selected unlisted event. Unlisted event it is an event that is not in the list of events, nut it comes from the URL.


### PR DESCRIPTION
## Summary
- add DisasterShield component for earthquake magnitude and cyclone category badges
- show DisasterShield next to severity on event cards
- document new shield in events list readme

## Testing
- `pnpm vitest run`
- `pnpm lint`
- `make precommit` *(fails: No rule to make target 'precommit')*


------
https://chatgpt.com/codex/tasks/task_e_688f37dfd744832fad5f7760e198a539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a color-coded shield to event cards, visually displaying earthquake magnitude or cyclone category when available.
* **Documentation**
  * Updated documentation to describe the new shield indicator for event cards.
* **Tests**
  * Added tests to ensure the shield displays correct labels and colors for different disaster types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->