### PR TITLE
feat(events_list): add disaster panel filters

### DIFF
--- a/src/core/localization/gettext/template/common.pot
+++ b/src/core/localization/gettext/template/common.pot
@@ -753,6 +753,26 @@ msgstr ""
 msgid "Timeline"
 msgstr ""
 
+#: event_list##filter_type_label
+msgid "Type"
+msgstr ""
+
+#: event_list##filter_severity_label
+msgid "Severity"
+msgstr ""
+
+#: event_list##filter_date_from_label
+msgid "Start date"
+msgstr ""
+
+#: event_list##filter_date_to_label
+msgid "End date"
+msgstr ""
+
+#: event_list##filter_country_label
+msgid "Country"
+msgstr ""
+
 #: create_layer##save_and_draw
 msgid "Save and draw"
 msgstr ""

--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -228,7 +228,12 @@
     "severity_moderate": "Moderate",
     "severity_severe": "Severe",
     "severity_extreme": "Extreme",
-    "open_timeline_button": "Timeline"
+    "open_timeline_button": "Timeline",
+    "filter_type_label": "Type",
+    "filter_severity_label": "Severity",
+    "filter_date_from_label": "Start date",
+    "filter_date_to_label": "End date",
+    "filter_country_label": "Country"
   },
   "create_layer": {
     "save_and_draw": "Save and draw",

--- a/src/features/events_list/atoms/sortedEventList.ts
+++ b/src/features/events_list/atoms/sortedEventList.ts
@@ -6,12 +6,16 @@ import { sortEventsBySingleProperty } from '../helpers/singlePropertySort';
 import { sortEventsByMcda } from '../helpers/eventsMcdaSort';
 import {
   filterByExcludedEventTypes,
+  filterByEventTypes,
   filterByLastNDaysStartedAt,
   filterByLastNDaysUpdatedAt,
+  filterByCountry,
   filterByMinAffectedPopulation,
   filterByMinSeverity,
   filterByMinStartedAt,
   filterByMinUpdatedAt,
+  filterByMaxStartedAt,
+  filterByMaxUpdatedAt,
 } from '../helpers/localEventFilters';
 import { eventSortingConfigAtom } from './eventSortingConfig';
 import { eventListResourceAtom } from './eventListResource';
@@ -55,8 +59,14 @@ function applyLocalEventListFilters(
   if (filtersConfig.minSeverity) {
     result = filterByMinSeverity(result, filtersConfig.minSeverity);
   }
+  if (filtersConfig.eventTypes) {
+    result = filterByEventTypes(result, filtersConfig.eventTypes);
+  }
   if (filtersConfig.excludedEventTypes) {
     result = filterByExcludedEventTypes(result, filtersConfig.excludedEventTypes);
+  }
+  if (filtersConfig.country) {
+    result = filterByCountry(result, filtersConfig.country);
   }
   // date filters
   if (filtersConfig.minUpdatedAt) {
@@ -64,10 +74,16 @@ function applyLocalEventListFilters(
   } else if (isNumber(filtersConfig.lastNDaysUpdatedAt)) {
     result = filterByLastNDaysUpdatedAt(result, filtersConfig.lastNDaysUpdatedAt);
   }
+  if (filtersConfig.maxUpdatedAt) {
+    result = filterByMaxUpdatedAt(result, filtersConfig.maxUpdatedAt);
+  }
   if (filtersConfig.minStartedAt) {
     result = filterByMinStartedAt(result, filtersConfig.minStartedAt);
   } else if (isNumber(filtersConfig.lastNDaysStartedAt)) {
     result = filterByLastNDaysStartedAt(result, filtersConfig.lastNDaysStartedAt);
+  }
+  if (filtersConfig.maxStartedAt) {
+    result = filterByMaxStartedAt(result, filtersConfig.maxStartedAt);
   }
   return result;
 }

--- a/src/features/events_list/components/EventsPanelSettings/EventFilters.tsx
+++ b/src/features/events_list/components/EventsPanelSettings/EventFilters.tsx
@@ -1,0 +1,96 @@
+import { useAtom as useAtomV3 } from '@reatom/npm-react';
+import { i18n } from '~core/localization';
+import { localEventFiltersAtom } from '~features/events_list/atoms/localEventListFiltersConfig';
+import type { EventType, Severity } from '~core/types';
+import type { ChangeEvent } from 'react';
+
+const eventTypes: EventType[] = [
+  'FLOOD',
+  'TSUNAMI',
+  'WILDFIRE',
+  'THERMAL_ANOMALY',
+  'INDUSTRIAL_HEAT',
+  'TORNADO',
+  'WINTER_STORM',
+  'EARTHQUAKE',
+  'STORM',
+  'CYCLONE',
+  'DROUGHT',
+  'VOLCANO',
+  'OTHER',
+];
+
+const severities: Severity[] = ['TERMINATION', 'MINOR', 'MODERATE', 'SEVERE', 'EXTREME'];
+
+export function EventFilters() {
+  const [filters, setFilters] = useAtomV3(localEventFiltersAtom);
+  const cfg = filters || {};
+
+  const onEventTypesChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const selected = Array.from(e.target.selectedOptions).map(
+      (o) => o.value as EventType,
+    );
+    setFilters((prev) => ({
+      ...(prev || {}),
+      eventTypes: selected.length ? selected : undefined,
+    }));
+  };
+
+  const onSeverityChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value as Severity;
+    setFilters((prev) => ({ ...(prev || {}), minSeverity: value || undefined }));
+  };
+
+  const onCountryChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setFilters((prev) => ({ ...(prev || {}), country: value || undefined }));
+  };
+
+  const onStartFromChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setFilters((prev) => ({ ...(prev || {}), minStartedAt: value || undefined }));
+  };
+
+  const onStartToChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setFilters((prev) => ({ ...(prev || {}), maxStartedAt: value || undefined }));
+  };
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+      <label>
+        {i18n.t('event_list.filter_type_label')}
+        <select multiple value={cfg.eventTypes || []} onChange={onEventTypesChange}>
+          {eventTypes.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        {i18n.t('event_list.filter_severity_label')}
+        <select value={cfg.minSeverity || ''} onChange={onSeverityChange}>
+          <option value="" />
+          {severities.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        {i18n.t('event_list.filter_date_from_label')}
+        <input type="date" value={cfg.minStartedAt || ''} onChange={onStartFromChange} />
+      </label>
+      <label>
+        {i18n.t('event_list.filter_date_to_label')}
+        <input type="date" value={cfg.maxStartedAt || ''} onChange={onStartToChange} />
+      </label>
+      <label>
+        {i18n.t('event_list.filter_country_label')}
+        <input type="text" value={cfg.country || ''} onChange={onCountryChange} />
+      </label>
+    </div>
+  );
+}

