### PR TITLE
feat(layers): show disaster name for event shape layer

### DIFF
--- a/src/features/layers_in_area/atoms/areaLayersControls.test.ts
+++ b/src/features/layers_in_area/atoms/areaLayersControls.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { renameEventShapeLayer } from './renameEventShapeLayer';
+import type { LayerSummaryDto } from '~core/logical_layers/types/source';
+
+describe('renameEventShapeLayer', () => {
+  test('replaces Event shape layer name with eventName', () => {
+    const layers: LayerSummaryDto[] = [
+      {
+        id: 'eventShape',
+        name: 'Event shape',
+        boundaryRequiredForRetrieval: false,
+        ownedByUser: false,
+      },
+      {
+        id: 'otherLayer',
+        name: 'Other',
+        boundaryRequiredForRetrieval: false,
+        ownedByUser: false,
+      },
+    ];
+
+    const renamed = renameEventShapeLayer(layers, 'Flood');
+    const eventLayer = renamed.find((l) => l.id === 'eventShape');
+    expect(eventLayer?.name, 'Event layer name should match provided eventName').toBe(
+      'Flood',
+    );
+  });
+
+  test('returns original layers when eventName absent', () => {
+    const layers: LayerSummaryDto[] = [
+      {
+        id: 'eventShape',
+        name: 'Event shape',
+        boundaryRequiredForRetrieval: false,
+        ownedByUser: false,
+      },
+    ];
+
+    const renamed = renameEventShapeLayer(layers, undefined);
+    expect(renamed, 'Layers should remain unchanged').toEqual(layers);
+  });
+});

--- a/src/features/layers_in_area/atoms/areaLayersControls.ts
+++ b/src/features/layers_in_area/atoms/areaLayersControls.ts
@@ -2,8 +2,10 @@ import { createAtom } from '~utils/atoms/createPrimitives';
 import { layersRegistryAtom } from '~core/logical_layers/atoms/layersRegistry';
 import { getLayerRenderer } from '~core/logical_layers/utils/getLayerRenderer';
 import { createUpdateActionsFromLayersDTO } from '~core/logical_layers/utils/createUpdateActionsFromLayersDTO';
+import { currentEventResourceAtom } from '~core/shared_state/currentEventResource';
 import { layersInAreaAndEventLayerResource } from './layersInAreaAndEventLayerResource';
 import { layersGlobalResource } from './layersGlobalResource';
+import { renameEventShapeLayer } from './renameEventShapeLayer';
 import type { LayerSummaryDto } from '~core/logical_layers/types/source';
 import type { Action } from '@reatom/core-v2';
 
@@ -11,12 +13,15 @@ const allLayers = createAtom(
   {
     layersGlobalResource,
     layersInAreaAndEventLayerResource,
+    currentEventResourceAtom,
   },
   ({ get }) => {
-    return [
+    const layers = [
       ...(get('layersGlobalResource').data ?? []),
       ...(get('layersInAreaAndEventLayerResource').data ?? []),
     ];
+    const eventName = get('currentEventResourceAtom').data?.eventName;
+    return renameEventShapeLayer(layers, eventName);
   },
   'allLayers',
 );

--- a/src/features/layers_in_area/atoms/renameEventShapeLayer.ts
+++ b/src/features/layers_in_area/atoms/renameEventShapeLayer.ts
@@ -1,0 +1,10 @@
+import type { LayerSummaryDto } from '~core/logical_layers/types/source';
+
+export const EVENT_SHAPE_LAYER_ID = 'eventShape';
+
+export function renameEventShapeLayer(layers: LayerSummaryDto[], eventName?: string) {
+  if (!eventName) return layers;
+  return layers.map((layer) =>
+    layer.id === EVENT_SHAPE_LAYER_ID ? { ...layer, name: eventName } : layer,
+  );
+}


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Add-disaster-type-and-name-into-Event-shape-12523

## Summary
- replace static Event shape label with selected disaster's name
- test name replacement helper

## Testing
- `pnpm lint`
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688fd0e40478832fa01d66ce3b13e1b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The name of the "Event shape" layer now dynamically updates to reflect the current event name, providing clearer context when viewing layers.

* **Tests**
  * Added unit tests to ensure the correct renaming behavior of the event shape layer and to verify stability when no event name is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->