### PR TITLE
fix(mcda): add layer visibility toggle

### DIFF
--- a/src/core/logical_layers/renderers/MCDARenderer/popup.ts
+++ b/src/core/logical_layers/renderers/MCDARenderer/popup.ts
@@ -42,19 +42,25 @@ export function generateMCDALayersTableAndScore(
   feature: GeoJSON.Feature,
   layers: MCDAConfig['layers'],
 ) {
-  const mcdaLayersTable = createTableWithCalculations(feature, layers);
-  const resultMCDAScore = calcMcdaIndex(layers, mcdaLayersTable);
-  return { mcdaLayersTable, resultMCDAScore, layers };
+  const visibleLayers = layers.filter((l) => !l.isHidden);
+  const mcdaLayersTable = createTableWithCalculations(feature, visibleLayers);
+  const resultMCDAScore = calcMcdaIndex(visibleLayers, mcdaLayersTable);
+  return { mcdaLayersTable, resultMCDAScore, layers: visibleLayers };
 }
 
 export function generateMCDAPopupTable(
   feature: GeoJSON.Feature,
   layers: MCDAConfig['layers'],
 ) {
-  const { mcdaLayersTable, resultMCDAScore } = generateMCDALayersTableAndScore(
-    feature,
-    layers,
-  );
+  const {
+    mcdaLayersTable,
+    resultMCDAScore,
+    layers: visibleLayers,
+  } = generateMCDALayersTableAndScore(feature, layers);
 
-  return PopupMCDA({ layers, normalized: mcdaLayersTable, resultMCDA: resultMCDAScore });
+  return PopupMCDA({
+    layers: visibleLayers,
+    normalized: mcdaLayersTable,
+    resultMCDA: resultMCDAScore,
+  });
 }

--- a/src/core/logical_layers/renderers/stylesConfigs/index.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/index.ts
@@ -38,10 +38,12 @@ export const styleConfigs: Record<
       const layersForFilter: MCDAConfig['layers'] = [];
       // create filter based on all MCDA layers from opacity and extrusion
       if (typeof config.opacity === 'object' && config.opacity?.config.layers.length) {
-        layersForFilter.push(...config.opacity.config.layers);
+        layersForFilter.push(...config.opacity.config.layers.filter((l) => !l.isHidden));
       }
       if (config.extrusion?.height.config.layers.length) {
-        layersForFilter.push(...config.extrusion.height.config.layers);
+        layersForFilter.push(
+          ...config.extrusion.height.config.layers.filter((l) => !l.isHidden),
+        );
       }
       // monochrome fill specification
       multivariateStyle = createMonochromeFillSpec(

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.test.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.test.ts
@@ -13,6 +13,17 @@ describe('createMCDAStyle', () => {
       const result = filterSetup([layer1, { ...layer2, outliers: 'hide' }]);
       expect(result).toMatchSnapshot();
     });
+
+    it('ignores hidden layers in filter', () => {
+      const result = filterSetup([{ ...layer1, isHidden: true }, layer2]);
+      const expected = filterSetup([layer2]);
+      expect(result).toEqual(expected);
+    });
+
+    it('returns undefined when all layers are hidden', () => {
+      const result = filterSetup([{ ...layer1, isHidden: true }]);
+      expect(result).toBeUndefined();
+    });
   });
 });
 

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/types.ts
@@ -40,6 +40,7 @@ export interface MCDALayer {
   normalization: Normalization;
   unit: string | null;
   datasetStats?: AxisDatasetStats;
+  isHidden?: boolean;
 }
 
 export interface MCDAConfig {

--- a/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
+++ b/src/features/mcda/components/MCDALayerEditor/MCDALayerParameters/MCDALayerParameters.tsx
@@ -7,6 +7,7 @@ import { i18n } from '~core/localization';
 import { isNumber } from '~utils/common';
 import { LayerActionIcon } from '~components/LayerActionIcon/LayerActionIcon';
 import { LayerInfo } from '~components/LayerInfo/LayerInfo';
+import { LayerHideControl } from '~components/LayerHideControl/LayerHideControl';
 import { availableBivariateAxesAtom } from '~core/bivariate/atoms/availableBivariateAxesAtom';
 import { getAxisTransformations } from '~core/api/mcda';
 import { KonturSpinner } from '~components/LoadingSpinner/KonturSpinner';
@@ -269,12 +270,25 @@ export function MCDALayerParameters({
     }
   }, [onDeletePressed]);
 