--- a/src/features/events_list/components/EventsPanelSettings/EventsPanelSettings.tsx
+++ b/src/features/events_list/components/EventsPanelSettings/EventsPanelSettings.tsx
@@ -5,6 +5,7 @@ import { eventListFilters } from '~features/events_list/atoms/eventListFilters';
 import { BBoxFilterToggle } from '~components/BBoxFilterToggle/BBoxFilterToggle';
 import { PanelSettingsRow } from '~components/PanelSettingsRow/PanelSettingsRow';
 import { FeedSelectorFlagged } from '../FeedSelector';
+import { EventFilters } from './EventFilters';
 
 const featureFlags = configRepo.get().features;
 
@@ -25,6 +26,7 @@ export function EventsPanelSettings() {
           onCleanFilter={resetBboxFilter}
         />
       )}
+      <EventFilters />
       {/* TODO: for now we don't want these sort buttons, there was no design for them */}
       {/* <EventListSortButton
               onSort={onSort}

--- a/src/features/events_list/helpers/localEventFilters.test.ts
+++ b/src/features/events_list/helpers/localEventFilters.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterByEventTypes,
+  filterByCountry,
+  filterByMaxStartedAt,
+  filterByMaxUpdatedAt,
+} from './localEventFilters';
+import type { Event } from '~core/types';
+
+const sampleEvents: Event[] = [
+  {
+    eventId: '1',
+    eventName: 'Flood in USA',
+    location: 'United States',
+    severity: 'SEVERE',
+    affectedPopulation: 0,
+    settledArea: 0,
+    osmGaps: 0,
+    startedAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-05T00:00:00Z',
+    externalUrls: [],
+    bbox: [0, 0, 0, 0],
+    episodeCount: 1,
+    eventType: 'FLOOD',
+  },
+  {
+    eventId: '2',
+    eventName: 'Storm in Canada',
+    location: 'Canada',
+    severity: 'MINOR',
+    affectedPopulation: 0,
+    settledArea: 0,
+    osmGaps: 0,
+    startedAt: '2024-02-01T00:00:00Z',
+    updatedAt: '2024-02-10T00:00:00Z',
+    externalUrls: [],
+    bbox: [0, 0, 0, 0],
+    episodeCount: 1,
+    eventType: 'STORM',
+  },
+];
+
+describe('localEventFilters', () => {
+  it('filters by event types', () => {
+    const result = filterByEventTypes(sampleEvents, ['FLOOD']);
+    expect(result.length, 'filterByEventTypes should keep only FLOOD events').toBe(1);
+    expect(result[0].eventId, 'filterByEventTypes should return eventId 1').toBe('1');
+  });
+
+  it('filters by country', () => {
+    const result = filterByCountry(sampleEvents, 'can');
+    expect(
+      result.length,
+      'filterByCountry should match country substring case-insensitively',
+    ).toBe(1);
+    expect(result[0].eventId, 'filterByCountry should return eventId 2').toBe('2');
+  });
+
+  it('filters by max startedAt', () => {
+    const result = filterByMaxStartedAt(sampleEvents, '2024-01-15');
+    expect(
+      result.length,
+      'filterByMaxStartedAt should exclude events after the max date',
+    ).toBe(1);
+    expect(result[0].eventId, 'filterByMaxStartedAt should return eventId 1').toBe('1');
+  });
+
+  it('filters by max updatedAt', () => {
+    const result = filterByMaxUpdatedAt(sampleEvents, '2024-01-31');
+    expect(
+      result.length,
+      'filterByMaxUpdatedAt should exclude events updated after the max date',
+    ).toBe(1);
+    expect(result[0].eventId, 'filterByMaxUpdatedAt should return eventId 1').toBe('1');
+  });
+});

--- a/src/features/events_list/helpers/localEventFilters.ts
+++ b/src/features/events_list/helpers/localEventFilters.ts
@@ -33,6 +33,22 @@ export function filterByMinStartedAt(events: Event[], minDateString: string): Ev
   return events;
 }
 
+export function filterByMaxUpdatedAt(events: Event[], maxDateString: string): Event[] {
+  const maxTime = new Date(maxDateString).getTime();
+  if (maxTime) {
+    return filterByMaxTime(events, maxTime, (event) => event.updatedAt);
+  }
+  return events;
+}
+
+export function filterByMaxStartedAt(events: Event[], maxDateString: string): Event[] {
+  const maxTime = new Date(maxDateString).getTime();
+  if (maxTime) {
+    return filterByMaxTime(events, maxTime, (event) => event.startedAt);
+  }
+  return events;
+}
+
 export function filterByMinAffectedPopulation(
   events: Event[],
   minAffectedPopulation: number,
@@ -72,6 +88,25 @@ export function filterByExcludedEventTypes(
   return events;
 }
 
+export function filterByEventTypes(events: Event[], eventTypes: EventType[]): Event[] {
+  if (eventTypes.length > 0) {
+    return events.filter((event) => {
+      if (event.eventType) {
+        return eventTypes.includes(event.eventType);
+      }
+    });
+  }
+  return events;
+}
+
+export function filterByCountry(events: Event[], country: string): Event[] {
+  if (country) {
+    const lc = country.toLowerCase();
+    return events.filter((event) => event.location?.toLowerCase().includes(lc));
+  }
+  return events;
+}
+
 function filterByMinTime(
   events: Event[],
   minTimeMs: number,
@@ -80,6 +115,18 @@ function filterByMinTime(
   return events.filter((event) => {
     return (
       fieldExtractor(event) && new Date(fieldExtractor(event)).getTime() >= minTimeMs
+    );
+  });
+}
+
+function filterByMaxTime(
+  events: Event[],
+  maxTimeMs: number,
+  fieldExtractor: (event: Event) => string,
+): Event[] {
+  return events.filter((event) => {
+    return (
+      fieldExtractor(event) && new Date(fieldExtractor(event)).getTime() <= maxTimeMs
     );
   });
 }

--- a/src/features/events_list/readme.md
+++ b/src/features/events_list/readme.md
@@ -110,6 +110,24 @@ It has the following actions:
 - `setBBoxFilterFromCurrentMapView`
 - `resetBboxFilter`
 
+# `localEventFiltersAtom`
+
+`localEventFiltersAtom` holds filters applied on the client side. Available fields:
+
+```typescript
+{
+  eventTypes?: EventType[];
+  minSeverity?: Severity;
+  minStartedAt?: string;
+  maxStartedAt?: string;
+  minUpdatedAt?: string;
+  maxUpdatedAt?: string;
+  country?: string;
+}
+```
+
+These filters allow narrowing disasters by type, date range, severity threshold and country.
+
 # Feature config
 
 `initialSort` is an optional field which can hold front-end side sorting configuration.

--- a/src/features/events_list/types.ts
+++ b/src/features/events_list/types.ts
@@ -4,10 +4,14 @@ import type { EventSortConfig } from './atoms/eventSortingConfig';
 // event filters applied on front-end side
 export type LocalEventListFilters = {
   excludedEventTypes?: EventType[];
+  eventTypes?: EventType[];
   minAffectedPopulation?: number;
   minSeverity?: Severity;
   minStartedAt?: string;
+  maxStartedAt?: string;
   minUpdatedAt?: string;
+  maxUpdatedAt?: string;
+  country?: string;
   // minUpdatedAt has priority
   lastNDaysUpdatedAt?: number;
   // minStartedAt has priority


### PR DESCRIPTION
## Summary
- allow filtering disasters by type, date range, severity, and country
- wire filters into events panel settings
- document and test new filter helpers

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688f38e60ce4832fa75ca40375779a63