### PR TITLE
feat(layers panel): 22412 make axis group mutually exclusive. Fix "openByDefault" flag for groups and categories

### DIFF
--- a/src/core/localization/translations/en/common.json
+++ b/src/core/localization/translations/en/common.json
@@ -83,7 +83,8 @@
     "other": "Other",
     "elevation": "Elevation",
     "photo": "Imagery",
-    "map": "Map"
+    "map": "Map",
+    "indicators": "Indicators"
   },
   "advanced_analytics_data_list": {
     "load_world_data": "Load World Data",

--- a/src/core/logical_layers/constants.ts
+++ b/src/core/logical_layers/constants.ts
@@ -38,17 +38,23 @@ export const groupSettings: Record<string, GroupSettings> = {
     mutuallyExclusive: true,
     order: 2,
   },
+  axis: {
+    name: i18n.t('groups.indicators'),
+    openByDefault: false,
+    mutuallyExclusive: true,
+    order: 3,
+  },
   qa: {
     name: i18n.t('groups.qa'),
     openByDefault: true,
     mutuallyExclusive: false,
-    order: 3,
+    order: 4,
   },
   osmbasedmap: {
     name: i18n.t('groups.osmbasedmap'),
     openByDefault: false,
     mutuallyExclusive: false,
-    order: 4,
+    order: 5,
   },
   other: {
     name: i18n.t('groups.other'),

--- a/src/features/layers_panel/components/Category/Category.tsx
+++ b/src/features/layers_panel/components/Category/Category.tsx
@@ -15,7 +15,7 @@ export function Category({ category }: { category: CategoryWithSettings }) {
   const [openMap] = useAtomV2(layersTreeOpenStateAtom);
   const [counters] = useAtom(mountedLayersByCategoryAtom);
   const mountedLayersCounter = counters[category.id] ?? 0;
-  const isOpen = openMap.get(category.id) ?? true;
+  const isOpen = openMap.get(category.id) ?? category.openByDefault;
   const setOpen = useAction(layersTreeOpenStateAtom.set);
   const onCategoryDeselect = useAction(
     () => categoryDeselection.deselect(category.id),

--- a/src/features/layers_panel/components/Group/Group.tsx
+++ b/src/features/layers_panel/components/Group/Group.tsx
@@ -20,7 +20,7 @@ export function Group({
   const [openMap] = useAtomV2(layersTreeOpenStateAtom);
   const [counters] = useAtom(mountedLayersByGroupAtom);
   const mountedLayersCounter = counters[group.id] ?? 0;
-  const isOpen = openMap.get(group.id) ?? true;
+  const isOpen = openMap.get(group.id) ?? group.openByDefault;
   const setOpen = useAction(layersTreeOpenStateAtom.set);
   const groupDeselectAction = useAction(
     () => groupDeselection.deselect(group.id),


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/My-tasks-3575#Tasks/Task/Make-axis-group-mutually-exclusive-22412

<img width="374" height="289" alt="image" src="https://github.com/user-attachments/assets/5fe016ee-c510-4a23-a303-93650752a5a5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an Indicators group in the Layers panel, positioned between existing groups and set as mutually exclusive (select one at a time).
- UX Improvements
  - Groups and categories now open/close on first load based on their own default settings rather than always opening. Toggling behavior remains unchanged.
  - Updated group order to accommodate the new Indicators group; some existing groups move down accordingly.
- Localization
  - Added English translation for “Indicators.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->