### PR TITLE
feat(MVA): 22394 make static opacity an independent property

### DIFF
--- a/src/core/logical_layers/renderers/MultivariateRenderer/MultivariateRenderer.tsx
+++ b/src/core/logical_layers/renderers/MultivariateRenderer/MultivariateRenderer.tsx
@@ -10,7 +10,7 @@ import {
 import { generateMultivariatePopupContent } from './popup';
 import { createTextLayerSpecification } from './helpers/createTextLayerSpecification';
 import { createExtrusionLayerSpecification } from './helpers/createExtrusionLayerSpecification';
-import type { ExtrusionDimension, OpacityDimension, TextDimension } from './types';
+import type { ExtrusionDimension, TextDimension } from './types';
 import type { FilterSpecification, LayerSpecification } from 'maplibre-gl';
 import type { LayerTileSource } from '~core/logical_layers/types/source';
 import type { ApplicationMap } from '~components/ConnectedMap/ConnectedMap';
@@ -57,7 +57,7 @@ export class MultivariateRenderer extends ClickableFeaturesRenderer {
     extrusionDimension: ExtrusionDimension,
     mainLayerId: string,
     mainLayerSpecification: LayerSpecification,
-    opacityDimension?: OpacityDimension,
+    staticOpacity?: number,
   ) {
     const extrusionLayerId = mainLayerId + EXTRUSION_POSTFIX;
 
@@ -70,7 +70,7 @@ export class MultivariateRenderer extends ClickableFeaturesRenderer {
       mainLayerSpecification,
       filter,
       // Extrusion layers in Maplibre don't support opacity expressions
-      isNumber(opacityDimension) ? opacityDimension : undefined,
+      staticOpacity,
     );
 
     layerByOrder(map, this._layersOrderManager).addAboveLayerWithSameType(
@@ -106,7 +106,7 @@ export class MultivariateRenderer extends ClickableFeaturesRenderer {
           style.config.extrusion,
           layerId,
           mainLayerSpec,
-          style.config.opacity,
+          style.config.staticOpacity,
         );
       }
       this._layerId = layerId;

--- a/src/core/logical_layers/renderers/MultivariateRenderer/types.ts
+++ b/src/core/logical_layers/renderers/MultivariateRenderer/types.ts
@@ -9,9 +9,6 @@ import type {
 
 export type MultivariateDimension = MCDALayerStyle;
 
-// TODO: make static opacity a separate property.
-export type OpacityDimension = MultivariateDimension | number;
-
 export type TextDimension = {
   expressionValue?: ExpressionSpecification;
   mcdaValue?: MultivariateDimension;
@@ -50,8 +47,9 @@ export interface MultivariateLayerConfig {
   score?: MultivariateDimension;
   base?: MultivariateDimension;
   stepOverrides?: MultivariateStepOverrides;
-  opacity?: OpacityDimension;
+  opacity?: MultivariateDimension;
   text?: TextDimension;
   extrusion?: ExtrusionDimension;
   colors?: MultivariateColorConfig;
+  staticOpacity?: number;
 }

--- a/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
+++ b/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
@@ -81,10 +81,7 @@ export function MultivariateAnalysisForm({
   const [dimensionsLayers, setDimensionsLayers] = useState<MVAFormDimensions>({
     score: initialConfig?.score?.config.layers ?? [],
     compare: initialConfig?.base?.config.layers ?? [],
-    opacity:
-      initialConfig?.opacity && !isNumber(initialConfig?.opacity)
-        ? initialConfig?.opacity?.config.layers
-        : [],
+    opacity: initialConfig?.opacity?.config.layers ?? [],
     text: initialConfig?.text?.mcdaValue?.config.layers ?? [],
     extrusion: initialConfig?.extrusion?.height?.config.layers ?? [],
   });
@@ -100,7 +97,7 @@ export function MultivariateAnalysisForm({
   const buttonsRowRef = useRef<HTMLDivElement>(null);
 
   const [opacityStatic, setOpacityStatic] = useState(
-    isNumber(initialConfig?.opacity) ? initialConfig?.opacity?.toString() : undefined,
+    initialConfig?.staticOpacity ? String(initialConfig?.staticOpacity) : undefined,
   );
   const [extrusionMaxHeight, setExtrusionMaxHeight] = useState(
     initialConfig?.extrusion?.maxHeight?.toString() ??
@@ -144,17 +141,10 @@ export function MultivariateAnalysisForm({
       (dimensionsLayers.score.length > 0 ||
         dimensionsLayers.compare.length > 0 ||
         dimensionsLayers.opacity.length > 0 ||
-        opacityStatic !== undefined ||
         dimensionsLayers.extrusion.length > 0 ||
         dimensionsLayers.text.length > 0) &&
       ((isCustomStepsChecked && !customStepsErrors) || !isCustomStepsChecked),
-    [
-      axesResource.data,
-      customStepsErrors,
-      dimensionsLayers,
-      opacityStatic,
-      isCustomStepsChecked,
-    ],
+    [axesResource.data, customStepsErrors, dimensionsLayers, isCustomStepsChecked],
   );
 
   const previewConfig = useMemo(() => {
@@ -181,18 +171,18 @@ export function MultivariateAnalysisForm({
         ),
       };
     }
-    // mcda opacity takes precedence
-    let opacity: number | MCDALayer[] | undefined = dimensionsLayers.opacity;
-    if (!opacity.length && opacityStatic !== undefined) {
-      opacity = parseFloat(opacityStatic);
-      if (!isNumber(opacity)) {
-        opacity = undefined;
-      } else if (opacity > 1) {
-        opacity = 1;
-      } else if (opacity < 0) {
-        opacity = 0;
+
+    let staticOpacityNum: number | undefined = parseFloat(opacityStatic ?? '');
+    if (!isNumber(staticOpacityNum)) {
+      staticOpacityNum = undefined;
+    } else {
+      if (staticOpacityNum > 1) {
+        staticOpacityNum = 1;
+      } else if (staticOpacityNum < 0) {
+        staticOpacityNum = 0;
       }
     }
+
     const text: MCDALayer[] | undefined = dimensionsLayers.text;
     return isConfigValid
       ? createMultivariateConfig({
@@ -204,7 +194,8 @@ export function MultivariateAnalysisForm({
               ? initialConfig?.colors
               : undefined,
           stepOverrides,
-          opacity: opacity,
+          opacity: dimensionsLayers.opacity,
+          staticOpacity: staticOpacityNum,
           text,
           textSettings: {
             ...initialConfig?.text,
@@ -493,7 +484,7 @@ export function MultivariateAnalysisForm({
                 topControls={getTopControlsForDimension(dimensionKey)}
               />
             ))}
-          {previewConfig && !dimensionsLayers['opacity'].length && (
+          {previewConfig && (
             <div className={clsx(s.shortInput, s.staticOpacity)}>
               <Input
                 type="text"

--- a/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
+++ b/src/features/multivariate_layer/components/MultivariateAnalysisForm/MultivariateAnalysisForm.tsx
@@ -97,7 +97,9 @@ export function MultivariateAnalysisForm({
   const buttonsRowRef = useRef<HTMLDivElement>(null);
 
   const [opacityStatic, setOpacityStatic] = useState(
-    initialConfig?.staticOpacity ? String(initialConfig?.staticOpacity) : undefined,
+    isNumber(initialConfig?.staticOpacity)
+      ? String(initialConfig?.staticOpacity)
+      : undefined,
   );
   const [extrusionMaxHeight, setExtrusionMaxHeight] = useState(
     initialConfig?.extrusion?.maxHeight?.toString() ??

--- a/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
+++ b/src/features/multivariate_layer/helpers/createMultivariateConfig.ts
@@ -11,9 +11,7 @@ import {
   DEFAULT_MULTIVARIATE_TEXT_PRECISION,
 } from '../constants';
 import { generateMultivariateId } from './generateMultivariateId';
-import { createStepsForMCDADimension } from './createStepsForMCDADimension';
 import { createBivariateColorsForMVA } from './createBivariateColorsForMVA';
-import type { Axis } from '~utils/bivariate';
 import type {
   MCDALayer,
   MCDALayerStyle,
@@ -30,7 +28,8 @@ type MultivariateLayerConfigOverrides = {
   base?: MCDALayer[];
   colors?: MultivariateColorConfig;
   stepOverrides?: MultivariateLayerConfig['stepOverrides'];
-  opacity?: MCDALayer[] | number;
+  opacity?: MCDALayer[];
+  staticOpacity?: number;
   text?: MCDALayer[];
   textSettings?: Exclude<TextDimension, 'mcdaValue' | 'mcdaMode'>;
   extrusion?: MCDALayer[];
@@ -96,9 +95,6 @@ export function createMultivariateConfig(
         mcdaValue: textMCDAStyle,
       }
     : undefined;
-  const opacityStatic: number | undefined = isNumber(overrides.opacity)
-    ? overrides.opacity
-    : undefined;
 
   const extrusionMCDAStyle: MCDALayerStyle | undefined = hasExtrusion
     ? {
@@ -116,7 +112,8 @@ export function createMultivariateConfig(
     name,
     score: scoreMCDAStyle,
     base: baseMCDAStyle,
-    opacity: opacityMCDAStyle ?? opacityStatic,
+    opacity: opacityMCDAStyle,
+    staticOpacity: overrides.staticOpacity,
     text: textDimension,
     stepOverrides: isBivariateStyleLegend ? overrides.stepOverrides : undefined,
     colors:


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Make-static-opacity-a-separate-field-in-MVA-config-22394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring static numeric opacity separately from opacity layers in multivariate layer settings.

* **Refactor**
  * Simplified opacity handling by introducing a distinct static opacity property, improving clarity in both configuration and UI.
  * Updated forms and configuration logic to always display and handle static opacity input alongside opacity layers.
  * Refined opacity application in rendering and style configuration to consistently combine static and layered opacity values.

* **Bug Fixes**
  * Ensured consistent application of opacity settings across multivariate layer rendering and style configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->