### PR TITLE
fix(mcda): Fix forced normalization in mcda

### DIFF
--- a/src/core/logical_layers/renderers/MultivariateRenderer/helpers/createTextLayerSpecification.ts
+++ b/src/core/logical_layers/renderers/MultivariateRenderer/helpers/createTextLayerSpecification.ts
@@ -28,7 +28,7 @@ export function createTextLayerSpecification(
     } else {
       // @ts-expect-error - typing for calculateMCDALayer needs fixing, it actually returns ExpressionSpecification
       values = textDimension.mcdaValue.config.layers.map((layer) =>
-        calculateMCDALayer(layer),
+        calculateMCDALayer(layer, false, layer.normalization === 'no'),
       );
       units = textDimension.mcdaValue.config.layers.map((layer) =>
         layer.normalization === 'no' ? (layer.unit ?? '') : '',

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
@@ -178,7 +178,11 @@ export const calculateLayerPipeline =
     type: 'view' | 'layerStyle',
     getValue: (axis: { num: string; den: string }) => { num: T; den: T },
   ) =>
-  (layer: MCDALayer, forceMinMaxInLayerStyle?: boolean) => {
+  (
+    layer: MCDALayer,
+    forceMinMaxInLayerStyle?: boolean,
+    preventValueInversion?: boolean,
+  ) => {
     const {
       axis,
       range,
@@ -256,7 +260,7 @@ export const calculateLayerPipeline =
       normalized = operations.normalize({ x: tX, min: tMin, max: tMax });
     }
     let oriented = inverted ? operations.invert(normalized) : normalized;
-    if (type === 'view' && normalization === 'no') {
+    if ((type === 'view' && normalization === 'no') || preventValueInversion) {
       // don't invert non-normalized values, because applying (1-value) doesn't make sense for them
       oriented = normalized;
     }

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/calculations/index.ts
@@ -4,7 +4,7 @@ import { arraysAreEqualWithStrictOrder } from '~utils/common/equality';
 import { sentimentDefault, sentimentReversed } from './constants';
 import { JsMath, MapMath } from './operations';
 import type { IsomorphMath } from './operations';
-import type { MCDAConfig, TransformationFunction } from '../types';
+import type { MCDALayer, TransformationFunction } from '../types';
 
 const equalSentiments = (a: Array<string>, b: Array<string>) =>
   arraysAreEqualWithStrictOrder(a, b);
@@ -178,17 +178,18 @@ export const calculateLayerPipeline =
     type: 'view' | 'layerStyle',
     getValue: (axis: { num: string; den: string }) => { num: T; den: T },
   ) =>
-  ({
-    axis,
-    range,
-    coefficient,
-    sentiment,
-    transformationFunction,
-    transformation,
-    normalization,
-    outliers,
-    datasetStats,
-  }: MCDAConfig['layers'][0]) => {
+  (layer: MCDALayer, forceMinMaxInLayerStyle?: boolean) => {
+    const {
+      axis,
+      range,
+      coefficient,
+      sentiment,
+      transformationFunction,
+      transformation,
+      normalization,
+      outliers,
+      datasetStats,
+    } = layer;
     // @ts-expect-error - IsomorphCalculations typing needs fixing. The code works though, so for now ignoring the ts error
     const operations: IsomorphCalculations<number> =
       type === 'layerStyle' ? inStyleCalculations : inViewCalculations;
@@ -246,9 +247,12 @@ export const calculateLayerPipeline =
       }
     }
     let normalized = tX;
-    if (normalization === 'max-min' || type === 'layerStyle') {
-      // always apply min-max normalization for layer style,
-      // because we need to have (0..1) values in expressions for proper colors interpolation
+    if (
+      normalization === 'max-min' ||
+      (type === 'layerStyle' && forceMinMaxInLayerStyle)
+    ) {
+      // always apply min-max normalization for mcda style with sentiments colors,
+      // because we need to have (0..1) values in expressions for proper colors interpolation in sentiments colors (see sentimentPaint())
       normalized = operations.normalize({ x: tX, min: tMin, max: tMax });
     }
     let oriented = inverted ? operations.invert(normalized) : normalized;

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -62,11 +62,20 @@ export function filterSetup(
 
 export function linearNormalization(
   layers: MCDAConfig['layers'],
+  forceMinMax: boolean = false,
 ): ExpressionSpecification {
   if (layers.length === 1) {
-    return ['/', calculateMCDALayer(layers.at(0)!), layers.at(0)!.coefficient];
+    return [
+      '/',
+      calculateMCDALayer(layers.at(0)!, forceMinMax),
+      layers.at(0)!.coefficient,
+    ];
   } else {
-    return ['/', ['+', ...layers.map(calculateMCDALayer)], sumBy(layers, 'coefficient')];
+    return [
+      '/',
+      ['+', ...layers.map((layer) => calculateMCDALayer(layer, forceMinMax))],
+      sumBy(layers, 'coefficient'),
+    ];
   }
 }
 
@@ -180,7 +189,10 @@ export function createMCDAStyle(config: MCDAConfig): FillLayerSpecification {
     [] as [number, number] | [],
   );
 
-  const mcdaResult = linearNormalization(config.layers);
+  // always apply min-max normalization for mcda style with sentiments colors,
+  // because we need to have (0..1) values in expressions for proper colors interpolation in sentiments colors (see sentimentPaint())
+  const forceMinMaxForLayeStyle = config.colors.type === 'sentiments';
+  const mcdaResult = linearNormalization(config.layers, forceMinMaxForLayeStyle);
 
   const layerStyle: FillLayerSpecification = {
     // TODO: this id is useless and gets replaced in renderer. Needs refactoring

--- a/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
+++ b/src/core/logical_layers/renderers/stylesConfigs/mcda/mcdaStyle.ts
@@ -191,8 +191,8 @@ export function createMCDAStyle(config: MCDAConfig): FillLayerSpecification {
 
   // always apply min-max normalization for mcda style with sentiments colors,
   // because we need to have (0..1) values in expressions for proper colors interpolation in sentiments colors (see sentimentPaint())
-  const forceMinMaxForLayeStyle = config.colors.type === 'sentiments';
-  const mcdaResult = linearNormalization(config.layers, forceMinMaxForLayeStyle);
+  const forceMinMaxForLayerStyle = config.colors.type === 'sentiments';
+  const mcdaResult = linearNormalization(config.layers, forceMinMaxForLayerStyle);
 
   const layerStyle: FillLayerSpecification = {
     // TODO: this id is useless and gets replaced in renderer. Needs refactoring


### PR DESCRIPTION
- only forces min-max normalization for sentiment paint
- prevents non-normalized text dimension in MVA from being inverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional forcing of min–max normalization for layer-style evaluations, enabled for sentiment color schemes to ensure proper 0–1 gradients.

- Improvements
  - More consistent single- and multi-layer MCDA computations with clearer normalization rules.
  - Additional control to prevent unintended value inversion in specific views.

- Bug Fixes
  - Text-based MCDA outputs now respect each layer’s normalization setting.
  - Sentiment color maps render correct color transitions for non-normalized inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->