### PR TITLE
feat(draw-tools): add undo redo hotkeys

### DIFF
--- a/src/core/draw_tools/atoms/drawHistoryAtom.ts
+++ b/src/core/draw_tools/atoms/drawHistoryAtom.ts
@@ -1,0 +1,85 @@
+import { createAtom } from '~utils/atoms';
+import { deepCopy } from '~core/logical_layers/utils/deepCopy';
+import { drawnGeometryAtom } from './drawnGeometryAtom';
+import { activeDrawModeAtom } from './activeDrawMode';
+import type { FeatureCollection } from 'geojson';
+
+interface HistoryState {
+  past: FeatureCollection[];
+  future: FeatureCollection[];
+  ignore: boolean;
+}
+
+const defaultState: HistoryState = {
+  past: [],
+  future: [],
+  ignore: false,
+};
+
+export const drawHistoryAtom = createAtom(
+  {
+    drawnGeometryAtom,
+    activeDrawModeAtom,
+    undo: () => null,
+    redo: () => null,
+    reset: () => null,
+  },
+  (
+    { onChange, onAction, schedule, getUnlistedState },
+    state: HistoryState = defaultState,
+  ) => {
+    onChange('activeDrawModeAtom', (mode, prevMode) => {
+      if (mode && !prevMode) {
+        state = { ...defaultState, ignore: true };
+      } else if (!mode && prevMode) {
+        state = defaultState;
+      }
+    });
+
+    onChange('drawnGeometryAtom', (_current, prev) => {
+      if (state.ignore) {
+        state = { ...state, ignore: false };
+        return;
+      }
+      state = {
+        past: [...state.past, deepCopy(prev)],
+        future: [],
+        ignore: false,
+      };
+    });
+
+    onAction('undo', () => {
+      if (!state.past.length) return;
+      const past = [...state.past];
+      const previous = past.pop()!;
+      const current = getUnlistedState(drawnGeometryAtom);
+      state = {
+        past,
+        future: [deepCopy(current), ...state.future],
+        ignore: true,
+      };
+      schedule((dispatch) => dispatch(drawnGeometryAtom.setFeatures(previous.features)));
+    });
+
+    onAction('redo', () => {
+      if (!state.future.length) return;
+      const [next, ...restFuture] = state.future;
+      const current = getUnlistedState(drawnGeometryAtom);
+      state = {
+        past: [...state.past, deepCopy(current)],
+        future: restFuture,
+        ignore: true,
+      };
+      schedule((dispatch) => dispatch(drawnGeometryAtom.setFeatures(next.features)));
+    });
+
+    onAction('reset', () => {
+      state = defaultState;
+    });
+
+    return state;
+  },
+  'drawHistoryAtom',
+);
+
+export type DrawHistoryAtom = typeof drawHistoryAtom;

--- a/src/core/draw_tools/index.ts
+++ b/src/core/draw_tools/index.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { useAtom } from '@reatom/react-v2';
 import { store } from '~core/store/store';
 import { i18n } from '~core/localization';
@@ -10,6 +10,7 @@ import { activeDrawModeAtom } from './atoms/activeDrawMode';
 import { drawModes } from './constants';
 import { setIndexesForCurrentGeometryAtom } from './atoms/selectedIndexesAtom';
 import { drawnGeometryAtom } from './atoms/drawnGeometryAtom';
+import { drawHistoryAtom } from './atoms/drawHistoryAtom';
 import { convertToFeatures } from './convertToFeatures';
 import { toolboxAtom } from './atoms/toolboxAtom';
 import type { DrawToolController, DrawToolsController, DrawToolsHook } from './types';
@@ -117,6 +118,19 @@ export const useDrawTools: DrawToolsHook = () => {
       cancelDrawing,
     },
   ] = useAtom(toolboxAtom);
+
+  useEffect(() => {
+    if (!activeDrawMode) return;
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      if (e.key.toLowerCase() !== 'z') return;
+      e.preventDefault();
+      if (e.shiftKey) store.dispatch(drawHistoryAtom.redo());
+      else store.dispatch(drawHistoryAtom.undo());
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [activeDrawMode]);
 
   const controls = useMemo(() => {
     const controlsArray: Array<DrawToolController> =


### PR DESCRIPTION
## Summary
- enable geometry undo/redo history
- wire up Ctrl/Cmd+Z and Shift+Ctrl/Cmd+Z hotkeys for draw tools

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688fd28efb20832f904da092baf70311