### PR TITLE
fix(MCDA, MVA): 22397 fix layer style and popup values for non normalized mcda

### DIFF
--- a/src/core/logical_layers/renderers/MCDARenderer/popup.ts
+++ b/src/core/logical_layers/renderers/MCDARenderer/popup.ts
@@ -1,8 +1,5 @@
 import { sumBy } from '~utils/common';
-import {
-  calculateLayerPipeline,
-  inViewCalculations,
-} from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations';
+import { calculateLayerPipeline } from '~core/logical_layers/renderers/stylesConfigs/mcda/calculations';
 import { PopupMCDA } from './components/PopupMCDA';
 import type { PopupMCDAProps } from './types';
 import type { MCDAConfig } from '~core/logical_layers/renderers/stylesConfigs/mcda/types';
@@ -11,7 +8,7 @@ function createTableWithCalculations(
   feature: GeoJSON.Feature,
   layers: MCDAConfig['layers'],
 ) {
-  const calculateLayer = calculateLayerPipeline(inViewCalculations, ({ num, den }) => ({
+  const calculateLayer = calculateLayerPipeline('view', ({ num, den }) => ({
     num: feature.properties?.[num],
     den: feature.properties?.[den],
   }));

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/calculateLayerPipeline.test.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/calculateLayerPipeline.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { test, describe, expect } from 'vitest';
 import papa from 'papaparse';
 import * as dot from 'dot-object';
-import { calculateLayerPipeline, inViewCalculations } from '.';
+import { calculateLayerPipeline } from '.';
 import type { MCDALayer, TransformationFunction } from '../types';
 
 const PRECISION = 0.0000000001;
@@ -16,7 +16,7 @@ describe('mcda calculations', async () => {
   jsonResult.forEach((testEntry) => {
     test(`${testEntry.testId}: ${testEntry.description}`, () => {
       expect(testEntry.description).toBeTruthy();
-      const calculateNumber = calculateLayerPipeline(inViewCalculations, () => ({
+      const calculateNumber = calculateLayerPipeline('view', () => ({
         num: testEntry.value.numerator,
         den: testEntry.value.denominator,
       }));

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/calculations.test.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/calculations.test.ts
@@ -1,10 +1,11 @@
 import { test, expect } from 'vitest';
-import { calculateLayerPipeline, inStyleCalculations } from '.';
+import { calculateLayerPipeline } from '.';
 import type { MCDALayer } from '../types';
 
-// @ts-expect-error types compatibility
-const calculateLayerStyle = calculateLayerPipeline(inStyleCalculations, (axis) => ({
+const calculateLayerStyle = calculateLayerPipeline('layerStyle', (axis) => ({
+  // @ts-expect-error types compatibility
   num: ['get', axis.num],
+  // @ts-expect-error types compatibility
   den: ['get', axis.den],
 }));
 

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/calculations.test.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/calculations.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import { calculateLayerPipeline, inStyleCalculations, inViewCalculations } from '.';
+import { calculateLayerPipeline, inStyleCalculations } from '.';
 import type { MCDALayer } from '../types';
 
 // @ts-expect-error types compatibility
@@ -20,12 +20,12 @@ test('style correct for bad good sentiments', () => {
   expect(result).toMatchSnapshot();
 });
 
-const calculateNumber = calculateLayerPipeline(inViewCalculations, (axis) => ({
+const calculateNumber = calculateLayerPipeline('view', (axis) => ({
   num: 10,
   den: 1,
 }));
 
-const calculateNegativeNumber = calculateLayerPipeline(inViewCalculations, (axis) => ({
+const calculateNegativeNumber = calculateLayerPipeline('view', (axis) => ({
   num: -10,
   den: 1,
 }));

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
@@ -245,10 +245,11 @@ export const calculateLayerPipeline =
         tX = operations.clamp(tX, tMin, tMax);
       }
     }
-    // always normalize for map style - we need to have (0..1) values for proper colors interpolation
-    let normalized = operations.normalize({ x: tX, min: tMin, max: tMax });
-    if (type === 'view' && normalization === 'no') {
-      normalized = tX;
+    let normalized = tX;
+    if (normalization === 'max-min' || type === 'layerStyle') {
+      // always apply min-max normalization for layer style,
+      // because we need to have (0..1) values in expressions for proper colors interpolation
+      normalized = operations.normalize({ x: tX, min: tMin, max: tMax });
     }
     let oriented = inverted ? operations.invert(normalized) : normalized;
     if (type === 'view' && normalization === 'no') {

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -8,7 +8,7 @@ import {
 } from '~utils/bivariate/bivariate_style/styleGen';
 import { sumBy } from '~utils/common';
 import { DEFAULT_GREEN, DEFAULT_RED } from './calculations/constants';
-import { calculateLayerPipeline, inStyleCalculations } from './calculations';
+import { calculateLayerPipeline } from './calculations';
 import { SOURCE_LAYER_MCDA } from './constants';
 import type {
   ExpressionSpecification,
@@ -17,9 +17,10 @@ import type {
 } from 'maplibre-gl';
 import type { ColorsByMapLibreExpression, MCDAConfig } from './types';
 
-//@ts-expect-error - not clear how to type this right, but this compromise do the trick
-export const calculateMCDALayer = calculateLayerPipeline(inStyleCalculations, (axis) => ({
+export const calculateMCDALayer = calculateLayerPipeline('layerStyle', (axis) => ({
+  // @ts-expect-error - need to fix calculateLayerPipeline typing
   num: ['get', axis.num],
+  // @ts-expect-error - need to fix calculateLayerPipeline typing
   den: ['get', axis.den],
 }));
 

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -78,7 +78,7 @@ type PaintProps = {
 };
 
 // in order for sentiment paint to work properly, its mcdaResult must be normalized
-// (popups can show non-normalized values, but colors must always work with min-max normalization)
+// (colors must always work with [0; 1] min-max normalization)
 function sentimentPaint({
   colorsConfig,
   mcdaResult,


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Fix-layer-style-and-popup-values-for-non-normalized-MCDA-22397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined calculation logic by passing string identifiers instead of calculation objects to relevant functions.
  * Updated function signatures for improved clarity and consistency.
  * Adjusted normalization and inversion logic for more predictable behavior.
  * Simplified sentiment color mapping to always use normalized values between 0 and 1.

* **Tests**
  * Updated tests to align with the new function signatures and calculation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->