### PR TITLE
fix(legend): replace outline circles with lines

### DIFF
--- a/src/components/SimpleLegend/SimpleLegend.test.tsx
+++ b/src/components/SimpleLegend/SimpleLegend.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@konturio/ui-kit', () => ({
+  Text: ({ children }) => <span>{children}</span>,
+}));
+
+import { SimpleLegendStep } from './SimpleLegend';
+
+describe('SimpleLegendStep', () => {
+  it.each([
+    ['Active mappers', '#ff0000'],
+    ['Possibly local mappers', '#00ff00'],
+  ])('shows Figma letter icon with matching color for %s', (stepName, color) => {
+    const step = {
+      stepName,
+      stepShape: 'letter',
+      style: { 'text-color': color },
+    } as any;
+    const { container } = render(<SimpleLegendStep step={step} />);
+    const svg = container.querySelector('svg');
+    const path = svg?.querySelector('path');
+    expect(svg, `${stepName} should render letter icon`).not.toBeNull();
+    expect(
+      path?.getAttribute('d')?.startsWith('M6 6H18V9.08508H16.769V8.53835'),
+      `${stepName} should use Figma letter icon path`,
+    ).toBe(true);
+    expect(
+      svg?.getAttribute('style') || '',
+      `${stepName} letter icon color should match legend text color ${color}`,
+    ).toContain(color);
+  });
+});

--- a/src/components/SimpleLegend/SimpleLegend.tsx
+++ b/src/components/SimpleLegend/SimpleLegend.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@konturio/ui-kit';
+import Letter from '@konturio/default-icons/tslib/figma-icons/Letter.js';
 import { HexIcon } from '~components/SimpleLegend/icons/HexIcon';
 import { CircleIcon } from '~components/SimpleLegend/icons/CircleIcon';
 import { SquareIcon } from '~components/SimpleLegend/icons/SquareIcon';
@@ -8,19 +9,36 @@ import type { CSSProperties } from 'react';
 
 type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;
 
-function icon(
-  type: string,
-  styles: Flatten<SimpleLegendType['steps']>['style'],
-  fill?: string,
-  stroke?: string,
-) {
-  if (!type) return null;
-  if (type === 'hex')
-    return <HexIcon styles={styles} size="small" fill={fill} stroke={stroke} />;
-  if (type === 'circle')
-    return <CircleIcon styles={styles} size="small" fill={fill} stroke={stroke} />;
-  if (type === 'square')
-    return <SquareIcon styles={styles} size="normal" fill={fill} stroke={stroke} />;
+function icon(step: Flatten<SimpleLegendType['steps']>) {
+  const { stepShape, style, stepIconFill, stepIconStroke } = step;
+
+  if (!stepShape) return null;
+  if (stepShape === 'letter') {
+    const color = style['text-color'] || '#000000';
+    return <Letter width={12} height={12} style={{ color }} />;
+  }
+  if (stepShape === 'hex')
+    return (
+      <HexIcon styles={style} size="small" fill={stepIconFill} stroke={stepIconStroke} />
+    );
+  if (stepShape === 'circle')
+    return (
+      <CircleIcon
+        styles={style}
+        size="small"
+        fill={stepIconFill}
+        stroke={stepIconStroke}
+      />
+    );
+  if (stepShape === 'square')
+    return (
+      <SquareIcon
+        styles={style}
+        size="normal"
+        fill={stepIconFill}
+        stroke={stepIconStroke}
+      />
+    );
 }
 
 export function SimpleLegendStep({
@@ -37,7 +55,7 @@ export function SimpleLegendStep({
 
   return (
     <div className={s.legendStep}>
-      {icon(step.stepShape, step.style, step.stepIconFill, step.stepIconStroke)}
+      {icon(step)}
       {!onlyIcon && (
         <Text type="caption">
           <span className={s.stepName} style={style}>

--- a/src/components/SimpleLegend/icons/CircleIcon.test.tsx
+++ b/src/components/SimpleLegend/icons/CircleIcon.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { CircleIcon } from './CircleIcon';
+
+describe('CircleIcon', () => {
+  it('renders horizontal line when no fill color provided', () => {
+    const { container } = render(
+      <CircleIcon styles={{ width: 4 } as any} size="normal" />,
+    );
+    const line = container.querySelector('line');
+    expect(line, 'CircleIcon without fill should render line element').not.toBeNull();
+    const circle = container.querySelector('circle');
+    expect(circle, 'CircleIcon without fill should not render circle element').toBeNull();
+  });
+});

--- a/src/components/SimpleLegend/icons/CircleIcon.tsx
+++ b/src/components/SimpleLegend/icons/CircleIcon.tsx
@@ -17,6 +17,14 @@ export function CircleIcon({
   fill?: string;
   stroke?: string;
 }) {
+  const fillColor = fill || styles['fill-color'] || styles['circle-color'] || 'none';
+  const strokeColor =
+    stroke ||
+    styles['circle-stroke-color'] ||
+    styles.color ||
+    styles['circle-color'] ||
+    '#000000';
+
   return (
     <svg
       width={sizes[size]}
@@ -26,20 +34,25 @@ export function CircleIcon({
       xmlns="http://www.w3.org/2000/svg"
       className={className}
     >
-      <circle
-        cx="9"
-        cy="9"
-        r="7"
-        fill={fill || styles['fill-color'] || styles['circle-color'] || 'none'}
-        stroke={
-          stroke ||
-          styles['circle-stroke-color'] ||
-          styles.color ||
-          styles['circle-color'] ||
-          '#000000'
-        }
-        strokeWidth={styles.width ?? 4}
-      />
+      {fillColor === 'none' ? (
+        <line
+          x1="2"
+          y1="9"
+          x2="16"
+          y2="9"
+          stroke={strokeColor}
+          strokeWidth={styles.width ?? 4}
+        />
+      ) : (
+        <circle
+          cx="9"
+          cy="9"
+          r="7"
+          fill={fillColor}
+          stroke={strokeColor}
+          strokeWidth={styles.width ?? 4}
+        />
+      )}
     </svg>
   );
 }

--- a/src/core/logical_layers/types/legends.ts
+++ b/src/core/logical_layers/types/legends.ts
@@ -1,7 +1,7 @@
 import type { MultivariateLayerConfig } from '../renderers/MultivariateRenderer/types';
 import type { Axis } from '~utils/bivariate';
 
-type SimpleLegendStepType = 'square' | 'circle' | 'hex';
+type SimpleLegendStepType = 'square' | 'circle' | 'hex' | 'letter';
 interface MapCSSProperties {
   [key: string]: any;
   // Add bivariate steps


### PR DESCRIPTION
## Summary
- render horizontal line instead of outline circle in legend when no fill color
- support new "letter" legend step type to render Figma Letter icon colored via `text-color`
- color Figma letter icon directly from legend text color so it matches the label

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688f389ee554832f805700390345f36c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "letter" icon type in legends, allowing legend steps to display a letter icon with customizable color.
  * Circle icons in legends now display a horizontal line instead of a circle when no fill color is provided.

* **Tests**
  * Introduced new tests for both the SimpleLegendStep and CircleIcon components to ensure correct rendering and behavior for various icon types and styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->