+  const hideLayer = useCallback(() => {
+    onLayerEdited({ ...layer, isHidden: true });
+  }, [layer, onLayerEdited]);
+
+  const unhideLayer = useCallback(() => {
+    onLayerEdited({ ...layer, isHidden: false });
+  }, [layer, onLayerEdited]);
+
   return (
     <div>
       <div key={layer.id} className={s.layer}>
         <div className={s.layerHeader}>
           <div>{layer.name}</div>
           <div className={s.layerButtons}>
+            <LayerHideControl
+              isVisible={!layer.isHidden}
+              hideLayer={hideLayer}
+              unhideLayer={unhideLayer}
+            />
             <LayerActionIcon
               onClick={editLayer}
               hint={i18n.t('layer_actions.tooltips.edit')}

--- a/src/features/mcda/readme.md
+++ b/src/features/mcda/readme.md
@@ -55,6 +55,7 @@ By clicking it in activated prompt window user needs to enter JSON of next struc
    - range: [min: number, max: number] - min, max values for specific axis
    - sentiment: only 2 options here - ["bad", "good"] as deafult direction and ["good", "bad"] as a reversed
    - coefficient: weight of layer in analysis, could be >=0 and <=1
+   - isHidden: optional flag to exclude layer from analysis and hide it in UI
 
 ## How it calculates
 

--- a/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
+++ b/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
@@ -127,8 +127,8 @@ export function createMultivariateConfig(
             colors:
               scoreMCDAStyle?.config && baseMCDAStyle?.config
                 ? createBivariateColorsForMVA(
-                    scoreMCDAStyle.config.layers,
-                    baseMCDAStyle.config.layers,
+                    scoreMCDAStyle.config.layers.filter((l) => !l.isHidden),
+                    baseMCDAStyle.config.layers.filter((l) => !l.isHidden),
                     DEFAULT_MULTIBIVARIATE_COLORS,
                   )
                 : DEFAULT_MULTIBIVARIATE_COLORS,
@@ -151,8 +151,9 @@ function createMCDANameOverride(
   layers: MCDALayer[] | undefined,
   fallbackNameOverride?: string,
 ): string | undefined {
-  if (layers?.length === 1) {
-    return layers[0].name;
+  const visibleLayers = layers?.filter((l) => !l.isHidden);
+  if (visibleLayers?.length === 1) {
+    return visibleLayers[0].name;
   } else {
     return fallbackNameOverride;
   }

--- a/src/features/multivariate_layer/helpers/createStepsForMCDADimension.ts
+++ b/src/features/multivariate_layer/helpers/createStepsForMCDADimension.ts
@@ -6,9 +6,10 @@ export function createStepsForMCDADimension(
   layers: MCDALayer[] | undefined,
   availableAxes: Axis[],
 ): Step[] {
-  if (layers?.length === 1 && layers[0].normalization === 'no') {
+  const visibleLayers = layers?.filter((l) => !l.isHidden);
+  if (visibleLayers?.length === 1 && visibleLayers[0].normalization === 'no') {
     // just one layer with no normalization - use axis data for steps
-    const axis = availableAxes.find((axis) => layers[0].id === axis.id);
+    const axis = availableAxes.find((axis) => visibleLayers[0].id === axis.id);
     return axis?.steps || DEFAULT_MULTIBIVARIATE_STEPS;
   } else {
     // multiple layers or normalized layer - use default steps from 0 to 1

--- a/src/utils/mcda/createMCDALayersFromBivariateAxes.ts
+++ b/src/utils/mcda/createMCDALayersFromBivariateAxes.ts
@@ -32,6 +32,7 @@ export function createMCDALayersFromBivariateAxes(axes: Axis[]): MCDALayer[] {
       transformationFunction: axis.transformation?.transformation ?? 'no',
       transformation: axis.transformation,
       normalization: 'max-min',
+      isHidden: false,
     });
     return acc;
   }, []);

--- a/src/utils/mcda/getDirectAndReversedMCDALayers.ts
+++ b/src/utils/mcda/getDirectAndReversedMCDALayers.ts
@@ -9,7 +9,7 @@ export function getDirectAndReversedMCDALayers(config: MCDAConfig) {
   const reversedLayers: MCDALayer[] = [];
   const directLayers: MCDALayer[] = [];
   config.layers
-    .filter((layer) => layer.name)
+    .filter((layer) => layer.name && !layer.isHidden)
     .forEach((layer) => {
       if (arraysAreEqualWithStrictOrder(layer.sentiment, sentimentReversed)) {
         reversedLayers.push(layer);


### PR DESCRIPTION
## Summary
- allow toggling MCDA layer visibility via eye icon
- ignore hidden layers in MCDA style generation and helpers
- document optional `isHidden` flag in MCDA config

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688f3ab5ab48832fb078f6106a05fcfa