### PR TITLE
feat(event-episodes): select current episode and zoom timeline

### DIFF
--- a/src/features/event_episodes/components/EpisodesTimeline/EpisodesTimeline.test.tsx
+++ b/src/features/event_episodes/components/EpisodesTimeline/EpisodesTimeline.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+import { createStore } from '@reatom/core-v2';
+import { reatomContext } from '@reatom/react-v2';
+import { vi, test, expect } from 'vitest';
+import { currentEpisodeAtom } from '../../../../core/shared_state';
+import { EpisodesTimeline } from './EpisodesTimeline';
+import type { Episode } from '~core/types';
+
+const focus = vi.fn();
+const setSelection = vi.fn();
+
+vi.mock('@konturio/ui-kit', () => ({
+  Timeline: forwardRef((_props: any, ref) => {
+    useImperativeHandle(ref, () => ({ focus, setSelection }));
+    return <div data-testid="timeline" />;
+  }),
+}));
+
+test('focuses timeline on current episode and selects it', async () => {
+  const episodes: Episode[] = [
+    {
+      id: '1',
+      name: 'ep',
+      externalUrls: [],
+      severity: '',
+      startedAt: '2024-01-01T00:00:00Z',
+      endedAt: '2024-01-01T01:00:00Z',
+      updatedAt: '2024-01-01T01:00:00Z',
+      geojson: { type: 'FeatureCollection', features: [] },
+      location: '',
+      forecasted: false,
+    },
+  ];
+
+  const store = createStore();
+
+  render(
+    <reatomContext.Provider value={store}>
+      <EpisodesTimeline episodes={episodes} />
+    </reatomContext.Provider>,
+  );
+
+  act(() => {
+    store.dispatch(currentEpisodeAtom.set('1'));
+  });
+
+  await waitFor(() => {
+    expect(
+      setSelection,
+      'timeline selection should include current episode id 1',
+    ).toHaveBeenCalledWith(['1']);
+  });
+  await waitFor(() => {
+    expect(focus, 'timeline should focus on current episode id 1').toHaveBeenCalledWith(
+      '1',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- zoom timeline to currently selected episode and keep selection synced
- add unit test for timeline focusing

## Testing
- `make precommit` (fails: No rule to make target 'precommit')
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_688fd2defa10832fb1c10b1fb934ea9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify that the EpisodesTimeline component correctly focuses and selects the current episode in the timeline.

* **Bug Fixes**
  * Improved synchronization between the selected episode and the timeline display to ensure the correct episode is focused and selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->